### PR TITLE
fix: JsonScheduledTaskStore scope filtering & use shared resolveAgentDir

### DIFF
--- a/packages/pi-task-scheduler/README.md
+++ b/packages/pi-task-scheduler/README.md
@@ -36,7 +36,7 @@ Configuration via settings key `pi-scheduler`:
 }
 ```
 
-Data is stored in `<agentDir>/pi-scheduler/` by default.
+Data is stored in `<agentDir>/data/` by default (`~/.pi/agent/data/`).
 
 ## Example
 

--- a/packages/pi-task-scheduler/src/extension.ts
+++ b/packages/pi-task-scheduler/src/extension.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
-import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
+import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import {
   PersistentTaskScheduler,
@@ -29,7 +28,7 @@ type ResolvedConfig = {
 function resolveConfig(raw?: PiSchedulerExtensionConfig): ResolvedConfig {
   return {
     enabled: raw?.enabled !== false,
-    dataDir: raw?.dataDir?.trim() || path.join(getAgentDir(), 'pi-scheduler'),
+    dataDir: raw?.dataDir?.trim() || path.join(resolveAgentDir(), 'data'),
   };
 }
 
@@ -37,7 +36,7 @@ function loadSettings(cwd: string): PiSchedulerExtensionConfig | undefined {
   try {
     const config = loadPiSettings<Partial<PiSchedulerExtensionConfig>>(SETTINGS_KEY, {
       cwd,
-      agentDir: getAgentDir(),
+      agentDir: resolveAgentDir(),
     });
     return Object.keys(config).length > 0 ? (config as PiSchedulerExtensionConfig) : undefined;
   } catch {

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -1,6 +1,5 @@
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { initMulticaProvider } from './adapters/multica.js';
 import type { ExecFn, TeamworkConfig, TeamworkProvider } from './types.js';
@@ -219,7 +218,7 @@ function loadConfig(cwd: string): TeamworkConfig {
   try {
     const config = loadPiSettings<Partial<TeamworkConfig>>(SETTINGS_KEY, {
       cwd,
-      agentDir: getAgentDir(),
+      agentDir: resolveAgentDir(),
     });
     return Object.keys(config).length > 0 ? (config as TeamworkConfig) : {};
   } catch {

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -44,7 +44,7 @@ function readSettingsSection<T>(filePath: string, key: string): Partial<T> {
 }
 
 export function resolveAgentDir(override?: string): string {
-  return resolve(override ?? join(homedir(), '.pi', 'agent'));
+  return resolve(override ?? process.env.PI_AGENT_HOME ?? join(homedir(), '.pi', 'agent'));
 }
 
 /**

--- a/packages/storage/src/scheduled-task-stores.ts
+++ b/packages/storage/src/scheduled-task-stores.ts
@@ -19,15 +19,14 @@ export class JsonScheduledTaskStore implements ScheduledTaskStore {
 
   constructor(private readonly filePath: string) {}
 
-  async list(scope: TaskSchedulerScope = {}): Promise<ScheduledTask[]> {
+  async list(_scope: TaskSchedulerScope = {}): Promise<ScheduledTask[]> {
     await this.load();
-    return [...this.tasks.values()].filter((task) => taskMatchesScope(task, scope));
+    return [...this.tasks.values()];
   }
 
-  async get(taskId: string, scope: TaskSchedulerScope = {}): Promise<ScheduledTask | undefined> {
+  async get(taskId: string, _scope: TaskSchedulerScope = {}): Promise<ScheduledTask | undefined> {
     await this.load();
-    const task = this.tasks.get(taskId);
-    return task && taskMatchesScope(task, scope) ? task : undefined;
+    return this.tasks.get(taskId);
   }
 
   async create(task: ScheduledTask): Promise<ScheduledTask> {
@@ -41,11 +40,10 @@ export class JsonScheduledTaskStore implements ScheduledTaskStore {
   async update(
     taskId: string,
     task: ScheduledTask,
-    scope: TaskSchedulerScope = {},
+    _scope: TaskSchedulerScope = {},
   ): Promise<ScheduledTask | undefined> {
     await this.load();
-    const existing = await this.get(taskId, scope);
-    if (!existing) {
+    if (!this.tasks.has(taskId)) {
       return undefined;
     }
     const normalized = normalizeScheduledTask(task);
@@ -54,10 +52,9 @@ export class JsonScheduledTaskStore implements ScheduledTaskStore {
     return normalized;
   }
 
-  async delete(taskId: string, scope: TaskSchedulerScope = {}): Promise<boolean> {
+  async delete(taskId: string, _scope: TaskSchedulerScope = {}): Promise<boolean> {
     await this.load();
-    const existing = await this.get(taskId, scope);
-    if (!existing) {
+    if (!this.tasks.has(taskId)) {
       return false;
     }
     const deleted = this.tasks.delete(taskId);
@@ -294,13 +291,6 @@ export class DbScheduledTaskStore implements ScheduledTaskStore {
 
 // biome-ignore lint/suspicious/noExplicitAny: Prisma record shape is dynamic
 type PrismaRecord = Record<string, any>;
-
-function taskMatchesScope(task: ScheduledTask, scope: TaskSchedulerScope): boolean {
-  return (
-    (!scope.tenantId || task.tenantId === scope.tenantId) &&
-    (!scope.userId || task.userId === scope.userId)
-  );
-}
 
 function isProcessAlive(pid: number): boolean {
   try {


### PR DESCRIPTION
## Summary
- Remove tenant/user scope filtering from `JsonScheduledTaskStore` — JSON mode is local single-user, scope filtering should only happen at the DB layer
- Switch pi-task-scheduler and pi-teamwork to use `resolveAgentDir` from shared instead of `getAgentDir` from pi-coding-agent
- `resolveAgentDir` now respects `PI_AGENT_HOME` env var
- pi-task-scheduler data dir aligned to `<agentDir>/data/` to match server's storage path

## Test plan
- [ ] Verify scheduled tasks created via `scheduler_create` tool appear in the UI task list
- [ ] Verify CRUD operations on tasks still work in local JSON mode
- [ ] Verify DB mode still filters by tenant/user via SQL WHERE