### PR TITLE
dev/weaxs: extensions refactor & new packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "description": "Pi extension for browser automation via chrome-devtools-mcp with browser_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-channels",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "description": "Pi extension for native messaging channels including Feishu, WeCom, and webhooks.",
   "keywords": ["pi-package", "pi", "extension", "channels", "feishu", "wecom", "webhooks"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "description": "Pi extension for desktop automation via cua-driver-rs with computer_use_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "computer-use", "desktop", "automation", "cua-driver", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/src/__tests__/index.test.ts
+++ b/packages/pi-computer-use/src/__tests__/index.test.ts
@@ -48,6 +48,8 @@ vi.mock('node:fs', async (importOriginal) => {
   return {
     ...actual,
     existsSync: vi.fn().mockReturnValue(true),
+    accessSync: vi.fn(),
+    chmodSync: vi.fn(),
     readFileSync: vi.fn((..._args: unknown[]) => {
       if (mockConfigContent !== null) return mockConfigContent;
       throw new Error('ENOENT');
@@ -355,5 +357,76 @@ describe('permissions', () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toBe('element_not_found: ref is stale');
+  });
+});
+
+describe('binary permissions', () => {
+  beforeEach(() => {
+    registeredTools.clear();
+    for (const k of Object.keys(eventHandlers)) delete eventHandlers[k];
+    mockNotify.mockClear();
+  });
+
+  test('auto-fixes binary without execute permission via chmod', async () => {
+    const { accessSync, chmodSync } = await import('node:fs');
+    const mockAccessSync = vi.mocked(accessSync);
+    const mockChmodSync = vi.mocked(chmodSync);
+
+    mockAccessSync.mockImplementation((_path, mode) => {
+      if (mode === 1) throw new Error('EACCES');
+    });
+    mockChmodSync.mockImplementation(() => {});
+
+    await initExtension();
+
+    expect(mockChmodSync).toHaveBeenCalled();
+    expect(registeredTools.has('computer_use_screenshot')).toBe(true);
+
+    mockAccessSync.mockReset();
+    mockChmodSync.mockReset();
+  });
+
+  test('notifies warning when chmod fails (e.g. root-owned binary)', async () => {
+    const { accessSync, chmodSync } = await import('node:fs');
+    const mockAccessSync = vi.mocked(accessSync);
+    const mockChmodSync = vi.mocked(chmodSync);
+
+    mockAccessSync.mockImplementation((_path, mode) => {
+      if (mode === 1) throw new Error('EACCES');
+    });
+    mockChmodSync.mockImplementation(() => {
+      throw new Error('EPERM: operation not permitted');
+    });
+
+    await initExtension();
+
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.stringContaining('failed to initialize'),
+      'warning',
+    );
+
+    mockAccessSync.mockReset();
+    mockChmodSync.mockReset();
+  });
+
+  test('session_start does not crash when binary is not executable', async () => {
+    const { accessSync, chmodSync } = await import('node:fs');
+    const mockAccessSync = vi.mocked(accessSync);
+    const mockChmodSync = vi.mocked(chmodSync);
+
+    mockAccessSync.mockImplementation((_path, mode) => {
+      if (mode === 1) throw new Error('EACCES');
+    });
+    mockChmodSync.mockImplementation(() => {
+      throw new Error('EPERM');
+    });
+
+    await initExtension();
+
+    expect(mockNotify).toHaveBeenCalled();
+    expect(registeredTools.has('computer_use_screenshot')).toBe(false);
+
+    mockAccessSync.mockReset();
+    mockChmodSync.mockReset();
   });
 });

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -172,8 +172,15 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
     config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
     client = new CuaDriverClient(config);
     connected = false;
-    await registerUpstreamTools();
-    await registerVisionTool();
+
+    try {
+      await registerUpstreamTools();
+      await registerVisionTool();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      ctx.ui.notify(`pi-computer-use: failed to initialize — ${msg}`, 'warning');
+      return;
+    }
 
     try {
       const permResult = await client!.callTool('check_permissions', {});

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { accessSync, chmodSync, constants, existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -93,6 +93,20 @@ export class CuaDriverClient {
         `[pi-computer-use] cua-driver binary not found at ${binPath}. ` +
           `Platform "${platform}" may not be supported, or set mode: "path" with binaryPath in config.`,
       );
+    }
+
+    try {
+      accessSync(binPath, constants.X_OK);
+    } catch {
+      try {
+        chmodSync(binPath, 0o755);
+      } catch (chmodErr) {
+        throw new Error(
+          `[pi-computer-use] cua-driver binary at ${binPath} is not executable. ` +
+            `Auto-fix failed (${chmodErr instanceof Error ? chmodErr.message : String(chmodErr)}). ` +
+            `Run: sudo chmod +x "${binPath}"`,
+        );
+      }
     }
 
     return binPath;

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "description": "Pi extension for resource-aware security policy engine and tool authorization",
   "keywords": ["pi-package", "pi", "extension", "security", "policy", "authorization", "access-control"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/README.md
+++ b/packages/pi-task-scheduler/README.md
@@ -6,16 +6,57 @@ The package owns schedule parsing, task lifecycle state, process-local timers,
 runner callbacks, scheduler hooks, and LLM-callable tools for autonomous task
 management.
 
-## Scope
+## Storage
 
-This package does not persist data by itself and does not know how to execute a
-pi chat turn. Applications provide both:
+The package ships with a built-in file-based storage (default, zero external
+dependencies):
 
-- a `ScheduledTaskStore` for persistence
-- a `SchedulerLock` for single-owner execution
-- a `ScheduledTaskRunner` callback for the actual work
+- `JsonScheduledTaskStore` — persists tasks to a JSON file with atomic writes
+- `FileSchedulerLock` — PID-based file lock for single-owner execution
 
-Storage adapters live in `@amaster.ai/pi-storage/scheduler`.
+For database-backed storage (multi-tenant, Prisma), use
+`@amaster.ai/pi-storage/scheduler` which implements the same interfaces with
+`DbScheduledTaskStore` and `RedisSchedulerLock`.
+
+### Default (file storage)
+
+```ts
+import {
+  PersistentTaskScheduler,
+  JsonScheduledTaskStore,
+  FileSchedulerLock,
+} from "@amaster.ai/pi-task-scheduler";
+
+const scheduler = new PersistentTaskScheduler({
+  store: new JsonScheduledTaskStore("/var/lib/pi/tasks.json"),
+  lock: new FileSchedulerLock("/var/lib/pi/tasks.lock"),
+  runner: async (task, run) => {
+    await runPrompt(task.prompt, { sessionId: run.sessionId });
+  },
+});
+
+await scheduler.start();
+```
+
+### Database storage (pi-agent server)
+
+```ts
+import { PersistentTaskScheduler } from "@amaster.ai/pi-task-scheduler";
+import {
+  DbScheduledTaskStore,
+  RedisSchedulerLock,
+} from "@amaster.ai/pi-storage/scheduler";
+
+const scheduler = new PersistentTaskScheduler({
+  store: new DbScheduledTaskStore(databaseUrl),
+  lock: new RedisSchedulerLock(redisUrl),
+  runner: async (task, run) => {
+    await runPrompt(task.prompt, { sessionId: run.sessionId });
+  },
+});
+
+await scheduler.start();
+```
 
 ## Extension
 
@@ -30,7 +71,6 @@ Configuration via settings key `pi-scheduler`:
 ```json
 {
   "pi-scheduler": {
-    "enabled": true,
     "dataDir": "/custom/path"
   }
 }
@@ -38,30 +78,38 @@ Configuration via settings key `pi-scheduler`:
 
 Data is stored in `<agentDir>/data/` by default (`~/.pi/agent/data/`).
 
-## Example
+### Standalone mode (default)
+
+When installed as an npm extension package, the extension creates its own
+scheduler with `JsonScheduledTaskStore` and `FileSchedulerLock`. No additional
+dependencies required.
+
+### Injected mode (pi-agent server)
+
+When the host already owns a scheduler instance (e.g. pi-agent server with DB
+storage), pass it directly to avoid creating a second scheduler:
 
 ```ts
+import taskSchedulerExtension from "@amaster.ai/pi-task-scheduler";
 import { PersistentTaskScheduler } from "@amaster.ai/pi-task-scheduler";
 import {
-  FileSchedulerLock,
-  JsonScheduledTaskStore,
+  DbScheduledTaskStore,
+  RedisSchedulerLock,
 } from "@amaster.ai/pi-storage/scheduler";
 
 const scheduler = new PersistentTaskScheduler({
-  store: new JsonScheduledTaskStore("/var/lib/pi/tasks.json"),
-  lock: new FileSchedulerLock("/var/lib/pi/tasks.lock"),
-  runner: async (task, run) => {
-    await runPrompt(task.prompt, { sessionId: run.sessionId });
-  },
-  hooks: {
-    onTaskFailed: ({ task, error }) => {
-      console.warn("scheduled task failed", task.id, error);
-    },
-  },
+  store: new DbScheduledTaskStore(databaseUrl),
+  lock: new RedisSchedulerLock(redisUrl),
+  runner,
 });
-
 await scheduler.start();
+
+// Extension only registers tools, does not create/stop the scheduler
+taskSchedulerExtension(pi, { scheduler });
 ```
+
+In injected mode, `session_shutdown` does **not** stop the scheduler — the host
+manages its lifecycle.
 
 ## Scheduling
 

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -13,6 +13,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./stores": {
+      "types": "./dist/stores.d.ts",
+      "default": "./dist/stores.js"
+    },
     "./extension": {
       "types": "./dist/extension.d.ts",
       "default": "./dist/extension.js"
@@ -49,14 +53,10 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@amaster.ai/pi-storage": "workspace:*",
     "typebox": "*"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {
-      "optional": true
-    },
-    "@amaster.ai/pi-storage": {
       "optional": true
     },
     "typebox": {
@@ -65,7 +65,6 @@
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.74.0",
-    "@amaster.ai/pi-storage": "workspace:*",
     "typebox": "*",
     "vitest": "^4.0.0"
   }

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "description": "Pi extension for cron-based scheduled task management with LLM-callable tools",
   "keywords": ["pi-package", "pi", "extension", "scheduler", "cron", "tasks"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/src/extension.test.ts
+++ b/packages/pi-task-scheduler/src/extension.test.ts
@@ -1,0 +1,398 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PersistentTaskScheduler,
+  type ScheduledTask,
+  type ScheduledTaskStore,
+  type SchedulerLock,
+  type TaskScheduler,
+  type TaskSchedulerScope,
+} from './index.js';
+
+interface RegisteredTool {
+  name: string;
+  label: string;
+  description: string;
+  parameters: unknown;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+    signal: undefined,
+    onUpdate: undefined,
+    ctx: unknown,
+  ) => Promise<unknown>;
+}
+
+interface RegisteredCommand {
+  description: string;
+  handler: (args: string, ctx: unknown) => Promise<void>;
+}
+
+function createMockPi() {
+  const tools = new Map<string, RegisteredTool>();
+  const commands = new Map<string, RegisteredCommand>();
+  const eventHandlers: Record<string, Array<(event: unknown, ctx: unknown) => Promise<void>>> = {};
+
+  return {
+    tools,
+    commands,
+    eventHandlers,
+    registerTool: vi.fn((tool: RegisteredTool) => {
+      tools.set(tool.name, tool);
+    }),
+    registerCommand: vi.fn((name: string, cmd: RegisteredCommand) => {
+      commands.set(name, cmd);
+    }),
+    on: vi.fn((event: string, handler: (event: unknown, ctx: unknown) => Promise<void>) => {
+      if (!eventHandlers[event]) eventHandlers[event] = [];
+      eventHandlers[event].push(handler);
+    }),
+    sendUserMessage: vi.fn(),
+  };
+}
+
+function createMockCtx(cwd = '/tmp') {
+  return {
+    cwd,
+    ui: {
+      setStatus: vi.fn(),
+      notify: vi.fn(),
+    },
+    sessionManager: { getSessionId: () => 'test-session-1' },
+    model: { id: 'test-model' },
+  };
+}
+
+class MemStore implements ScheduledTaskStore {
+  readonly tasks = new Map<string, ScheduledTask>();
+
+  async list(_scope: TaskSchedulerScope = {}): Promise<ScheduledTask[]> {
+    return Array.from(this.tasks.values());
+  }
+  async get(taskId: string): Promise<ScheduledTask | undefined> {
+    return this.tasks.get(taskId);
+  }
+  async create(task: ScheduledTask): Promise<ScheduledTask> {
+    this.tasks.set(task.id, task);
+    return task;
+  }
+  async update(taskId: string, task: ScheduledTask): Promise<ScheduledTask | undefined> {
+    if (!this.tasks.has(taskId)) return undefined;
+    this.tasks.set(taskId, task);
+    return task;
+  }
+  async delete(taskId: string): Promise<boolean> {
+    return this.tasks.delete(taskId);
+  }
+}
+
+class MemLock implements SchedulerLock {
+  readonly path = 'memory:test';
+  private locked = false;
+  acquire(): boolean {
+    if (this.locked) return false;
+    this.locked = true;
+    return true;
+  }
+  release(): void {
+    this.locked = false;
+  }
+  isAcquired(): boolean {
+    return this.locked;
+  }
+  holderPid(): number | undefined {
+    return this.locked ? process.pid : undefined;
+  }
+}
+
+async function setupExtension(injectedConfig?: Record<string, unknown>) {
+  const { default: taskSchedulerExtension } = await import('./extension.js');
+  const pi = createMockPi();
+  const ctx = createMockCtx();
+
+  taskSchedulerExtension(pi as any, injectedConfig as any);
+
+  for (const handler of pi.eventHandlers.session_start ?? []) {
+    await handler({}, ctx);
+  }
+
+  return { pi, ctx };
+}
+
+describe('extension — default file storage mode', () => {
+  it('registers all tools and commands on session_start', async () => {
+    const { pi } = await setupExtension({ dataDir: '/tmp/pi-test-ext' });
+
+    expect(pi.tools.has('scheduler_create')).toBe(true);
+    expect(pi.tools.has('scheduler_list')).toBe(true);
+    expect(pi.tools.has('scheduler_get')).toBe(true);
+    expect(pi.tools.has('scheduler_update')).toBe(true);
+    expect(pi.tools.has('scheduler_delete')).toBe(true);
+    expect(pi.tools.has('scheduler_run_now')).toBe(true);
+
+    expect(pi.commands.has('pi-scheduler-status')).toBe(true);
+    expect(pi.commands.has('pi-scheduler-list')).toBe(true);
+    expect(pi.commands.has('pi-scheduler-run-now')).toBe(true);
+  });
+
+  it('sets status to active when scheduler starts', async () => {
+    const { ctx } = await setupExtension({ dataDir: '/tmp/pi-test-ext' });
+
+    expect(ctx.ui.setStatus).toHaveBeenCalledWith('pi-scheduler', 'scheduler: active');
+  });
+
+  it('scheduler_list returns empty when no tasks', async () => {
+    const { pi } = await setupExtension({ dataDir: '/tmp/pi-test-ext' });
+
+    const tool = pi.tools.get('scheduler_list')!;
+    const result = (await tool.execute('id', {}, undefined, undefined, createMockCtx())) as any;
+
+    expect(result.content[0].text).toBe('No scheduled tasks.');
+  });
+});
+
+describe('extension — injected scheduler', () => {
+  let externalScheduler: TaskScheduler;
+  let store: MemStore;
+
+  beforeEach(async () => {
+    store = new MemStore();
+    externalScheduler = new PersistentTaskScheduler({
+      store,
+      lock: new MemLock(),
+      runner: async () => {},
+    });
+    await externalScheduler.start();
+  });
+
+  it('uses injected scheduler without creating its own', async () => {
+    const { pi, ctx } = await setupExtension({ scheduler: externalScheduler });
+
+    expect(ctx.ui.setStatus).toHaveBeenCalledWith('pi-scheduler', 'scheduler: active');
+
+    const tool = pi.tools.get('scheduler_create')!;
+    const result = (await tool.execute(
+      'id',
+      { type: 'interval', schedule: '10m', prompt: 'injected test' },
+      undefined,
+      undefined,
+      createMockCtx(),
+    )) as any;
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.prompt).toBe('injected test');
+    expect(store.tasks.size).toBe(1);
+  });
+
+  it('does not stop injected scheduler on session_shutdown', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+
+    for (const handler of pi.eventHandlers.session_shutdown ?? []) {
+      await handler({}, createMockCtx());
+    }
+
+    expect(externalScheduler.isActive()).toBe(true);
+  });
+
+  it('stops self-created scheduler on session_shutdown', async () => {
+    const { pi } = await setupExtension({
+      store: new MemStore(),
+      lock: new MemLock(),
+    });
+
+    for (const handler of pi.eventHandlers.session_shutdown ?? []) {
+      await handler({}, createMockCtx());
+    }
+
+    // Tools should return "not running" after shutdown
+    const tool = pi.tools.get('scheduler_list')!;
+    const result = (await tool.execute('id', {}, undefined, undefined, createMockCtx())) as any;
+    expect(result.content[0].text).toBe('Task scheduler is not running.');
+  });
+});
+
+describe('extension — tool operations with injected scheduler', () => {
+  let externalScheduler: TaskScheduler;
+  let store: MemStore;
+
+  beforeEach(async () => {
+    store = new MemStore();
+    externalScheduler = new PersistentTaskScheduler({
+      store,
+      lock: new MemLock(),
+      runner: async () => {},
+    });
+    await externalScheduler.start();
+  });
+
+  it('scheduler_create creates a task via injected scheduler', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+    const tool = pi.tools.get('scheduler_create')!;
+    const ctx = createMockCtx();
+
+    const result = (await tool.execute(
+      'id',
+      {
+        type: 'cron',
+        schedule: '0 9 * * 1-5',
+        prompt: 'daily standup reminder',
+        name: 'standup',
+      },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.name).toBe('standup');
+    expect(parsed.type).toBe('cron');
+    expect(parsed.schedule).toBe('0 9 * * 1-5');
+    expect(store.tasks.size).toBe(1);
+  });
+
+  it('scheduler_get returns task details', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+    const createTool = pi.tools.get('scheduler_create')!;
+    const getTool = pi.tools.get('scheduler_get')!;
+    const ctx = createMockCtx();
+
+    const createResult = (await createTool.execute(
+      'id',
+      { type: 'interval', schedule: '5m', prompt: 'check health' },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    const taskId = JSON.parse(createResult.content[0].text).id;
+
+    const getResult = (await getTool.execute(
+      'id',
+      { taskId },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    const task = JSON.parse(getResult.content[0].text);
+    expect(task.id).toBe(taskId);
+    expect(task.prompt).toBe('check health');
+  });
+
+  it('scheduler_get returns not found for missing task', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+    const tool = pi.tools.get('scheduler_get')!;
+
+    const result = (await tool.execute(
+      'id',
+      { taskId: 'nonexistent' },
+      undefined,
+      undefined,
+      createMockCtx(),
+    )) as any;
+
+    expect(result.content[0].text).toBe('Task not found: nonexistent');
+  });
+
+  it('scheduler_update modifies task fields', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+    const createTool = pi.tools.get('scheduler_create')!;
+    const updateTool = pi.tools.get('scheduler_update')!;
+    const ctx = createMockCtx();
+
+    const createResult = (await createTool.execute(
+      'id',
+      { type: 'interval', schedule: '10m', prompt: 'original' },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    const taskId = JSON.parse(createResult.content[0].text).id;
+
+    const updateResult = (await updateTool.execute(
+      'id',
+      { taskId, prompt: 'updated', enabled: false },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    const updated = JSON.parse(updateResult.content[0].text);
+    expect(updated.prompt).toBe('updated');
+    expect(updated.enabled).toBe(false);
+  });
+
+  it('scheduler_delete removes a task', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+    const createTool = pi.tools.get('scheduler_create')!;
+    const deleteTool = pi.tools.get('scheduler_delete')!;
+    const ctx = createMockCtx();
+
+    const createResult = (await createTool.execute(
+      'id',
+      { type: 'interval', schedule: '1h', prompt: 'temp' },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    const taskId = JSON.parse(createResult.content[0].text).id;
+
+    const deleteResult = (await deleteTool.execute(
+      'id',
+      { taskId },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    expect(deleteResult.content[0].text).toBe(`Deleted task: ${taskId}`);
+    expect(store.tasks.size).toBe(0);
+  });
+
+  it('scheduler_delete returns not found for missing task', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+    const tool = pi.tools.get('scheduler_delete')!;
+
+    const result = (await tool.execute(
+      'id',
+      { taskId: 'ghost' },
+      undefined,
+      undefined,
+      createMockCtx(),
+    )) as any;
+    expect(result.content[0].text).toBe('Task not found: ghost');
+  });
+
+  it('scheduler_run_now triggers a task', async () => {
+    const { pi } = await setupExtension({ scheduler: externalScheduler });
+    const createTool = pi.tools.get('scheduler_create')!;
+    const runTool = pi.tools.get('scheduler_run_now')!;
+    const ctx = createMockCtx();
+
+    const createResult = (await createTool.execute(
+      'id',
+      { type: 'interval', schedule: '1h', prompt: 'run me', name: 'runner' },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    const taskId = JSON.parse(createResult.content[0].text).id;
+
+    const runResult = (await runTool.execute(
+      'id',
+      { taskId },
+      undefined,
+      undefined,
+      ctx,
+    )) as any;
+    expect(runResult.content[0].text).toBe('Triggered: runner');
+  });
+
+  it('all tools return not running when scheduler is undefined', async () => {
+    const { default: taskSchedulerExtension } = await import('./extension.js');
+    const pi = createMockPi();
+    taskSchedulerExtension(pi as any);
+    // Don't fire session_start — scheduler stays undefined
+
+    const ctx = createMockCtx();
+    for (const tool of Array.from(pi.tools.values())) {
+      const result = (await tool.execute('id', {}, undefined, undefined, ctx)) as any;
+      expect(result.content[0].text).toContain('not running');
+    }
+  });
+});

--- a/packages/pi-task-scheduler/src/extension.test.ts
+++ b/packages/pi-task-scheduler/src/extension.test.ts
@@ -264,13 +264,7 @@ describe('extension — tool operations with injected scheduler', () => {
     )) as any;
     const taskId = JSON.parse(createResult.content[0].text).id;
 
-    const getResult = (await getTool.execute(
-      'id',
-      { taskId },
-      undefined,
-      undefined,
-      ctx,
-    )) as any;
+    const getResult = (await getTool.execute('id', { taskId }, undefined, undefined, ctx)) as any;
     const task = JSON.parse(getResult.content[0].text);
     expect(task.id).toBe(taskId);
     expect(task.prompt).toBe('check health');
@@ -373,13 +367,7 @@ describe('extension — tool operations with injected scheduler', () => {
     )) as any;
     const taskId = JSON.parse(createResult.content[0].text).id;
 
-    const runResult = (await runTool.execute(
-      'id',
-      { taskId },
-      undefined,
-      undefined,
-      ctx,
-    )) as any;
+    const runResult = (await runTool.execute('id', { taskId }, undefined, undefined, ctx)) as any;
     expect(runResult.content[0].text).toBe('Triggered: runner');
   });
 

--- a/packages/pi-task-scheduler/src/extension.ts
+++ b/packages/pi-task-scheduler/src/extension.ts
@@ -70,12 +70,10 @@ export default function taskSchedulerExtension(
         scheduler = config.scheduler;
         ownsScheduler = false;
       } else {
-        const store = config.store ?? new JsonScheduledTaskStore(
-          path.join(config.dataDir, 'tasks.json'),
-        );
-        const lock = config.lock ?? new FileSchedulerLock(
-          path.join(config.dataDir, 'scheduler.lock'),
-        );
+        const store =
+          config.store ?? new JsonScheduledTaskStore(path.join(config.dataDir, 'tasks.json'));
+        const lock =
+          config.lock ?? new FileSchedulerLock(path.join(config.dataDir, 'scheduler.lock'));
 
         const runner: ScheduledTaskRunner = async (task) => {
           pi.sendUserMessage(task.prompt);
@@ -341,7 +339,7 @@ function formatTaskSummary(task: ScheduledTask) {
     lastStatus: task.lastStatus ?? 'pending',
     nextRunAt: task.nextRunAt,
     runCount: task.runCount,
-    prompt: task.prompt.length > 100 ? task.prompt.slice(0, 100) + '…' : task.prompt,
+    prompt: task.prompt.length > 100 ? `${task.prompt.slice(0, 100)}…` : task.prompt,
   };
 }
 

--- a/packages/pi-task-scheduler/src/extension.ts
+++ b/packages/pi-task-scheduler/src/extension.ts
@@ -8,28 +8,38 @@ import {
   type ScheduledTask,
   type ScheduledTaskCreateInput,
   type ScheduledTaskRunner,
+  type ScheduledTaskStore,
   type ScheduledTaskType,
+  type SchedulerLock,
   type TaskScheduler,
 } from './index.js';
+import { FileSchedulerLock, JsonScheduledTaskStore } from './stores.js';
 
 const SETTINGS_KEY = 'pi-scheduler';
 const STATUS_KEY = 'pi-scheduler';
 
 export type PiSchedulerExtensionConfig = {
-  enabled?: boolean;
   dataDir?: string;
+  store?: ScheduledTaskStore;
+  lock?: SchedulerLock;
+  scheduler?: TaskScheduler;
 };
 
 type ResolvedConfig = {
-  enabled: boolean;
   dataDir: string;
+  store?: ScheduledTaskStore;
+  lock?: SchedulerLock;
+  scheduler?: TaskScheduler;
 };
 
 function resolveConfig(raw?: PiSchedulerExtensionConfig): ResolvedConfig {
-  return {
-    enabled: raw?.enabled !== false,
+  const resolved: ResolvedConfig = {
     dataDir: raw?.dataDir?.trim() || path.join(resolveAgentDir(), 'data'),
   };
+  if (raw?.store) resolved.store = raw.store;
+  if (raw?.lock) resolved.lock = raw.lock;
+  if (raw?.scheduler) resolved.scheduler = raw.scheduler;
+  return resolved;
 }
 
 function loadSettings(cwd: string): PiSchedulerExtensionConfig | undefined {
@@ -44,44 +54,51 @@ function loadSettings(cwd: string): PiSchedulerExtensionConfig | undefined {
   }
 }
 
-export default function taskSchedulerExtension(pi: ExtensionAPI): void {
+export default function taskSchedulerExtension(
+  pi: ExtensionAPI,
+  injectedConfig?: PiSchedulerExtensionConfig,
+): void {
   let scheduler: TaskScheduler | undefined;
+  let ownsScheduler = false;
 
   pi.on('session_start', async (_event, ctx) => {
-    const config = resolveConfig(loadSettings(ctx.cwd));
-    if (!config.enabled) {
-      ctx.ui.setStatus(STATUS_KEY, 'scheduler: disabled');
-      return;
-    }
+    const fileConfig = loadSettings(ctx.cwd);
+    const config = resolveConfig({ ...fileConfig, ...injectedConfig });
 
     try {
-      const storageMod = '@amaster.ai/pi-storage/scheduler';
-      // @ts-ignore - circular dependency: storage imports types from this package
-      const storageScheduler = await import(/* webpackIgnore: true */ storageMod);
-      const store = new storageScheduler.JsonScheduledTaskStore(
-        path.join(config.dataDir, 'tasks.json'),
-      );
-      const lock = new storageScheduler.FileSchedulerLock(
-        path.join(config.dataDir, 'scheduler.lock'),
-      );
+      if (config.scheduler) {
+        scheduler = config.scheduler;
+        ownsScheduler = false;
+      } else {
+        const store = config.store ?? new JsonScheduledTaskStore(
+          path.join(config.dataDir, 'tasks.json'),
+        );
+        const lock = config.lock ?? new FileSchedulerLock(
+          path.join(config.dataDir, 'scheduler.lock'),
+        );
 
-      const runner: ScheduledTaskRunner = async (task) => {
-        pi.sendUserMessage(task.prompt);
-      };
+        const runner: ScheduledTaskRunner = async (task) => {
+          pi.sendUserMessage(task.prompt);
+        };
 
-      const instance = new PersistentTaskScheduler({ store, lock, runner });
-      await instance.start();
-      scheduler = instance;
+        const instance = new PersistentTaskScheduler({ store, lock, runner });
+        await instance.start();
+        scheduler = instance;
+        ownsScheduler = true;
+      }
 
-      ctx.ui.setStatus(STATUS_KEY, instance.isActive() ? 'scheduler: active' : 'scheduler: idle');
+      ctx.ui.setStatus(STATUS_KEY, scheduler.isActive() ? 'scheduler: active' : 'scheduler: idle');
     } catch {
       ctx.ui.setStatus(STATUS_KEY, 'scheduler: unavailable');
     }
   });
 
   pi.on('session_shutdown', async () => {
-    await scheduler?.stop();
+    if (ownsScheduler) {
+      await scheduler?.stop();
+    }
     scheduler = undefined;
+    ownsScheduler = false;
   });
 
   pi.registerCommand('pi-scheduler-status', {

--- a/packages/pi-task-scheduler/src/index.ts
+++ b/packages/pi-task-scheduler/src/index.ts
@@ -889,4 +889,5 @@ function rruleDayToCron(value: string | undefined): string {
     .join(',');
 }
 
+export { JsonScheduledTaskStore, FileSchedulerLock } from './stores.js';
 export { default } from './extension.js';

--- a/packages/pi-task-scheduler/src/index.ts
+++ b/packages/pi-task-scheduler/src/index.ts
@@ -889,5 +889,5 @@ function rruleDayToCron(value: string | undefined): string {
     .join(',');
 }
 
-export { JsonScheduledTaskStore, FileSchedulerLock } from './stores.js';
 export { default } from './extension.js';
+export { FileSchedulerLock, JsonScheduledTaskStore } from './stores.js';

--- a/packages/pi-task-scheduler/src/json-file.ts
+++ b/packages/pi-task-scheduler/src/json-file.ts
@@ -1,0 +1,48 @@
+import { randomUUID } from 'node:crypto';
+import { copyFile, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export async function readJsonFile<T>(filePath: string, fallback: T): Promise<T> {
+  const backupPath = jsonBackupPath(filePath);
+  try {
+    return await readJsonFileStrict<T>(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return fallback;
+    }
+    if (error instanceof SyntaxError) {
+      try {
+        return await readJsonFileStrict<T>(backupPath);
+      } catch {
+        return fallback;
+      }
+    }
+    throw error;
+  }
+}
+
+export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${randomUUID()}.tmp`;
+  const backupPath = jsonBackupPath(filePath);
+  await copyFile(filePath, backupPath).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  });
+  try {
+    await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`);
+    await rename(tempPath, filePath);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+function readJsonFileStrict<T>(filePath: string): Promise<T> {
+  return readFile(filePath, 'utf8').then((content) => JSON.parse(content) as T);
+}
+
+function jsonBackupPath(filePath: string): string {
+  return `${filePath}.bak`;
+}

--- a/packages/pi-task-scheduler/src/stores.test.ts
+++ b/packages/pi-task-scheduler/src/stores.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';

--- a/packages/pi-task-scheduler/src/stores.test.ts
+++ b/packages/pi-task-scheduler/src/stores.test.ts
@@ -1,0 +1,338 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  PersistentTaskScheduler,
+  type ScheduledTask,
+  type ScheduledTaskStore,
+  type SchedulerLock,
+  type TaskSchedulerScope,
+} from './index.js';
+import { FileSchedulerLock, JsonScheduledTaskStore } from './stores.js';
+
+const TEST_DIR = path.join(tmpdir(), 'pi-task-scheduler-test');
+
+function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    id: `task-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    sessionId: 'test-session',
+    prompt: 'test prompt',
+    type: 'interval',
+    schedule: '10m',
+    intervalSeconds: 600,
+    enabled: true,
+    model: { provider: 'test', model: 'test-model' },
+    toolPolicyProfile: 'default',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    runCount: 0,
+    ...overrides,
+  };
+}
+
+describe('JsonScheduledTaskStore', () => {
+  const filePath = path.join(TEST_DIR, 'tasks.json');
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    if (existsSync(filePath)) rmSync(filePath);
+    if (existsSync(`${filePath}.bak`)) rmSync(`${filePath}.bak`);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('creates and lists tasks', async () => {
+    const store = new JsonScheduledTaskStore(filePath);
+    const task = makeTask({ id: 'task-1' });
+
+    const created = await store.create(task);
+    expect(created.id).toBe('task-1');
+
+    const all = await store.list();
+    expect(all).toHaveLength(1);
+    expect(all[0].id).toBe('task-1');
+  });
+
+  it('gets a task by id', async () => {
+    const store = new JsonScheduledTaskStore(filePath);
+    await store.create(makeTask({ id: 'task-get' }));
+
+    const found = await store.get('task-get');
+    expect(found?.id).toBe('task-get');
+
+    const notFound = await store.get('nonexistent');
+    expect(notFound).toBeUndefined();
+  });
+
+  it('updates an existing task', async () => {
+    const store = new JsonScheduledTaskStore(filePath);
+    const task = makeTask({ id: 'task-update', prompt: 'old' });
+    await store.create(task);
+
+    const updated = await store.update('task-update', { ...task, prompt: 'new' });
+    expect(updated?.prompt).toBe('new');
+
+    const missing = await store.update('nonexistent', task);
+    expect(missing).toBeUndefined();
+  });
+
+  it('deletes a task', async () => {
+    const store = new JsonScheduledTaskStore(filePath);
+    await store.create(makeTask({ id: 'task-del' }));
+
+    expect(await store.delete('task-del')).toBe(true);
+    expect(await store.delete('task-del')).toBe(false);
+    expect(await store.list()).toHaveLength(0);
+  });
+
+  it('persists to disk and reloads', async () => {
+    const store1 = new JsonScheduledTaskStore(filePath);
+    await store1.create(makeTask({ id: 'persist-1', prompt: 'hello' }));
+
+    const store2 = new JsonScheduledTaskStore(filePath);
+    const tasks = await store2.list();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].prompt).toBe('hello');
+  });
+
+  it('recovers from corrupted JSON via backup', async () => {
+    const store1 = new JsonScheduledTaskStore(filePath);
+    await store1.create(makeTask({ id: 'backup-test' }));
+    // second write creates a backup of the first state
+    await store1.create(makeTask({ id: 'backup-test-2' }));
+
+    writeFileSync(filePath, 'corrupted{{{');
+
+    const store2 = new JsonScheduledTaskStore(filePath);
+    const tasks = await store2.list();
+    // backup contains state after first create (before second write)
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe('backup-test');
+  });
+
+  it('returns empty list when file does not exist', async () => {
+    const store = new JsonScheduledTaskStore(path.join(TEST_DIR, 'nonexistent.json'));
+    const tasks = await store.list();
+    expect(tasks).toHaveLength(0);
+  });
+});
+
+describe('FileSchedulerLock', () => {
+  const lockPath = path.join(TEST_DIR, 'scheduler.lock');
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    if (existsSync(lockPath)) rmSync(lockPath);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('acquires and releases a lock', () => {
+    const lock = new FileSchedulerLock(lockPath);
+
+    expect(lock.acquire()).toBe(true);
+    expect(lock.isAcquired()).toBe(true);
+    expect(lock.holderPid()).toBe(process.pid);
+
+    lock.release();
+    expect(lock.isAcquired()).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('allows re-acquire by same process', () => {
+    const lock = new FileSchedulerLock(lockPath);
+
+    expect(lock.acquire()).toBe(true);
+    expect(lock.acquire()).toBe(true);
+    lock.release();
+  });
+
+  it('blocks acquire when held by another process', () => {
+    // Use parent PID — guaranteed alive and not our own PID
+    writeFileSync(lockPath, String(process.ppid));
+
+    const lock = new FileSchedulerLock(lockPath);
+    expect(lock.acquire()).toBe(false);
+    expect(lock.isAcquired()).toBe(false);
+  });
+
+  it('cleans up stale lock from dead process', () => {
+    writeFileSync(lockPath, '999999999');
+
+    const lock = new FileSchedulerLock(lockPath);
+    expect(lock.acquire()).toBe(true);
+    expect(lock.isAcquired()).toBe(true);
+    lock.release();
+  });
+
+  it('creates parent directories if needed', () => {
+    const nested = path.join(TEST_DIR, 'nested', 'dir', 'scheduler.lock');
+    const lock = new FileSchedulerLock(nested);
+
+    expect(lock.acquire()).toBe(true);
+    expect(existsSync(nested)).toBe(true);
+    lock.release();
+  });
+});
+
+describe('custom storage injection', () => {
+  it('scheduler works with a custom ScheduledTaskStore implementation', async () => {
+    const events: string[] = [];
+    const customStore = new InMemoryStore();
+    const customLock = new InMemoryLock();
+
+    const scheduler = new PersistentTaskScheduler({
+      store: customStore,
+      lock: customLock,
+      runner: async (task) => {
+        events.push(`run:${task.prompt}`);
+      },
+    });
+
+    await scheduler.start();
+
+    const task = await scheduler.create({
+      sessionId: 'custom-session',
+      prompt: 'custom store test',
+      type: 'interval',
+      schedule: '1h',
+      intervalSeconds: 3600,
+      enabled: true,
+      model: { provider: 'test', model: 'test-model' },
+      toolPolicyProfile: 'default',
+    });
+
+    expect(customStore.tasks.size).toBe(1);
+    expect(customStore.tasks.get(task.id)?.prompt).toBe('custom store test');
+
+    await scheduler.runNow(task.id);
+    await waitFor(() => events.length > 0);
+
+    expect(events).toEqual(['run:custom store test']);
+
+    const updated = await scheduler.update(task.id, { prompt: 'updated prompt' });
+    expect(updated?.prompt).toBe('updated prompt');
+    expect(customStore.tasks.get(task.id)?.prompt).toBe('updated prompt');
+
+    await scheduler.delete(task.id);
+    expect(customStore.tasks.size).toBe(0);
+
+    await scheduler.stop();
+    expect(customLock.isAcquired()).toBe(false);
+  });
+
+  it('scheduler respects custom lock blocking', async () => {
+    const customLock = new InMemoryLock();
+    customLock.acquire();
+
+    const scheduler = new PersistentTaskScheduler({
+      store: new InMemoryStore(),
+      lock: customLock,
+      runner: async () => {},
+    });
+
+    await scheduler.start();
+    expect(scheduler.isActive()).toBe(false);
+  });
+
+  it('scheduler uses custom store for list/get operations', async () => {
+    const customStore = new InMemoryStore();
+    const now = new Date().toISOString();
+    customStore.tasks.set('pre-existing', {
+      id: 'pre-existing',
+      sessionId: 'session-1',
+      prompt: 'seeded task',
+      type: 'cron',
+      schedule: '0 9 * * *',
+      intervalSeconds: 0,
+      enabled: true,
+      model: { provider: 'openai', model: 'gpt-4' },
+      toolPolicyProfile: 'default',
+      createdAt: now,
+      updatedAt: now,
+      runCount: 3,
+    });
+
+    const scheduler = new PersistentTaskScheduler({
+      store: customStore,
+      lock: new InMemoryLock(),
+      runner: async () => {},
+    });
+
+    await scheduler.start();
+
+    const tasks = await scheduler.list();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe('pre-existing');
+
+    const task = await scheduler.get('pre-existing');
+    expect(task?.prompt).toBe('seeded task');
+    expect(task?.runCount).toBe(3);
+
+    await scheduler.stop();
+  });
+});
+
+class InMemoryStore implements ScheduledTaskStore {
+  readonly tasks = new Map<string, ScheduledTask>();
+
+  async list(_scope: TaskSchedulerScope = {}): Promise<ScheduledTask[]> {
+    return [...this.tasks.values()];
+  }
+
+  async get(taskId: string): Promise<ScheduledTask | undefined> {
+    return this.tasks.get(taskId);
+  }
+
+  async create(task: ScheduledTask): Promise<ScheduledTask> {
+    this.tasks.set(task.id, task);
+    return task;
+  }
+
+  async update(taskId: string, task: ScheduledTask): Promise<ScheduledTask | undefined> {
+    if (!this.tasks.has(taskId)) return undefined;
+    this.tasks.set(taskId, task);
+    return task;
+  }
+
+  async delete(taskId: string): Promise<boolean> {
+    return this.tasks.delete(taskId);
+  }
+}
+
+class InMemoryLock implements SchedulerLock {
+  readonly path = 'memory:test-lock';
+  private locked = false;
+
+  acquire(): boolean {
+    if (this.locked) return false;
+    this.locked = true;
+    return true;
+  }
+
+  release(): void {
+    this.locked = false;
+  }
+
+  isAcquired(): boolean {
+    return this.locked;
+  }
+
+  holderPid(): number | undefined {
+    return this.locked ? process.pid : undefined;
+  }
+}
+
+async function waitFor(assertion: () => boolean | Promise<boolean>): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < 1000) {
+    if (await assertion()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out waiting for assertion');
+}

--- a/packages/pi-task-scheduler/src/stores.test.ts
+++ b/packages/pi-task-scheduler/src/stores.test.ts
@@ -282,7 +282,7 @@ class InMemoryStore implements ScheduledTaskStore {
   readonly tasks = new Map<string, ScheduledTask>();
 
   async list(_scope: TaskSchedulerScope = {}): Promise<ScheduledTask[]> {
-    return [...this.tasks.values()];
+    return Array.from(this.tasks.values());
   }
 
   async get(taskId: string): Promise<ScheduledTask | undefined> {

--- a/packages/pi-task-scheduler/src/stores.ts
+++ b/packages/pi-task-scheduler/src/stores.ts
@@ -1,0 +1,148 @@
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { readJsonFile, writeJsonFile } from './json-file.js';
+import {
+  normalizeScheduledTask,
+  type ScheduledTask,
+  type ScheduledTaskStore,
+  type SchedulerLock,
+  type TaskSchedulerScope,
+} from './index.js';
+
+export class JsonScheduledTaskStore implements ScheduledTaskStore {
+  private loaded = false;
+  private readonly tasks = new Map<string, ScheduledTask>();
+
+  constructor(private readonly filePath: string) {}
+
+  async list(_scope: TaskSchedulerScope = {}): Promise<ScheduledTask[]> {
+    await this.load();
+    return Array.from(this.tasks.values());
+  }
+
+  async get(taskId: string, _scope: TaskSchedulerScope = {}): Promise<ScheduledTask | undefined> {
+    await this.load();
+    return this.tasks.get(taskId);
+  }
+
+  async create(task: ScheduledTask): Promise<ScheduledTask> {
+    await this.load();
+    const normalized = normalizeScheduledTask(task);
+    this.tasks.set(normalized.id, normalized);
+    await this.save();
+    return normalized;
+  }
+
+  async update(
+    taskId: string,
+    task: ScheduledTask,
+    _scope: TaskSchedulerScope = {},
+  ): Promise<ScheduledTask | undefined> {
+    await this.load();
+    if (!this.tasks.has(taskId)) {
+      return undefined;
+    }
+    const normalized = normalizeScheduledTask(task);
+    this.tasks.set(taskId, normalized);
+    await this.save();
+    return normalized;
+  }
+
+  async delete(taskId: string, _scope: TaskSchedulerScope = {}): Promise<boolean> {
+    await this.load();
+    if (!this.tasks.has(taskId)) {
+      return false;
+    }
+    const deleted = this.tasks.delete(taskId);
+    await this.save();
+    return deleted;
+  }
+
+  private async load(): Promise<void> {
+    if (this.loaded) {
+      return;
+    }
+    const tasks = await readJsonFile<ScheduledTask[]>(this.filePath, []);
+    this.tasks.clear();
+    for (const rawTask of tasks) {
+      const task = normalizeScheduledTask(rawTask);
+      this.tasks.set(task.id, task);
+    }
+    this.loaded = true;
+  }
+
+  private async save(): Promise<void> {
+    await writeJsonFile(this.filePath, Array.from(this.tasks.values()));
+  }
+}
+
+export class FileSchedulerLock implements SchedulerLock {
+  private acquired = false;
+
+  constructor(readonly path: string) {}
+
+  acquire(): boolean {
+    mkdirSync(path.dirname(this.path), { recursive: true });
+    const holder = this.holderPid();
+    if (holder && holder !== process.pid) {
+      return false;
+    }
+    try {
+      unlinkSync(this.path);
+    } catch {
+      // Lock did not exist or was already removed between checks.
+    }
+    try {
+      writeFileSync(this.path, String(process.pid), { flag: 'wx' });
+      this.acquired = true;
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        this.acquired = false;
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  release(): void {
+    if (!this.acquired) {
+      return;
+    }
+    try {
+      const pid = Number(readFileSync(this.path, 'utf8').trim());
+      if (pid === process.pid) {
+        unlinkSync(this.path);
+      }
+    } catch {
+      // Lock was already gone; the scheduler is stopping anyway.
+    }
+    this.acquired = false;
+  }
+
+  isAcquired(): boolean {
+    return this.acquired;
+  }
+
+  holderPid(): number | undefined {
+    try {
+      const pid = Number(readFileSync(this.path, 'utf8').trim());
+      if (Number.isInteger(pid) && pid > 0 && isProcessAlive(pid)) {
+        return pid;
+      }
+      unlinkSync(this.path);
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/pi-task-scheduler/src/stores.ts
+++ b/packages/pi-task-scheduler/src/stores.ts
@@ -1,6 +1,5 @@
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { readJsonFile, writeJsonFile } from './json-file.js';
 import {
   normalizeScheduledTask,
   type ScheduledTask,
@@ -8,6 +7,7 @@ import {
   type SchedulerLock,
   type TaskSchedulerScope,
 } from './index.js';
+import { readJsonFile, writeJsonFile } from './json-file.js';
 
 export class JsonScheduledTaskStore implements ScheduledTaskStore {
   private loaded = false;

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-teamwork",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "description": "Pi extension for team collaboration and issue management via Multica",
   "keywords": ["pi-package", "pi", "extension", "teamwork", "issues", "project-management", "multica"],
   "license": "Apache-2.0",

--- a/packages/pi-teamwork/src/index.test.ts
+++ b/packages/pi-teamwork/src/index.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { initMulticaProvider, MulticaAdapter } from './adapters/multica.js';
 import type { ExecFn } from './types.js';
 
-function mockExec(
+function _mockExec(
   responses: Record<string, { stdout: string; stderr: string; code: number }>,
 ): ExecFn {
   return async (_cmd, args) => {

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "description": "Pi extension for runtime telemetry with Langfuse and OpenTelemetry exporters",
   "keywords": ["pi-package", "pi", "extension", "telemetry", "observability", "langfuse", "opentelemetry", "tracing"],
   "license": "Apache-2.0",

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -393,7 +393,7 @@ describe('telemetry', () => {
     expect(client.closed).toBe(1);
     expect(client.traces[0]?.body).toMatchObject({
       sessionId: 'session-1',
-      name: 'copilot-chat-turn',
+      name: 'chat-turn',
       input: 'hello',
     });
     const traceUpdates = client.traces[0]?.updates ?? [];
@@ -404,7 +404,7 @@ describe('telemetry', () => {
     const rootSpan = client.traces[0]?.spans[0];
     const toolSpan = rootSpan?.spans[0];
     expect(rootSpan?.body).toMatchObject({
-      name: 'copilot-chat-turn',
+      name: 'chat-turn',
       input: 'hello',
       level: 'DEFAULT',
     });
@@ -618,7 +618,7 @@ describe('telemetry', () => {
     const batchSpan = rootSpan?.spans.find((span) => span.body.name === 'subagent fan-out');
     const subagentSpan = batchSpan?.spans[0];
     expect(trace?.body).toMatchObject({ sessionId: 'parent' });
-    expect(rootSpan?.body).toMatchObject({ name: 'copilot-chat-turn' });
+    expect(rootSpan?.body).toMatchObject({ name: 'chat-turn' });
     expect(spawnToolSpan?.body).toMatchObject({ name: 'sessions_spawn [child task]' });
     expect(batchSpan?.body).toMatchObject({
       name: 'subagent fan-out',
@@ -747,7 +747,7 @@ describe('telemetry', () => {
     });
 
     const rootSpan = client.traces[0]?.spans[0];
-    expect(rootSpan?.body).toMatchObject({ name: 'copilot-chat-turn' });
+    expect(rootSpan?.body).toMatchObject({ name: 'chat-turn' });
     expect(rootSpan?.generations).toHaveLength(2);
     expect(rootSpan?.generations[0]?.body).toMatchObject({ name: 'llm-generation [main] [hello]' });
     expect(rootSpan?.generations[1]?.body).toMatchObject({

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -140,7 +140,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
       case 'chat_turn_started': {
         const body = {
           id: rootSpanId,
-          name: 'copilot-chat-turn',
+          name: 'chat-turn',
           startTime: event.createdAt,
           input: event.details?.input,
           level: 'DEFAULT',
@@ -164,7 +164,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
         this.closeSdkSubagentBatchSpans(traceId, event);
         trace.update({
           sessionId: event.sessionId,
-          name: 'copilot-chat-turn',
+          name: 'chat-turn',
           output,
           metadata: lifecycleMetadata(event),
         });
@@ -172,7 +172,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
           this.spans.get(rootKey) ??
           trace.span({
             id: rootSpanId,
-            name: 'copilot-chat-turn',
+            name: 'chat-turn',
             startTime: event.createdAt,
             metadata: lifecycleMetadata(event),
           });
@@ -372,7 +372,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
     const trace = this.client.trace({
       id: langfuseTraceId(traceId),
       sessionId: event.sessionId,
-      name: 'copilot-chat-turn',
+      name: 'chat-turn',
       timestamp: event.createdAt,
       input: !isToolEvent(event) && !isLlmGenerationEvent(event) ? event.details?.input : undefined,
       metadata: isToolEvent(event)
@@ -458,7 +458,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
     const traceId = requireTraceId(event.traceId);
     const span = trace.span({
       id: langfuseSpanId(traceId, rootKey),
-      name: 'copilot-chat-turn',
+      name: 'chat-turn',
       startTime: event.createdAt,
       metadata: isToolEvent(event)
         ? toolMetadata(event)
@@ -660,7 +660,7 @@ function mapLifecycleEventToOtelSpans(
       pendingStarts.set(rootKey, {
         traceId: langfuseTraceId(traceId),
         spanId: rootSpanId,
-        name: 'copilot-chat-turn',
+        name: 'chat-turn',
         startTime: event.createdAt,
         attributes: {
           ...lifecycleMetadata(event),
@@ -678,7 +678,7 @@ function mapLifecycleEventToOtelSpans(
           {
             traceId: langfuseTraceId(traceId),
             spanId: rootSpanId,
-            name: 'copilot-chat-turn',
+            name: 'chat-turn',
             startTime: event.createdAt,
             attributes: {
               ...lifecycleMetadata(event),

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import type {
   JsonObject,
   JsonValue,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.4",
+  "version": "0.1.2-beta.5",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1
     devDependencies:
-      '@amaster.ai/pi-storage':
-        specifier: workspace:*
-        version: link:../storage
       '@earendil-works/pi-coding-agent':
         specifier: 0.74.0
         version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)


### PR DESCRIPTION
## Summary

- **pi-computer-use**: Replace Python cua-server with cua-driver-rs binary via MCP stdio, add permission detection with friendly error guidance, improve screenshot error messages, handle EACCES on binary
- **pi-task-scheduler**: New extension with LLM-callable tools, self-contained file storage (removes pi-storage dependency), support injected scheduler for pi-agent server
- **pi-teamwork**: New teamwork extension with multica adapter
- **pi-telemetry**: Enhanced telemetry with turn-level tracing, new event hooks, remove Langfuse ingestion transport (keep SDK only)
- **pi-browser-use**: Add sessionMode support (persistent/isolated/existing), rewrite vision to use model registry
- **pi-security**: Switch auto-review profile to denylist mode
- **Cleanup**: Remove subagents and turns packages, bump to 0.1.2-beta.4, add pi-package keywords for catalog indexing
- **Shared**: Use `resolveAgentDir` from shared instead of `getAgentDir`

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes across all packages
- [ ] pi-task-scheduler: verify file-based storage works without pi-storage
- [ ] pi-computer-use: verify binary auto-chmod and permission detection on macOS
- [ ] pi-teamwork: verify multica adapter integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)