### PR TITLE
Add 3-layer settings/policy resolution for Desktop agentDir support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@types/node": "^24.0.0",
+    "jiti": "^2.7.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"
   }

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "description": "MCP proxy plugin for chrome-devtools-mcp with browser_ prefixed tools",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-browser-use/src/__tests__/index.test.ts
+++ b/packages/pi-browser-use/src/__tests__/index.test.ts
@@ -87,7 +87,7 @@ const mockPi = {
   registerTool: vi.fn((tool: RegisteredTool) => {
     registeredTools.set(tool.name, tool);
   }),
-  on: vi.fn((event: string, handler: () => Promise<void>) => {
+  on: vi.fn((event: string, handler: (...args: any[]) => Promise<void>) => {
     if (event === 'session_start') sessionStartHandlers.push(handler);
     if (event === 'session_shutdown') sessionShutdownHandlers.push(handler);
   }),
@@ -106,8 +106,10 @@ async function startExtension(config?: Record<string, unknown>) {
 
   browserUseExtension(mockPi as any);
 
+  const fakeEvent = { type: 'session_start', reason: 'startup' };
+  const fakeCtx = { cwd: process.cwd() };
   for (const handler of sessionStartHandlers) {
-    await handler();
+    await handler(fakeEvent, fakeCtx);
   }
 }
 

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -1,6 +1,7 @@
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
 import { type TextContent as AiTextContent, complete } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -129,8 +130,11 @@ export class DevToolsClient {
 }
 
 /** Read the pi-browser-use section from .pi/settings.json. */
-function loadConfigFromFile(): BrowserUseConfig {
-  return loadPiSettings<BrowserUseConfig>('pi-browser-use');
+function loadConfigFromFile(options?: PiSettingsOptions): BrowserUseConfig {
+  return loadPiSettings<BrowserUseConfig>('pi-browser-use', {
+    agentDir: getAgentDir(),
+    ...options,
+  });
 }
 
 /** Convert upstream MCP result into pi-agent TextContent[], applying post-processing. */
@@ -179,11 +183,12 @@ function toTextContent(
  * If visionModel is configured, an additional analyze_screenshot tool is registered.
  */
 export default function browserUseExtension(pi: ExtensionAPI): void {
-  const config = resolveConfig(loadConfigFromFile());
-  const client = new DevToolsClient(config);
+  let config: BrowserUseConfig | undefined;
+  let client: DevToolsClient | undefined;
   let connected = false;
 
   async function ensureConnected(): Promise<void> {
+    if (!client) throw new Error('browser-use: session not started');
     if (!connected) {
       await client.connect();
       connected = true;
@@ -192,7 +197,7 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
 
   async function registerUpstreamTools(): Promise<void> {
     await ensureConnected();
-    const upstreamTools = await client.listAllTools();
+    const upstreamTools = await client!.listAllTools();
 
     for (const tool of upstreamTools) {
       if (EXCLUDED_TOOLS.has(tool.name)) continue;
@@ -213,7 +218,8 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
           _onUpdate: unknown,
           _ctx: ExtensionContext,
         ) {
-          const result = await client.callTool(originalName, params);
+          await ensureConnected();
+          const result = await client!.callTool(originalName, params);
           const { content } = toTextContent(result, originalName);
           return { content, details: undefined };
         },
@@ -297,7 +303,7 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       ) {
         await ensureConnected();
         const callVision = createPiVisionCaller(visionConfig, ctx);
-        const result = await handleAnalyzeScreenshot(client, callVision, params);
+        const result = await handleAnalyzeScreenshot(client!, callVision, params);
         const content: Array<{ type: 'text'; text: string }> = [];
         if (result.content) {
           for (const item of result.content) {
@@ -314,7 +320,10 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
     });
   }
 
-  pi.on('session_start', async () => {
+  pi.on('session_start', async (_event, ctx) => {
+    config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
+    client = new DevToolsClient(config);
+    connected = false;
     await registerUpstreamTools();
     if (config.visionModel) {
       await registerVisionTool(config.visionModel);
@@ -322,7 +331,7 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
   });
 
   pi.on('session_shutdown', async () => {
-    if (connected) {
+    if (connected && client) {
       await client.close();
       connected = false;
     }

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "description": "Pi extension for CUA computer-use: spawns and controls cua-computer-server",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-computer-use/src/config.ts
+++ b/packages/pi-computer-use/src/config.ts
@@ -1,4 +1,5 @@
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 export interface VisionModelConfig {
   provider: string;
@@ -46,6 +47,9 @@ export function resolveConfig(config?: ComputerUseConfig): ComputerUseConfig {
   return { ...DEFAULTS, ...config };
 }
 
-export function loadConfigFromFile(): ComputerUseConfig {
-  return loadPiSettings<ComputerUseConfig>('pi-computer-use');
+export function loadConfigFromFile(options?: PiSettingsOptions): ComputerUseConfig {
+  return loadPiSettings<ComputerUseConfig>('pi-computer-use', {
+    agentDir: getAgentDir(),
+    ...options,
+  });
 }

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -49,9 +49,10 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
         scroll_x: Type.Optional(Type.Number({ description: 'Horizontal scroll amount' })),
         scroll_y: Type.Optional(Type.Number({ description: 'Vertical scroll amount' })),
         path: Type.Optional(
-          Type.Array(Type.Tuple([Type.Number(), Type.Number()]), {
-            description: 'Drag path as [[x,y], ...] coordinates',
-          }),
+          Type.Array(
+            Type.Array(Type.Number(), { minItems: 2, maxItems: 2 }),
+            { description: 'Drag path as [[x,y], ...] coordinates' },
+          ),
         ),
         command: Type.Optional(Type.String({ description: 'Shell command (run_command action)' })),
       }),

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -10,9 +10,9 @@ export type { ComputerUseConfig };
 export { loadConfigFromFile, resolveConfig };
 
 export default function computerUseExtension(pi: ExtensionAPI): void {
-  const config = resolveConfig(loadConfigFromFile());
+  let config = resolveConfig(loadConfigFromFile());
   const serverProcess = new ComputerServerProcess();
-  const client = new ComputerClient(config);
+  let client = new ComputerClient(config);
   let started = false;
 
   async function ensureRunning(): Promise<void> {
@@ -49,10 +49,9 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
         scroll_x: Type.Optional(Type.Number({ description: 'Horizontal scroll amount' })),
         scroll_y: Type.Optional(Type.Number({ description: 'Vertical scroll amount' })),
         path: Type.Optional(
-          Type.Array(
-            Type.Array(Type.Number(), { minItems: 2, maxItems: 2 }),
-            { description: 'Drag path as [[x,y], ...] coordinates' },
-          ),
+          Type.Array(Type.Array(Type.Number(), { minItems: 2, maxItems: 2 }), {
+            description: 'Drag path as [[x,y], ...] coordinates',
+          }),
         ),
         command: Type.Optional(Type.String({ description: 'Shell command (run_command action)' })),
       }),
@@ -122,8 +121,9 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
     },
   });
 
-  pi.on('session_start', async () => {
-    // Lazy — actual startup happens on first tool call
+  pi.on('session_start', async (_event, ctx) => {
+    config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
+    client = new ComputerClient(config);
   });
 
   pi.on('session_shutdown', async () => {

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "description": "Security policy engine and Pi extension for resource-aware tool authorization.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-security/src/__tests__/policy-loader.test.ts
+++ b/packages/pi-security/src/__tests__/policy-loader.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isCapabilityExposed, resolveCapabilityPolicy } from '../index.js';
 import { loadFilePolicies, loadPolicyDir } from '../policy-loader.js';
 
 describe('loadPolicyDir', () => {
@@ -176,5 +177,71 @@ describe('loadFilePolicies', () => {
 
     const result = loadFilePolicies(cwd);
     expect(result).toEqual({});
+  });
+});
+
+describe('loadFilePolicies 3-layer with agentDir', () => {
+  let base: string;
+  let agentDir: string;
+  let agentPolicyDir: string;
+  let cwd: string;
+  let projectPolicyDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    base = join(tmpdir(), `pi-policy-3layer-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    agentDir = join(base, 'agent-config');
+    agentPolicyDir = join(agentDir, 'policy');
+    cwd = join(base, 'project');
+    projectPolicyDir = join(cwd, '.pi', 'policy');
+    mkdirSync(join(base, 'home', '.pi', 'agent', 'policy'), { recursive: true });
+    mkdirSync(agentPolicyDir, { recursive: true });
+    mkdirSync(projectPolicyDir, { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = join(base, 'home');
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    }
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('agentDir policy is loaded via loadFilePolicies', () => {
+    writeFileSync(
+      join(agentPolicyDir, 'sandbox-exec.json'),
+      JSON.stringify({
+        capabilities: { allow: ['browser_*'] },
+      }),
+    );
+
+    const result = loadFilePolicies(cwd, agentDir);
+    expect(result['sandbox-exec']).toEqual({
+      capabilities: { allow: ['browser_*'] },
+    });
+  });
+
+  it('project policy overrides agentDir policy', () => {
+    writeFileSync(join(agentPolicyDir, 'custom.json'), JSON.stringify({ extends: 'chat' }));
+    writeFileSync(join(projectPolicyDir, 'custom.json'), JSON.stringify({ extends: 'admin' }));
+
+    const result = loadFilePolicies(cwd, agentDir);
+    expect(result.custom).toEqual({ extends: 'admin' });
+  });
+
+  it('sandbox-exec.json merges browser_* into built-in sandbox-exec capabilities', () => {
+    writeFileSync(
+      join(agentPolicyDir, 'sandbox-exec.json'),
+      JSON.stringify({
+        capabilities: { allow: ['browser_*'] },
+      }),
+    );
+
+    const filePolicies = loadFilePolicies(cwd, agentDir);
+    const policy = resolveCapabilityPolicy('sandbox-exec', {}, filePolicies);
+    expect(isCapabilityExposed('browser_list_pages', policy)).toBe(true);
+    expect(isCapabilityExposed('read_file', policy)).toBe(true);
+    expect(isCapabilityExposed('run_shell', policy)).toBe(true);
   });
 });

--- a/packages/pi-security/src/extension.ts
+++ b/packages/pi-security/src/extension.ts
@@ -5,6 +5,7 @@ import type {
   ToolCallRequest,
   ToolSource,
 } from '@amaster.ai/pi-shared';
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import type {
   ExtensionAPI,
   ExtensionContext,
@@ -13,7 +14,7 @@ import type {
   UserBashEvent,
   UserBashEventResult,
 } from '@earendil-works/pi-coding-agent';
-import { getAgentDir, SettingsManager } from '@earendil-works/pi-coding-agent';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import {
   type SecurityAuditEvent,
   type SecurityConfig,
@@ -185,7 +186,7 @@ function createGate(ctx: ExtensionContext, state: PiSecurityExtensionState): Sec
   return new SecurityGate({
     profile: state.config.profile,
     ...(state.config.security ? { config: state.config.security } : {}),
-    filePolicies: loadFilePolicies(ctx.cwd),
+    filePolicies: loadFilePolicies(ctx.cwd, getAgentDir()),
     approvalHandler: async ({ toolCall, decision }) =>
       resolveApproval(ctx, state, toolCall, decision),
     auditSink: (event) => {
@@ -236,27 +237,14 @@ async function resolveApproval(
 
 function loadSettings(cwd: string): PiSecurityExtensionConfig | undefined {
   try {
-    const settings = SettingsManager.create(cwd, getAgentDir());
-    const global = settings.getGlobalSettings() as Record<string, unknown>;
-    const project = settings.getProjectSettings() as Record<string, unknown>;
-    return mergePlainObjects(global[SETTINGS_KEY], project[SETTINGS_KEY]) as
-      | PiSecurityExtensionConfig
-      | undefined;
+    const config = loadPiSettings<Partial<PiSecurityExtensionConfig>>(SETTINGS_KEY, {
+      cwd,
+      agentDir: getAgentDir(),
+    });
+    return Object.keys(config).length > 0 ? (config as PiSecurityExtensionConfig) : undefined;
   } catch {
     return undefined;
   }
-}
-
-function mergePlainObjects(first: unknown, second: unknown): Record<string, unknown> | undefined {
-  const a = isPlainObject(first) ? first : undefined;
-  const b = isPlainObject(second) ? second : undefined;
-  if (!a && !b) {
-    return undefined;
-  }
-  return {
-    ...(a ?? {}),
-    ...(b ?? {}),
-  };
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/pi-security/src/policy-loader.ts
+++ b/packages/pi-security/src/policy-loader.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
+import { loadPiPolicyProfiles } from '@amaster.ai/pi-shared/settings';
 import type { SecurityProfileConfig } from './index.js';
 
 export function loadPolicyDir(dirPath: string): Record<string, SecurityProfileConfig> {
@@ -27,10 +27,12 @@ export function loadPolicyDir(dirPath: string): Record<string, SecurityProfileCo
   return result;
 }
 
-export function loadFilePolicies(cwd: string): Record<string, SecurityProfileConfig> {
-  const userDir = join(homedir(), '.pi', 'agent', 'policy');
-  const projectDir = join(cwd, '.pi', 'policy');
-  const userPolicies = loadPolicyDir(userDir);
-  const projectPolicies = loadPolicyDir(projectDir);
-  return { ...userPolicies, ...projectPolicies };
+export function loadFilePolicies(
+  cwd: string,
+  agentDir?: string,
+): Record<string, SecurityProfileConfig> {
+  return loadPiPolicyProfiles<SecurityProfileConfig>({
+    cwd,
+    ...(agentDir !== undefined ? { agentDir } : {}),
+  });
 }

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/pi-telemetry/src/config.ts
+++ b/packages/pi-telemetry/src/config.ts
@@ -1,4 +1,5 @@
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 export interface LangfuseConfig {
   enabled?: boolean;
@@ -37,6 +38,6 @@ export function resolveConfig(config?: TelemetryConfig): TelemetryConfig {
   return { ...DEFAULTS, ...config };
 }
 
-export function loadConfigFromFile(): TelemetryConfig {
-  return loadPiSettings<TelemetryConfig>('pi-telemetry');
+export function loadConfigFromFile(options?: PiSettingsOptions): TelemetryConfig {
+  return loadPiSettings<TelemetryConfig>('pi-telemetry', { agentDir: getAgentDir(), ...options });
 }

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -47,8 +47,8 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
   let llmGenerationCounter = 0;
   let pendingInput: string | undefined;
 
-  pi.on('session_start', async () => {
-    const config = resolveConfig(loadConfigFromFile());
+  pi.on('session_start', async (_event, ctx) => {
+    const config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
     const langfuse = createLangfuseExporter(config);
     const otel = createOtelExporter(config);
 

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -20,12 +20,32 @@ function extractModelConfig(payload: unknown): RuntimeModelConfig {
   return { provider: 'unknown', model: 'unknown' };
 }
 
+function extractOutput(message: unknown): string | undefined {
+  if (!message || typeof message !== 'object') return undefined;
+  const msg = message as Record<string, unknown>;
+  if (msg.role !== 'assistant' || !Array.isArray(msg.content)) return undefined;
+  const texts: string[] = [];
+  for (const block of msg.content) {
+    if (
+      block &&
+      typeof block === 'object' &&
+      'type' in block &&
+      block.type === 'text' &&
+      'text' in block
+    ) {
+      texts.push(String(block.text));
+    }
+  }
+  return texts.length > 0 ? texts.join('\n') : undefined;
+}
+
 export default function telemetryExtension(pi: ExtensionAPI): void {
   let exporter: RuntimeEventExporter = new NoopRuntimeEventExporter();
   const sessionId = randomUUID();
   let currentTraceId: string | undefined;
   let turnStartTime: number | undefined;
   let llmGenerationCounter = 0;
+  let pendingInput: string | undefined;
 
   pi.on('session_start', async () => {
     const config = resolveConfig(loadConfigFromFile());
@@ -40,6 +60,10 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
     }
   });
 
+  pi.on('input', async (event) => {
+    pendingInput = event.text;
+  });
+
   pi.on('turn_start', async (event) => {
     currentTraceId = randomUUID().replace(/-/g, '');
     turnStartTime = event.timestamp;
@@ -51,13 +75,16 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
       type: 'chat_turn_started',
       sessionId,
       createdAt: new Date(event.timestamp).toISOString(),
+      ...(pendingInput !== undefined ? { details: { input: pendingInput } } : {}),
     });
+    pendingInput = undefined;
   });
 
-  pi.on('turn_end', async () => {
+  pi.on('turn_end', async (event) => {
     if (!currentTraceId) return;
     const now = Date.now();
     const durationMs = turnStartTime ? now - turnStartTime : undefined;
+    const output = extractOutput(event.message);
 
     await exporter.publish({
       id: randomUUID(),
@@ -66,6 +93,7 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
       sessionId,
       createdAt: new Date(now).toISOString(),
       ...(durationMs !== undefined ? { durationMs } : {}),
+      ...(output !== undefined ? { details: { output } } : {}),
     });
 
     currentTraceId = undefined;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -1,7 +1,17 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mockedHome: string | undefined;
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: () => mockedHome ?? actual.homedir(),
+  };
+});
 
 // Helper to build env-var placeholder strings without triggering biome's noTemplateCurlyInString
 function envRef(expr: string): string {
@@ -155,5 +165,249 @@ describe('loadPiSettings env var resolution', () => {
     );
     const result = await loadSettings<{ val: string }>('myExt');
     expect(result.val).toBe('a:-b');
+  });
+});
+
+describe('3-layer settings resolution', () => {
+  let base: string;
+  let globalDir: string;
+  let agentDir: string;
+  let projectDir: string;
+
+  beforeEach(() => {
+    base = join(tmpdir(), `pi-3layer-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    globalDir = join(base, 'home', '.pi', 'agent');
+    agentDir = join(base, 'agent-config');
+    projectDir = join(base, 'project');
+    mkdirSync(globalDir, { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+    mkdirSync(join(projectDir, '.pi'), { recursive: true });
+    mockedHome = join(base, 'home');
+  });
+
+  afterEach(() => {
+    mockedHome = undefined;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('agentDir settings override global settings', async () => {
+    writeFileSync(
+      join(globalDir, 'settings.json'),
+      JSON.stringify({ ext: { a: 'global', b: 'global' } }),
+    );
+    writeFileSync(join(agentDir, 'settings.json'), JSON.stringify({ ext: { a: 'agent' } }));
+
+    const { loadPiSettings } = await import('../../src/settings.js');
+    const result = loadPiSettings<{ a: string; b: string }>('ext', {
+      agentDir,
+      cwd: projectDir,
+    });
+    expect(result.a).toBe('agent');
+    expect(result.b).toBe('global');
+  });
+
+  it('project settings override agentDir settings', async () => {
+    writeFileSync(
+      join(agentDir, 'settings.json'),
+      JSON.stringify({ ext: { a: 'agent', b: 'agent' } }),
+    );
+    writeFileSync(
+      join(projectDir, '.pi', 'settings.json'),
+      JSON.stringify({ ext: { a: 'project' } }),
+    );
+
+    const { loadPiSettings } = await import('../../src/settings.js');
+    const result = loadPiSettings<{ a: string; b: string }>('ext', {
+      agentDir,
+      cwd: projectDir,
+    });
+    expect(result.a).toBe('project');
+    expect(result.b).toBe('agent');
+  });
+
+  it('env var interpolation works in agentDir layer', async () => {
+    const origEndpoint = process.env.MY_ENDPOINT;
+    process.env.MY_ENDPOINT = 'https://api.example.com';
+    writeFileSync(
+      join(agentDir, 'settings.json'),
+      JSON.stringify({ ext: { url: envRef('MY_ENDPOINT') } }),
+    );
+
+    const { loadPiSettings } = await import('../../src/settings.js');
+    const result = loadPiSettings<{ url: string }>('ext', { agentDir, cwd: projectDir });
+    expect(result.url).toBe('https://api.example.com');
+    if (origEndpoint === undefined) delete process.env.MY_ENDPOINT;
+    else process.env.MY_ENDPOINT = origEndpoint;
+  });
+
+  it('skips agentDir layer when it equals global dir', async () => {
+    writeFileSync(join(globalDir, 'settings.json'), JSON.stringify({ ext: { a: 'global' } }));
+    writeFileSync(
+      join(projectDir, '.pi', 'settings.json'),
+      JSON.stringify({ ext: { b: 'project' } }),
+    );
+
+    const { loadPiSettings } = await import('../../src/settings.js');
+    const result = loadPiSettings<{ a: string; b: string }>('ext', { cwd: projectDir });
+    expect(result.a).toBe('global');
+    expect(result.b).toBe('project');
+  });
+});
+
+describe('loadPiPolicyProfiles', () => {
+  let base: string;
+  let globalPolicyDir: string;
+  let agentDir: string;
+  let agentPolicyDir: string;
+  let projectDir: string;
+  let projectPolicyDir: string;
+
+  beforeEach(() => {
+    base = join(tmpdir(), `pi-policy-3layer-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    globalPolicyDir = join(base, 'home', '.pi', 'agent', 'policy');
+    agentDir = join(base, 'agent-config');
+    agentPolicyDir = join(agentDir, 'policy');
+    projectDir = join(base, 'project');
+    projectPolicyDir = join(projectDir, '.pi', 'policy');
+    mkdirSync(globalPolicyDir, { recursive: true });
+    mkdirSync(agentPolicyDir, { recursive: true });
+    mkdirSync(projectPolicyDir, { recursive: true });
+    mockedHome = join(base, 'home');
+  });
+
+  afterEach(() => {
+    mockedHome = undefined;
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('agentDir policy is readable', async () => {
+    writeFileSync(
+      join(agentPolicyDir, 'sandbox-exec.json'),
+      JSON.stringify({ extends: 'sandbox-exec', capabilities: { allow: ['browser_*'] } }),
+    );
+
+    const { loadPiPolicyProfiles } = await import('../../src/settings.js');
+    const result = loadPiPolicyProfiles<{ extends?: string; capabilities?: { allow?: string[] } }>({
+      agentDir,
+      cwd: projectDir,
+    });
+    expect(result['sandbox-exec']).toEqual({
+      extends: 'sandbox-exec',
+      capabilities: { allow: ['browser_*'] },
+    });
+  });
+
+  it('project policy overrides agentDir policy with same name', async () => {
+    writeFileSync(
+      join(agentPolicyDir, 'custom.json'),
+      JSON.stringify({ extends: 'chat', capabilities: { allow: ['read_file'] } }),
+    );
+    writeFileSync(
+      join(projectPolicyDir, 'custom.json'),
+      JSON.stringify({ extends: 'copilot', capabilities: { allow: ['*'] } }),
+    );
+
+    const { loadPiPolicyProfiles } = await import('../../src/settings.js');
+    const result = loadPiPolicyProfiles<{ extends?: string; capabilities?: { allow?: string[] } }>({
+      agentDir,
+      cwd: projectDir,
+    });
+    expect(result.custom).toEqual({ extends: 'copilot', capabilities: { allow: ['*'] } });
+  });
+
+  it('merges profiles from all three directories', async () => {
+    writeFileSync(join(globalPolicyDir, 'global-only.json'), JSON.stringify({ extends: 'chat' }));
+    writeFileSync(join(agentPolicyDir, 'agent-only.json'), JSON.stringify({ extends: 'admin' }));
+    writeFileSync(
+      join(projectPolicyDir, 'project-only.json'),
+      JSON.stringify({ extends: 'copilot' }),
+    );
+
+    const { loadPiPolicyProfiles } = await import('../../src/settings.js');
+    const result = loadPiPolicyProfiles<{ extends?: string }>({ agentDir, cwd: projectDir });
+    expect(result['global-only']).toEqual({ extends: 'chat' });
+    expect(result['agent-only']).toEqual({ extends: 'admin' });
+    expect(result['project-only']).toEqual({ extends: 'copilot' });
+  });
+
+  it('works when directories do not exist', async () => {
+    rmSync(globalPolicyDir, { recursive: true });
+    rmSync(agentPolicyDir, { recursive: true });
+    rmSync(projectPolicyDir, { recursive: true });
+
+    const { loadPiPolicyProfiles } = await import('../../src/settings.js');
+    const result = loadPiPolicyProfiles({ agentDir, cwd: projectDir });
+    expect(result).toEqual({});
+  });
+});
+
+describe('loadJsonProfileDir', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = join(tmpdir(), `pi-profile-dir-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(dir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads all .json files and returns Record keyed by filename', async () => {
+    writeFileSync(join(dir, 'alpha.json'), JSON.stringify({ value: 1 }));
+    writeFileSync(join(dir, 'beta.json'), JSON.stringify({ value: 2 }));
+
+    const { loadJsonProfileDir } = await import('../../src/settings.js');
+    const result = loadJsonProfileDir<{ value: number }>(dir);
+    expect(result).toEqual({ alpha: { value: 1 }, beta: { value: 2 } });
+  });
+
+  it('returns empty for non-existent directory', async () => {
+    const { loadJsonProfileDir } = await import('../../src/settings.js');
+    expect(loadJsonProfileDir('/non/existent/path')).toEqual({});
+  });
+
+  it('skips malformed JSON', async () => {
+    writeFileSync(join(dir, 'bad.json'), '{ invalid !!!');
+    writeFileSync(join(dir, 'good.json'), JSON.stringify({ ok: true }));
+
+    const { loadJsonProfileDir } = await import('../../src/settings.js');
+    const result = loadJsonProfileDir<{ ok?: boolean }>(dir);
+    expect(result).toEqual({ good: { ok: true } });
+  });
+
+  it('skips non-JSON files', async () => {
+    writeFileSync(join(dir, 'notes.txt'), 'not json');
+    writeFileSync(join(dir, 'valid.json'), JSON.stringify({ x: 1 }));
+
+    const { loadJsonProfileDir } = await import('../../src/settings.js');
+    const result = loadJsonProfileDir<{ x: number }>(dir);
+    expect(Object.keys(result)).toEqual(['valid']);
+  });
+
+  it('skips non-object JSON values', async () => {
+    writeFileSync(join(dir, 'array.json'), JSON.stringify([1, 2]));
+    writeFileSync(join(dir, 'str.json'), JSON.stringify('hello'));
+    writeFileSync(join(dir, 'obj.json'), JSON.stringify({ ok: true }));
+
+    const { loadJsonProfileDir } = await import('../../src/settings.js');
+    const result = loadJsonProfileDir<{ ok?: boolean }>(dir);
+    expect(Object.keys(result)).toEqual(['obj']);
+  });
+});
+
+describe('resolveAgentDir', () => {
+  it('uses explicit override when provided', async () => {
+    const { resolveAgentDir } = await import('../../src/settings.js');
+    const result = resolveAgentDir('/explicit/path');
+    expect(result).toBe('/explicit/path');
+  });
+
+  it('defaults to ~/.pi/agent when no override', async () => {
+    const { resolveAgentDir } = await import('../../src/settings.js');
+    const os = await import('node:os');
+    const path = await import('node:path');
+    const result = resolveAgentDir();
+    expect(result).toBe(path.resolve(path.join(os.homedir(), '.pi', 'agent')));
   });
 });

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -1,6 +1,11 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
+
+export type PiSettingsOptions = {
+  cwd?: string;
+  agentDir?: string;
+};
 
 function resolveEnvVars(value: unknown): unknown {
   if (typeof value === 'string') {
@@ -38,19 +43,65 @@ function readSettingsSection<T>(filePath: string, key: string): Partial<T> {
   }
 }
 
+export function resolveAgentDir(override?: string): string {
+  return resolve(override ?? join(homedir(), '.pi', 'agent'));
+}
+
 /**
  * Load extension config from pi-agent settings files.
- * Reads from user (~/.pi/agent/settings.json) and project (<cwd>/.pi/settings.json),
- * with project-level fields taking priority.
+ * Reads from global (~/.pi/agent/settings.json), agentDir (env/param), and project (<cwd>/.pi/settings.json).
+ * Priority from low to high: global < agentDir < project.
  */
-export function loadPiSettings<T>(key: string): T {
-  const userSettings = readSettingsSection<T>(
-    join(homedir(), '.pi', 'agent', 'settings.json'),
-    key,
-  );
-  const projectSettings = readSettingsSection<T>(
-    resolve(process.cwd(), '.pi', 'settings.json'),
-    key,
-  );
-  return { ...userSettings, ...projectSettings } as T;
+export function loadPiSettings<T>(key: string, options?: PiSettingsOptions): T {
+  const globalDir = resolve(join(homedir(), '.pi', 'agent'));
+  const agentDir = resolveAgentDir(options?.agentDir);
+  const cwd = options?.cwd ?? process.cwd();
+
+  const globalSettings = readSettingsSection<T>(join(globalDir, 'settings.json'), key);
+
+  const agentSettings =
+    agentDir === globalDir
+      ? ({} as Partial<T>)
+      : readSettingsSection<T>(join(agentDir, 'settings.json'), key);
+
+  const projectSettings = readSettingsSection<T>(join(cwd, '.pi', 'settings.json'), key);
+
+  return { ...globalSettings, ...agentSettings, ...projectSettings } as T;
+}
+
+export function loadJsonProfileDir<T>(dir: string): Record<string, T> {
+  const result: Record<string, T> = {};
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return result;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const name = basename(entry, '.json');
+    try {
+      const raw = readFileSync(join(dir, entry), 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        result[name] = parsed as T;
+      }
+    } catch {
+      // skip malformed files
+    }
+  }
+  return result;
+}
+
+export function loadPiPolicyProfiles<T>(options?: PiSettingsOptions): Record<string, T> {
+  const globalDir = resolve(join(homedir(), '.pi', 'agent', 'policy'));
+  const agentDir = resolve(join(resolveAgentDir(options?.agentDir), 'policy'));
+  const projectDir = resolve(join(options?.cwd ?? process.cwd(), '.pi', 'policy'));
+
+  const globalPolicies = loadJsonProfileDir<T>(globalDir);
+  const agentPolicies =
+    agentDir === globalDir ? ({} as Record<string, T>) : loadJsonProfileDir<T>(agentDir);
+  const projectPolicies = loadJsonProfileDir<T>(projectDir);
+
+  return { ...globalPolicies, ...agentPolicies, ...projectPolicies };
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-subagents",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/task-scheduler/package.json
+++ b/packages/task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/turns/package.json
+++ b/packages/turns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-turns",
-  "version": "0.1.2-beta.1",
+  "version": "0.1.2-beta.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.4
+      jiti:
+        specifier: ^2.7.0
+        version: 2.7.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/tests/extension-e2e.test.ts
+++ b/tests/extension-e2e.test.ts
@@ -1,0 +1,163 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createJiti } from 'jiti/static';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.resolve(__dirname, '..');
+const PACKAGES_DIR = path.join(ROOT, 'packages');
+
+const EXTENSION_PACKAGES = [
+  'pi-security',
+  'pi-telemetry',
+  'pi-browser-use',
+  'pi-computer-use',
+] as const;
+
+interface CollectedExtension {
+  handlers: Map<string, unknown[]>;
+  tools: Map<string, { name: string; parameters: unknown; [k: string]: unknown }>;
+  commands: Map<string, unknown>;
+}
+
+function createCollector(): { api: Record<string, unknown>; ext: CollectedExtension } {
+  const ext: CollectedExtension = {
+    handlers: new Map(),
+    tools: new Map(),
+    commands: new Map(),
+  };
+  const api = {
+    on(event: string, handler: unknown) {
+      ext.handlers.set(event, [...(ext.handlers.get(event) || []), handler]);
+    },
+    registerTool(tool: { name: string; parameters: unknown }) {
+      ext.tools.set(tool.name, tool as CollectedExtension['tools'] extends Map<string, infer V> ? V : never);
+    },
+    registerCommand(name: string, opts: unknown) {
+      ext.commands.set(name, opts);
+    },
+  };
+  return { api, ext };
+}
+
+async function loadExtensionWithJiti(pkgName: string): Promise<{ factory: Function; ext: CollectedExtension }> {
+  const entryPath = path.join(PACKAGES_DIR, pkgName, 'src', 'index.ts');
+  const jiti = createJiti(entryPath, { moduleCache: false });
+  const factory = (await jiti.import(entryPath, { default: true })) as Function;
+  const { api, ext } = createCollector();
+  await factory(api);
+  return { factory, ext };
+}
+
+function findSchemaViolations(schema: unknown, path = ''): string[] {
+  const violations: string[] = [];
+  if (!schema || typeof schema !== 'object') return violations;
+  const s = schema as Record<string, unknown>;
+  if (Array.isArray(s.items)) {
+    violations.push(`${path}.items is an array (tuple schema) — incompatible with Moonshot/Kimi`);
+  }
+  if (s.items && typeof s.items === 'object' && !Array.isArray(s.items)) {
+    violations.push(...findSchemaViolations(s.items, `${path}.items`));
+  }
+  if (s.properties && typeof s.properties === 'object') {
+    for (const [key, val] of Object.entries(s.properties as Record<string, unknown>)) {
+      violations.push(...findSchemaViolations(val, `${path}.${key}`));
+    }
+  }
+  if (s.additionalProperties && typeof s.additionalProperties === 'object') {
+    violations.push(...findSchemaViolations(s.additionalProperties, `${path}.additionalProperties`));
+  }
+  return violations;
+}
+
+describe('Extension E2E loading via jiti', () => {
+  for (const pkgName of EXTENSION_PACKAGES) {
+    it(`${pkgName}: package.json declares pi.extensions`, () => {
+      const pkgJson = JSON.parse(
+        readFileSync(path.join(PACKAGES_DIR, pkgName, 'package.json'), 'utf8'),
+      );
+      expect(pkgJson.pi?.extensions).toBeInstanceOf(Array);
+      expect(pkgJson.pi.extensions.length).toBeGreaterThan(0);
+    });
+  }
+
+  it('pi-computer-use: loads via jiti and registers computer_use tool', async () => {
+    const { ext } = await loadExtensionWithJiti('pi-computer-use');
+    expect(ext.tools.has('computer_use')).toBe(true);
+    expect(ext.handlers.has('session_shutdown')).toBe(true);
+  });
+
+  it('pi-computer-use: tool schema has no tuple (items as array)', async () => {
+    const { ext } = await loadExtensionWithJiti('pi-computer-use');
+    const tool = ext.tools.get('computer_use')!;
+    const violations = findSchemaViolations(tool.parameters);
+    expect(violations).toEqual([]);
+  });
+
+  it('pi-computer-use: path field uses minItems/maxItems for coordinate pairs', async () => {
+    const { ext } = await loadExtensionWithJiti('pi-computer-use');
+    const tool = ext.tools.get('computer_use')!;
+    const params = tool.parameters as Record<string, unknown>;
+    const action = (params.properties as Record<string, unknown>).action as Record<string, unknown>;
+    const pathProp = (action.properties as Record<string, unknown>).path as Record<string, unknown>;
+    const innerItems = pathProp.items as Record<string, unknown>;
+    expect(innerItems.type).toBe('array');
+    expect(innerItems.items).toEqual({ type: 'number' });
+    expect(innerItems.minItems).toBe(2);
+    expect(innerItems.maxItems).toBe(2);
+  });
+
+  it('pi-browser-use: loads via jiti and registers session handlers', async () => {
+    const { ext } = await loadExtensionWithJiti('pi-browser-use');
+    expect(ext.handlers.has('session_start')).toBe(true);
+    expect(ext.handlers.has('session_shutdown')).toBe(true);
+  });
+});
+
+describe('findSchemaViolations regression', () => {
+  it('detects tuple-style items (array of schemas)', () => {
+    const tupleSchema = {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'array',
+              items: {
+                type: 'array',
+                items: [{ type: 'number' }, { type: 'number' }],
+              },
+            },
+          },
+        },
+      },
+    };
+    const violations = findSchemaViolations(tupleSchema);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations[0]).toContain('tuple');
+  });
+
+  it('passes for valid array-style items (object schema)', () => {
+    const arraySchema = {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'array',
+              items: {
+                type: 'array',
+                items: { type: 'number' },
+                minItems: 2,
+                maxItems: 2,
+              },
+            },
+          },
+        },
+      },
+    };
+    const violations = findSchemaViolations(arraySchema);
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/extension-loading.test.ts
+++ b/tests/extension-loading.test.ts
@@ -4,9 +4,15 @@ import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: vi.fn().mockImplementation(() => ({
-    connect: vi.fn(),
-    close: vi.fn(),
-    listTools: vi.fn().mockResolvedValue({ tools: [] }),
+    connect: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    listTools: vi.fn().mockResolvedValue({
+      tools: [
+        { name: 'click', description: 'Click', inputSchema: { type: 'object' } },
+        { name: 'take_snapshot', description: 'Snapshot', inputSchema: { type: 'object' } },
+      ],
+      nextCursor: undefined,
+    }),
     callTool: vi.fn().mockResolvedValue({ content: [] }),
   })),
 }));
@@ -119,6 +125,25 @@ describe('Extension loading contract', () => {
       const onCalls = pi.on.mock.calls.map((c: unknown[]) => c[0]);
       expect(onCalls).toContain('session_start');
       expect(onCalls).toContain('session_shutdown');
+    });
+
+    it('registers browser_ prefixed tools after session_start', async () => {
+      const mod = await import(join(EXTENSIONS_DIR, 'pi-browser-use', 'src', 'index.ts'));
+      const pi = createMockExtensionAPI();
+      // biome-ignore lint/suspicious/noExplicitAny: mock API
+      mod.default(pi as any);
+
+      const sessionStartHandler = pi.on.mock.calls.find(
+        (c: unknown[]) => c[0] === 'session_start',
+      )?.[1] as () => Promise<void>;
+      expect(sessionStartHandler).toBeDefined();
+
+      await sessionStartHandler();
+
+      expect(pi.registerTool).toHaveBeenCalled();
+      const toolNames = pi.registerTool.mock.calls.map((c: unknown[]) => c[0].name);
+      expect(toolNames).toContain('browser_click');
+      expect(toolNames).toContain('browser_take_snapshot');
     });
   });
 

--- a/tests/extension-loading.test.ts
+++ b/tests/extension-loading.test.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: vi.fn(),
+    close: vi.fn(),
+    listTools: vi.fn().mockResolvedValue({ tools: [] }),
+    callTool: vi.fn().mockResolvedValue({ content: [] }),
+  })),
+}));
+
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('@earendil-works/pi-ai', () => ({
+  complete: vi.fn().mockResolvedValue({ text: 'mock' }),
+}));
+
+interface MockExtensionAPI {
+  on: ReturnType<typeof vi.fn>;
+  registerTool: ReturnType<typeof vi.fn>;
+  registerCommand: ReturnType<typeof vi.fn>;
+}
+
+function createMockExtensionAPI(): MockExtensionAPI {
+  return {
+    on: vi.fn(),
+    registerTool: vi.fn(),
+    registerCommand: vi.fn(),
+  };
+}
+
+const EXTENSIONS_DIR = join(__dirname, '..', 'packages');
+
+const EXTENSION_PACKAGES = [
+  'pi-security',
+  'pi-telemetry',
+  'pi-browser-use',
+  'pi-computer-use',
+] as const;
+
+describe('Extension loading contract', () => {
+  for (const pkgName of EXTENSION_PACKAGES) {
+    describe(pkgName, () => {
+      const pkgDir = join(EXTENSIONS_DIR, pkgName);
+      const pkgJsonPath = join(pkgDir, 'package.json');
+
+      it('declares "pi" field with extensions in package.json', () => {
+        const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+        expect(pkgJson.pi).toBeDefined();
+        expect(pkgJson.pi.extensions).toBeInstanceOf(Array);
+        expect(pkgJson.pi.extensions.length).toBeGreaterThan(0);
+      });
+
+      it('exports a default function (extension factory)', async () => {
+        const mod = await import(join(pkgDir, 'src', 'index.ts'));
+        expect(typeof mod.default).toBe('function');
+      });
+
+      it('calls factory without throwing', async () => {
+        const mod = await import(join(pkgDir, 'src', 'index.ts'));
+        const pi = createMockExtensionAPI();
+        // biome-ignore lint/suspicious/noExplicitAny: mock API
+        expect(() => mod.default(pi as any)).not.toThrow();
+      });
+    });
+  }
+
+  describe('pi-security registrations', () => {
+    it('registers tool_call + user_bash handlers and 3 commands', async () => {
+      const mod = await import(join(EXTENSIONS_DIR, 'pi-security', 'src', 'index.ts'));
+      const pi = createMockExtensionAPI();
+      // biome-ignore lint/suspicious/noExplicitAny: mock API
+      mod.default(pi as any);
+
+      const onCalls = pi.on.mock.calls.map((c: unknown[]) => c[0]);
+      expect(onCalls).toContain('session_start');
+      expect(onCalls).toContain('session_shutdown');
+      expect(onCalls).toContain('tool_call');
+      expect(onCalls).toContain('user_bash');
+
+      const cmdNames = pi.registerCommand.mock.calls.map((c: unknown[]) => c[0]);
+      expect(cmdNames).toContain('pi-security-status');
+      expect(cmdNames).toContain('pi-security-audit');
+      expect(cmdNames).toContain('pi-security-reset');
+    });
+  });
+
+  describe('pi-telemetry registrations', () => {
+    it('registers all lifecycle event handlers', async () => {
+      const mod = await import(join(EXTENSIONS_DIR, 'pi-telemetry', 'src', 'index.ts'));
+      const pi = createMockExtensionAPI();
+      // biome-ignore lint/suspicious/noExplicitAny: mock API
+      mod.default(pi as any);
+
+      const onCalls = pi.on.mock.calls.map((c: unknown[]) => c[0]);
+      expect(onCalls).toContain('session_start');
+      expect(onCalls).toContain('input');
+      expect(onCalls).toContain('turn_start');
+      expect(onCalls).toContain('turn_end');
+      expect(onCalls).toContain('tool_execution_start');
+      expect(onCalls).toContain('tool_execution_end');
+      expect(onCalls).toContain('before_provider_request');
+      expect(onCalls).toContain('after_provider_response');
+      expect(onCalls).toContain('session_shutdown');
+    });
+  });
+
+  describe('pi-browser-use registrations', () => {
+    it('registers session_start and session_shutdown handlers', async () => {
+      const mod = await import(join(EXTENSIONS_DIR, 'pi-browser-use', 'src', 'index.ts'));
+      const pi = createMockExtensionAPI();
+      // biome-ignore lint/suspicious/noExplicitAny: mock API
+      mod.default(pi as any);
+
+      const onCalls = pi.on.mock.calls.map((c: unknown[]) => c[0]);
+      expect(onCalls).toContain('session_start');
+      expect(onCalls).toContain('session_shutdown');
+    });
+  });
+
+  describe('pi-computer-use registrations', () => {
+    it('registers computer_use tool and session_shutdown handler', async () => {
+      const mod = await import(join(EXTENSIONS_DIR, 'pi-computer-use', 'src', 'index.ts'));
+      const pi = createMockExtensionAPI();
+      // biome-ignore lint/suspicious/noExplicitAny: mock API
+      mod.default(pi as any);
+
+      expect(pi.registerTool).toHaveBeenCalled();
+      const toolName = pi.registerTool.mock.calls[0][0].name;
+      expect(toolName).toBe('computer_use');
+
+      const onCalls = pi.on.mock.calls.map((c: unknown[]) => c[0]);
+      expect(onCalls).toContain('session_shutdown');
+    });
+  });
+});

--- a/tests/extension-loading.test.ts
+++ b/tests/extension-loading.test.ts
@@ -135,10 +135,10 @@ describe('Extension loading contract', () => {
 
       const sessionStartHandler = pi.on.mock.calls.find(
         (c: unknown[]) => c[0] === 'session_start',
-      )?.[1] as () => Promise<void>;
+      )?.[1] as (...args: unknown[]) => Promise<void>;
       expect(sessionStartHandler).toBeDefined();
 
-      await sessionStartHandler();
+      await sessionStartHandler({ type: 'session_start', reason: 'startup' }, { cwd: process.cwd() });
 
       expect(pi.registerTool).toHaveBeenCalled();
       const toolNames = pi.registerTool.mock.calls.map((c: unknown[]) => c[0].name);


### PR DESCRIPTION
## Summary

- Add 3-layer settings and policy profile resolution in `pi-shared`: global (`~/.pi/agent/`) → agentDir (via SDK `getAgentDir()`) → project (`<cwd>/.pi/`)
- All extensions (`pi-security`, `pi-telemetry`, `pi-computer-use`, `pi-browser-use`) now pass `ctx.cwd` and `getAgentDir()` at `session_start`, ensuring Desktop scenarios correctly read workspace-level overrides
- Fix `sandbox-exec.json` self-referencing `extends` cycle in policy tests

## Test plan

- [x] `pi-shared` tests: 25 passed
- [x] `pi-security` tests: 39 passed
- [x] `pi-telemetry` tests: 36 passed
- [x] `pi-computer-use` tests: 52 passed
- [x] `pi-browser-use` tests: 106 passed
- [x] Typecheck passes for all packages
- [x] Lint clean