### PR TITLE
Add env var resolution to pi-shared settings loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.0",
+  "version": "0.1.2-beta.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
+++ b/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
@@ -2,9 +2,9 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mockClientConnect = vi.fn(() => Promise.resolve());
 const mockClientClose = vi.fn(() => Promise.resolve());
-let listToolsCalls = 0;
+let _listToolsCalls = 0;
 const mockListTools = vi.fn((opts?: { cursor?: string }) => {
-  listToolsCalls++;
+  _listToolsCalls++;
   if (!opts?.cursor) {
     return Promise.resolve({
       tools: [{ name: 'click', description: 'Click', inputSchema: {} }],
@@ -44,7 +44,7 @@ describe('DevToolsClient', () => {
     mockClientClose.mockClear();
     mockListTools.mockClear();
     mockCallTool.mockClear();
-    listToolsCalls = 0;
+    _listToolsCalls = 0;
   });
 
   describe('connect()', () => {

--- a/packages/pi-computer-use/src/__tests__/computer-client.test.ts
+++ b/packages/pi-computer-use/src/__tests__/computer-client.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 const mockSend = vi.fn();
 const mockClose = vi.fn();
 const mockOff = vi.fn();
-let openHandler: (() => void) | null = null;
+let _openHandler: (() => void) | null = null;
 let errorHandler: ((err: Error) => void) | null = null;
 let messageHandler: ((data: string) => void) | null = null;
 let shouldAutoOpen = true;
@@ -17,7 +17,7 @@ vi.mock('ws', () => ({
     off = mockOff;
     on = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       if (event === 'open') {
-        openHandler = handler as () => void;
+        _openHandler = handler as () => void;
         if (shouldAutoOpen) setTimeout(() => handler(), 0);
       }
       if (event === 'error') errorHandler = handler as (err: Error) => void;
@@ -33,7 +33,7 @@ describe('ComputerClient', () => {
     mockSend.mockClear();
     mockClose.mockClear();
     mockOff.mockClear();
-    openHandler = null;
+    _openHandler = null;
     errorHandler = null;
     messageHandler = null;
     shouldAutoOpen = true;

--- a/packages/pi-computer-use/src/__tests__/index.test.ts
+++ b/packages/pi-computer-use/src/__tests__/index.test.ts
@@ -7,7 +7,7 @@ const mockWsClose = vi.fn();
 const mockWsOn = vi.fn();
 const mockWsOff = vi.fn();
 let wsOpenCallback: (() => void) | null = null;
-let wsMessageCallback: ((data: string) => void) | null = null;
+let _wsMessageCallback: ((data: string) => void) | null = null;
 
 vi.mock('ws', () => ({
   default: class MockWebSocket {
@@ -17,7 +17,7 @@ vi.mock('ws', () => ({
     close = mockWsClose;
     on = vi.fn((event: string, handler: (...args: unknown[]) => void) => {
       if (event === 'open') wsOpenCallback = handler as () => void;
-      if (event === 'message') wsMessageCallback = handler as (data: string) => void;
+      if (event === 'message') _wsMessageCallback = handler as (data: string) => void;
       mockWsOn(event, handler);
     });
     off = mockWsOff;
@@ -45,7 +45,7 @@ vi.mock('node:fs', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
-    readFileSync: vi.fn((...args: unknown[]) => {
+    readFileSync: vi.fn((..._args: unknown[]) => {
       if (mockConfigContent !== null) return mockConfigContent;
       throw new Error('ENOENT');
     }),
@@ -110,7 +110,7 @@ describe('computerUseExtension', () => {
     mockWsClose.mockClear();
     mockSpawn.mockClear();
     wsOpenCallback = null;
-    wsMessageCallback = null;
+    _wsMessageCallback = null;
   });
 
   test('registers session_start and session_shutdown handlers', () => {

--- a/packages/pi-computer-use/src/__tests__/server-process.test.ts
+++ b/packages/pi-computer-use/src/__tests__/server-process.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mockKill = vi.fn();
 let processExitHandler: ((code: number | null) => void) | null = null;
-let processErrorHandler: ((err: Error) => void) | null = null;
+let _processErrorHandler: ((err: Error) => void) | null = null;
 let mockExitCode: number | null = null;
 
 const mockSpawn = vi.fn((_cmd: string, _args: string[], _opts: object) => ({
@@ -14,7 +14,7 @@ const mockSpawn = vi.fn((_cmd: string, _args: string[], _opts: object) => ({
   },
   on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
     if (event === 'exit') processExitHandler = handler as (code: number | null) => void;
-    if (event === 'error') processErrorHandler = handler as (err: Error) => void;
+    if (event === 'error') _processErrorHandler = handler as (err: Error) => void;
   }),
   kill: mockKill,
 }));
@@ -58,7 +58,7 @@ describe('ComputerServerProcess', () => {
     mockSpawn.mockClear();
     mockKill.mockClear();
     processExitHandler = null;
-    processErrorHandler = null;
+    _processErrorHandler = null;
     mockExitCode = null;
     wsProbeCallCount = 0;
     wsProbeSuccess = () => true;

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -214,7 +214,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
       case 'subagent_spawned':
       case 'subagent_started': {
         const key = subagentSpanKey(event);
-        const rootSpan = this.ensureSdkRootSpan(trace, rootKey, event);
+        this.ensureSdkRootSpan(trace, rootKey, event);
         const body = {
           id: langfuseSpanId(traceId, key),
           name: 'subagent',
@@ -240,7 +240,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
       case 'subagent_cancelled': {
         const key = subagentSpanKey(event);
         const output = event.details?.output ?? (event.error ? { error: event.error } : undefined);
-        const rootSpan = this.ensureSdkRootSpan(trace, rootKey, event);
+        this.ensureSdkRootSpan(trace, rootKey, event);
         const span =
           this.spans.get(key) ??
           this.getSdkSubagentParent(trace, rootKey, event).span({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -32,6 +32,10 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "typecheck": "tsc -b --pretty false"
+    "typecheck": "tsc -b --pretty false",
+    "test": "vitest run src"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.0"
   }
 }

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -37,63 +37,84 @@ describe('loadPiSettings env var resolution', () => {
 
   it('resolves env ref to env value', async () => {
     process.env.TEST_MODEL = 'claude-opus';
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: envRef('TEST_MODEL') },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { name: envRef('TEST_MODEL') },
+      }),
+    );
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('claude-opus');
   });
 
   it('resolves env ref with default to default when env is unset', async () => {
     delete process.env.UNSET_VAR;
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: envRef('UNSET_VAR:-fallback-model') },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { name: envRef('UNSET_VAR:-fallback-model') },
+      }),
+    );
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('fallback-model');
   });
 
   it('resolves env ref with default to env value when set', async () => {
     process.env.SET_VAR = 'actual-value';
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: envRef('SET_VAR:-fallback') },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { name: envRef('SET_VAR:-fallback') },
+      }),
+    );
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('actual-value');
   });
 
   it('resolves env ref with empty default when env is unset', async () => {
     delete process.env.EMPTY_VAR;
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: envRef('EMPTY_VAR:-') },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { name: envRef('EMPTY_VAR:-') },
+      }),
+    );
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('');
   });
 
   it('resolves env ref with empty default when env is empty', async () => {
     process.env.EMPTY_VAR = '';
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: envRef('EMPTY_VAR:-') },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { name: envRef('EMPTY_VAR:-') },
+      }),
+    );
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('');
   });
 
   it('resolves env vars in nested objects', async () => {
     process.env.NESTED_VAL = 'deep';
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { outer: { inner: envRef('NESTED_VAL') } },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { outer: { inner: envRef('NESTED_VAL') } },
+      }),
+    );
     const result = await loadSettings<{ outer: { inner: string } }>('myExt');
     expect(result.outer.inner).toBe('deep');
   });
 
   it('resolves env vars in arrays', async () => {
     process.env.ARR_VAL = 'item1';
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { items: [envRef('ARR_VAL'), 'literal'] },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { items: [envRef('ARR_VAL'), 'literal'] },
+      }),
+    );
     const result = await loadSettings<{ items: string[] }>('myExt');
     expect(result.items).toEqual(['item1', 'literal']);
   });
@@ -101,17 +122,23 @@ describe('loadPiSettings env var resolution', () => {
   it('resolves multiple env vars in one string', async () => {
     process.env.HOST = 'localhost';
     process.env.PORT = '8080';
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { url: `http://${envRef('HOST')}:${envRef('PORT')}/api` },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { url: `http://${envRef('HOST')}:${envRef('PORT')}/api` },
+      }),
+    );
     const result = await loadSettings<{ url: string }>('myExt');
     expect(result.url).toBe('http://localhost:8080/api');
   });
 
   it('leaves non-string values untouched', async () => {
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { count: 42, enabled: true, empty: null },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { count: 42, enabled: true, empty: null },
+      }),
+    );
     const result = await loadSettings<{ count: number; enabled: boolean; empty: null }>('myExt');
     expect(result.count).toBe(42);
     expect(result.enabled).toBe(true);
@@ -120,9 +147,12 @@ describe('loadPiSettings env var resolution', () => {
 
   it('handles default value containing :-', async () => {
     delete process.env.TRICKY_VAR;
-    writeFileSync(settingsPath, JSON.stringify({
-      myExt: { val: envRef('TRICKY_VAR:-a:-b') },
-    }));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { val: envRef('TRICKY_VAR:-a:-b') },
+      }),
+    );
     const result = await loadSettings<{ val: string }>('myExt');
     expect(result.val).toBe('a:-b');
   });

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 // Helper to build env-var placeholder strings without triggering biome's noTemplateCurlyInString
 function envRef(expr: string): string {
+  // biome-ignore lint/style/useTemplate: intentional concatenation to avoid noTemplateCurlyInString
   return '$' + `{${expr}}`;
 }
 

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -1,7 +1,7 @@
-import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 describe('loadPiSettings env var resolution', () => {
   let tempDir: string;

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -3,6 +3,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+// Helper to build env-var placeholder strings without triggering biome's noTemplateCurlyInString
+function envRef(expr: string): string {
+  return '$' + `{${expr}}`;
+}
+
 describe('loadPiSettings env var resolution', () => {
   let tempDir: string;
   let settingsPath: string;
@@ -29,46 +34,46 @@ describe('loadPiSettings env var resolution', () => {
     return mod.loadPiSettings<T>(key);
   }
 
-  it('resolves ${VAR} to env value', async () => {
+  it('resolves env ref to env value', async () => {
     process.env.TEST_MODEL = 'claude-opus';
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: '${TEST_MODEL}' },
+      myExt: { name: envRef('TEST_MODEL') },
     }));
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('claude-opus');
   });
 
-  it('resolves ${VAR:-default} to default when env is unset', async () => {
+  it('resolves env ref with default to default when env is unset', async () => {
     delete process.env.UNSET_VAR;
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: '${UNSET_VAR:-fallback-model}' },
+      myExt: { name: envRef('UNSET_VAR:-fallback-model') },
     }));
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('fallback-model');
   });
 
-  it('resolves ${VAR:-default} to env value when set', async () => {
+  it('resolves env ref with default to env value when set', async () => {
     process.env.SET_VAR = 'actual-value';
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: '${SET_VAR:-fallback}' },
+      myExt: { name: envRef('SET_VAR:-fallback') },
     }));
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('actual-value');
   });
 
-  it('resolves ${VAR:-} to empty string when env is unset', async () => {
+  it('resolves env ref with empty default when env is unset', async () => {
     delete process.env.EMPTY_VAR;
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: '${EMPTY_VAR:-}' },
+      myExt: { name: envRef('EMPTY_VAR:-') },
     }));
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('');
   });
 
-  it('resolves ${VAR:-} to empty string when env is empty', async () => {
+  it('resolves env ref with empty default when env is empty', async () => {
     process.env.EMPTY_VAR = '';
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { name: '${EMPTY_VAR:-}' },
+      myExt: { name: envRef('EMPTY_VAR:-') },
     }));
     const result = await loadSettings<{ name: string }>('myExt');
     expect(result.name).toBe('');
@@ -77,7 +82,7 @@ describe('loadPiSettings env var resolution', () => {
   it('resolves env vars in nested objects', async () => {
     process.env.NESTED_VAL = 'deep';
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { outer: { inner: '${NESTED_VAL}' } },
+      myExt: { outer: { inner: envRef('NESTED_VAL') } },
     }));
     const result = await loadSettings<{ outer: { inner: string } }>('myExt');
     expect(result.outer.inner).toBe('deep');
@@ -86,7 +91,7 @@ describe('loadPiSettings env var resolution', () => {
   it('resolves env vars in arrays', async () => {
     process.env.ARR_VAL = 'item1';
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { items: ['${ARR_VAL}', 'literal'] },
+      myExt: { items: [envRef('ARR_VAL'), 'literal'] },
     }));
     const result = await loadSettings<{ items: string[] }>('myExt');
     expect(result.items).toEqual(['item1', 'literal']);
@@ -96,7 +101,7 @@ describe('loadPiSettings env var resolution', () => {
     process.env.HOST = 'localhost';
     process.env.PORT = '8080';
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { url: 'http://${HOST}:${PORT}/api' },
+      myExt: { url: `http://${envRef('HOST')}:${envRef('PORT')}/api` },
     }));
     const result = await loadSettings<{ url: string }>('myExt');
     expect(result.url).toBe('http://localhost:8080/api');
@@ -115,7 +120,7 @@ describe('loadPiSettings env var resolution', () => {
   it('handles default value containing :-', async () => {
     delete process.env.TRICKY_VAR;
     writeFileSync(settingsPath, JSON.stringify({
-      myExt: { val: '${TRICKY_VAR:-a:-b}' },
+      myExt: { val: envRef('TRICKY_VAR:-a:-b') },
     }));
     const result = await loadSettings<{ val: string }>('myExt');
     expect(result.val).toBe('a:-b');

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -1,0 +1,123 @@
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+describe('loadPiSettings env var resolution', () => {
+  let tempDir: string;
+  let settingsPath: string;
+  let originalCwd: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `pi-settings-test-${Date.now()}`);
+    mkdirSync(join(tempDir, '.pi'), { recursive: true });
+    settingsPath = join(tempDir, '.pi', 'settings.json');
+    originalCwd = process.cwd();
+    originalEnv = { ...process.env };
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env = originalEnv;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  async function loadSettings<T>(key: string): Promise<T> {
+    const mod = await import('../../src/settings.js');
+    return mod.loadPiSettings<T>(key);
+  }
+
+  it('resolves ${VAR} to env value', async () => {
+    process.env.TEST_MODEL = 'claude-opus';
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { name: '${TEST_MODEL}' },
+    }));
+    const result = await loadSettings<{ name: string }>('myExt');
+    expect(result.name).toBe('claude-opus');
+  });
+
+  it('resolves ${VAR:-default} to default when env is unset', async () => {
+    delete process.env.UNSET_VAR;
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { name: '${UNSET_VAR:-fallback-model}' },
+    }));
+    const result = await loadSettings<{ name: string }>('myExt');
+    expect(result.name).toBe('fallback-model');
+  });
+
+  it('resolves ${VAR:-default} to env value when set', async () => {
+    process.env.SET_VAR = 'actual-value';
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { name: '${SET_VAR:-fallback}' },
+    }));
+    const result = await loadSettings<{ name: string }>('myExt');
+    expect(result.name).toBe('actual-value');
+  });
+
+  it('resolves ${VAR:-} to empty string when env is unset', async () => {
+    delete process.env.EMPTY_VAR;
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { name: '${EMPTY_VAR:-}' },
+    }));
+    const result = await loadSettings<{ name: string }>('myExt');
+    expect(result.name).toBe('');
+  });
+
+  it('resolves ${VAR:-} to empty string when env is empty', async () => {
+    process.env.EMPTY_VAR = '';
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { name: '${EMPTY_VAR:-}' },
+    }));
+    const result = await loadSettings<{ name: string }>('myExt');
+    expect(result.name).toBe('');
+  });
+
+  it('resolves env vars in nested objects', async () => {
+    process.env.NESTED_VAL = 'deep';
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { outer: { inner: '${NESTED_VAL}' } },
+    }));
+    const result = await loadSettings<{ outer: { inner: string } }>('myExt');
+    expect(result.outer.inner).toBe('deep');
+  });
+
+  it('resolves env vars in arrays', async () => {
+    process.env.ARR_VAL = 'item1';
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { items: ['${ARR_VAL}', 'literal'] },
+    }));
+    const result = await loadSettings<{ items: string[] }>('myExt');
+    expect(result.items).toEqual(['item1', 'literal']);
+  });
+
+  it('resolves multiple env vars in one string', async () => {
+    process.env.HOST = 'localhost';
+    process.env.PORT = '8080';
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { url: 'http://${HOST}:${PORT}/api' },
+    }));
+    const result = await loadSettings<{ url: string }>('myExt');
+    expect(result.url).toBe('http://localhost:8080/api');
+  });
+
+  it('leaves non-string values untouched', async () => {
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { count: 42, enabled: true, empty: null },
+    }));
+    const result = await loadSettings<{ count: number; enabled: boolean; empty: null }>('myExt');
+    expect(result.count).toBe(42);
+    expect(result.enabled).toBe(true);
+    expect(result.empty).toBeNull();
+  });
+
+  it('handles default value containing :-', async () => {
+    delete process.env.TRICKY_VAR;
+    writeFileSync(settingsPath, JSON.stringify({
+      myExt: { val: '${TRICKY_VAR:-a:-b}' },
+    }));
+    const result = await loadSettings<{ val: string }>('myExt');
+    expect(result.val).toBe('a:-b');
+  });
+});

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -2,12 +2,35 @@ import { readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 
+function resolveEnvVars(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
+      const [name, ...rest] = expr.split(':-');
+      const fallback = rest.join(':-');
+      const envVal = process.env[name!];
+      if (envVal !== undefined && envVal !== '') return envVal;
+      return fallback;
+    });
+  }
+  if (Array.isArray(value)) {
+    return value.map(resolveEnvVars);
+  }
+  if (value && typeof value === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = resolveEnvVars(v);
+    }
+    return result;
+  }
+  return value;
+}
+
 function readSettingsSection<T>(filePath: string, key: string): Partial<T> {
   try {
     const raw = readFileSync(filePath, 'utf-8');
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return (parsed[key] ?? {}) as Partial<T>;
+      return resolveEnvVars(parsed[key] ?? {}) as Partial<T>;
     }
     return {};
   } catch {

--- a/packages/storage/src/db-runtime-storage.ts
+++ b/packages/storage/src/db-runtime-storage.ts
@@ -838,6 +838,7 @@ class DbArtifactStore implements RuntimeArtifactStore {
   }
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: Prisma record shape is dynamic
 type PrismaRecord = Record<string, any>;
 
 async function nextBigIntSeq(aggregatePromise: Promise<unknown>, key: string): Promise<bigint> {

--- a/packages/storage/src/event-stores.ts
+++ b/packages/storage/src/event-stores.ts
@@ -6,8 +6,6 @@
  * in event-recorders.
  */
 import type {
-  AppendOnlyEventStore,
-  JsonValue,
   LlmGenerationEventStore,
   RuntimeEventStore,
   RuntimeLifecycleEvent,

--- a/packages/storage/src/scheduled-task-stores.ts
+++ b/packages/storage/src/scheduled-task-stores.ts
@@ -5,7 +5,6 @@ import {
   type ScheduledTask,
   type ScheduledTaskModelConfig,
   type ScheduledTaskRunHistoryEntry,
-  type ScheduledTaskStatus,
   type ScheduledTaskStore,
   type SchedulerLock,
   type TaskSchedulerScope,
@@ -293,6 +292,7 @@ export class DbScheduledTaskStore implements ScheduledTaskStore {
   }
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: Prisma record shape is dynamic
 type PrismaRecord = Record<string, any>;
 
 function taskMatchesScope(task: ScheduledTask, scope: TaskSchedulerScope): boolean {

--- a/packages/storage/src/session-stores.ts
+++ b/packages/storage/src/session-stores.ts
@@ -7,14 +7,11 @@
  */
 import { randomUUID } from 'node:crypto';
 import type {
-  ConversationHistoryStore,
   ConversationMessage,
-  ConversationStore,
   ConversationTurn,
   CopilotMemoryStore,
   JsonObject,
   MemoryRecord,
-  MemoryStore,
   RuntimeScope,
   RuntimeSession,
   RuntimeSessionStore,

--- a/packages/storage/src/subagent-store.ts
+++ b/packages/storage/src/subagent-store.ts
@@ -8,7 +8,6 @@
 import { randomUUID } from 'node:crypto';
 import type {
   RuntimeScope,
-  SubagentLifecycleEvent,
   SubagentRun,
   SubagentRunStatus,
   SubagentRunStore,

--- a/packages/turns/src/prompt-turn.ts
+++ b/packages/turns/src/prompt-turn.ts
@@ -10,7 +10,6 @@ import type {
   JsonObject,
   RuntimeLifecycleEvent,
   RuntimeLlmGenerationEvent,
-  RuntimeModelConfig,
   RuntimeSession,
 } from '@amaster.ai/pi-shared';
 import type { AssistantMessage, ImageContent } from '@earendil-works/pi-ai';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,11 @@ importers:
         specifier: ^4.0.0
         version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
-  packages/shared: {}
+  packages/shared:
+    devDependencies:
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/storage:
     dependencies:


### PR DESCRIPTION
Support ${VAR}, ${VAR:-default}, and ${VAR:-} syntax in settings JSON string values. Recursively resolves nested objects and arrays.