### PR TITLE
Add pi extension manifest to extension packages and bump to 0.1.2-beta.1

### DIFF
--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "description": "MCP proxy plugin for chrome-devtools-mcp with browser_ prefixed tools",
   "license": "Apache-2.0",
   "type": "module",
@@ -23,6 +23,11 @@
     "dist",
     "README.md"
   ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "description": "Pi extension for CUA computer-use: spawns and controls cua-computer-server",
   "license": "Apache-2.0",
   "type": "module",
@@ -20,6 +20,11 @@
     "dist",
     "README.md"
   ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "description": "Security policy engine and Pi extension for resource-aware tool authorization.",
   "license": "Apache-2.0",
   "type": "module",
@@ -24,6 +24,11 @@
     "dist",
     "README.md"
   ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pi-security/src/index.ts
+++ b/packages/pi-security/src/index.ts
@@ -925,3 +925,5 @@ function summarizeTarget(value: string): string {
     ? `${value.slice(0, 200)}...[${value.length - 200} chars truncated]`
     : value;
 }
+
+export { default } from './extension.js';

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,
@@ -35,6 +35,11 @@
     "dist",
     "README.md"
   ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/pi-telemetry/src/index.ts
+++ b/packages/pi-telemetry/src/index.ts
@@ -57,3 +57,5 @@ export class CompositeRuntimeEventExporter implements RuntimeEventExporter {
     await Promise.allSettled(this.exporters.map((exporter) => exporter.close?.()));
   }
 }
+
+export { default } from './extension.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-subagents",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/task-scheduler/package.json
+++ b/packages/task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/turns/package.json
+++ b/packages/turns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-turns",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Add "pi": { "extensions": ["./dist/index.js"] } to pi-browser-use, pi-computer-use, pi-security, and pi-telemetry so the framework can discover their extensions via the package manifest. Re-export the default extension from index.ts for pi-security and pi-telemetry.