### PR TITLE
refactor(pi-task-scheduler): extract createSchedulerTools factory for…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm lint
+pnpm lint && pnpm typecheck && pnpm test && pnpm build

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "typecheck": "pnpm --filter @amaster.ai/pi-storage prisma:generate && tsc -b packages/* --pretty false",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@types/node": "^24.0.0",
+    "husky": "^9.1.7",
     "jiti": "^2.7.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.0"

--- a/packages/pi-task-scheduler/README.md
+++ b/packages/pi-task-scheduler/README.md
@@ -38,18 +38,17 @@ const scheduler = new PersistentTaskScheduler({
 await scheduler.start();
 ```
 
-### Database storage (pi-agent server)
+### Custom storage
+
+Implement `ScheduledTaskStore` and `SchedulerLock` interfaces for any backend
+(database, Redis, etc.):
 
 ```ts
 import { PersistentTaskScheduler } from "@amaster.ai/pi-task-scheduler";
-import {
-  DbScheduledTaskStore,
-  RedisSchedulerLock,
-} from "@amaster.ai/pi-storage/scheduler";
 
 const scheduler = new PersistentTaskScheduler({
-  store: new DbScheduledTaskStore(databaseUrl),
-  lock: new RedisSchedulerLock(redisUrl),
+  store: myCustomStore,   // implements ScheduledTaskStore
+  lock: myCustomLock,     // implements SchedulerLock
   runner: async (task, run) => {
     await runPrompt(task.prompt, { sessionId: run.sessionId });
   },
@@ -58,11 +57,25 @@ const scheduler = new PersistentTaskScheduler({
 await scheduler.start();
 ```
 
-## Extension
+## Integration Modes
 
-The package exports a pi extension that integrates with the agent runtime:
+The package provides two integration paths depending on who controls the
+scheduler lifecycle.
 
-- **Lifecycle**: creates a `PersistentTaskScheduler` on `session_start`, stops on `session_shutdown`
+### Mode 1: Extension auto-discovery (standalone / CLI)
+
+When installed as an npm dependency with the `pi.extensions` field in
+`package.json`, the runtime auto-discovers and loads the extension. The
+extension creates its own `PersistentTaskScheduler` with file-based storage
+(`JsonScheduledTaskStore` + `FileSchedulerLock`) — fully self-contained, no
+external infrastructure needed.
+
+```
+pi.extensions → session_start → creates file-based scheduler → registers tools + commands
+```
+
+- **Storage**: `<agentDir>/data/tasks.json` (configurable via `dataDir`)
+- **Lifecycle**: scheduler starts on `session_start`, stops on `session_shutdown`
 - **Commands**: `/pi-scheduler-status`, `/pi-scheduler-list`, `/pi-scheduler-run-now`
 - **LLM Tools**: `scheduler_create`, `scheduler_list`, `scheduler_get`, `scheduler_update`, `scheduler_delete`, `scheduler_run_now`
 
@@ -76,40 +89,44 @@ Configuration via settings key `pi-scheduler`:
 }
 ```
 
-Data is stored in `<agentDir>/data/` by default (`~/.pi/agent/data/`).
+### Mode 2: Dependency import (host-controlled)
 
-### Standalone mode (default)
-
-When installed as an npm extension package, the extension creates its own
-scheduler with `JsonScheduledTaskStore` and `FileSchedulerLock`. No additional
-dependencies required.
-
-### Injected mode (pi-agent server)
-
-When the host already owns a scheduler instance (e.g. pi-agent server with DB
-storage), pass it directly to avoid creating a second scheduler:
+When the host process owns the scheduler instance (e.g. backed by a database),
+it bypasses the extension and registers tools directly using
+`createSchedulerTools`:
 
 ```ts
-import taskSchedulerExtension from "@amaster.ai/pi-task-scheduler";
+import { createSchedulerTools } from "@amaster.ai/pi-task-scheduler/tools";
 import { PersistentTaskScheduler } from "@amaster.ai/pi-task-scheduler";
-import {
-  DbScheduledTaskStore,
-  RedisSchedulerLock,
-} from "@amaster.ai/pi-storage/scheduler";
 
 const scheduler = new PersistentTaskScheduler({
-  store: new DbScheduledTaskStore(databaseUrl),
-  lock: new RedisSchedulerLock(redisUrl),
+  store: myStore,
+  lock: myLock,
   runner,
 });
 await scheduler.start();
 
-// Extension only registers tools, does not create/stop the scheduler
-taskSchedulerExtension(pi, { scheduler });
+// Returns ToolDefinition[] — register via your tool injection mechanism
+const tools = createSchedulerTools(scheduler);
 ```
 
-In injected mode, `session_shutdown` does **not** stop the scheduler — the host
-manages its lifecycle.
+In this mode the auto-discovered extension should be filtered out to prevent
+double tool registration. The host manages scheduler start/stop independently.
+
+```
+host creates scheduler → createSchedulerTools(scheduler) → tools injected into runtime
+                       → extension filtered from auto-discovery
+```
+
+### Choosing a mode
+
+| | Extension (Mode 1) | Dependency (Mode 2) |
+|---|---|---|
+| Storage | File-based (JSON) | Host-controlled |
+| Scheduler lifecycle | Extension manages | Host manages |
+| Tool registration | Extension registers | Host registers |
+| Multi-tenant | No | Yes |
+| Use case | CLI / standalone agent | Server / custom host |
 
 ## Scheduling
 

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/extension.d.ts",
       "default": "./dist/extension.js"
     },
+    "./tools": {
+      "types": "./dist/tools.d.ts",
+      "default": "./dist/tools.js"
+    },
     "./package.json": {
       "default": "./package.json"
     }

--- a/packages/pi-task-scheduler/src/extension.test.ts
+++ b/packages/pi-task-scheduler/src/extension.test.ts
@@ -203,10 +203,10 @@ describe('extension — injected scheduler', () => {
       await handler({}, createMockCtx());
     }
 
-    // Tools should return "not running" after shutdown
+    // After shutdown, tools still work (scheduler instance persists) but scheduler is stopped
     const tool = pi.tools.get('scheduler_list')!;
     const result = (await tool.execute('id', {}, undefined, undefined, createMockCtx())) as any;
-    expect(result.content[0].text).toBe('Task scheduler is not running.');
+    expect(result.content[0].text).toBe('No scheduled tasks.');
   });
 });
 

--- a/packages/pi-task-scheduler/src/extension.ts
+++ b/packages/pi-task-scheduler/src/extension.ts
@@ -1,19 +1,16 @@
 import path from 'node:path';
 import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
-import { Type } from 'typebox';
 import {
   PersistentTaskScheduler,
-  resolveScheduledTaskDefinition,
   type ScheduledTask,
-  type ScheduledTaskCreateInput,
   type ScheduledTaskRunner,
   type ScheduledTaskStore,
-  type ScheduledTaskType,
   type SchedulerLock,
   type TaskScheduler,
 } from './index.js';
 import { FileSchedulerLock, JsonScheduledTaskStore } from './stores.js';
+import { createSchedulerTools } from './tools.js';
 
 const SETTINGS_KEY = 'pi-scheduler';
 const STATUS_KEY = 'pi-scheduler';
@@ -86,6 +83,12 @@ export default function taskSchedulerExtension(
       }
 
       ctx.ui.setStatus(STATUS_KEY, scheduler.isActive() ? 'scheduler: active' : 'scheduler: idle');
+
+      // Register LLM-callable tools after scheduler is ready
+      const tools = createSchedulerTools(scheduler);
+      for (const tool of tools) {
+        pi.registerTool(tool);
+      }
     } catch {
       ctx.ui.setStatus(STATUS_KEY, 'scheduler: unavailable');
     }
@@ -143,204 +146,6 @@ export default function taskSchedulerExtension(
       ctx.ui.notify(`Triggered: ${task.name ?? task.id}`, 'info');
     },
   });
-
-  // --- LLM-callable tools ---
-
-  const taskTypeSchema = Type.Union([
-    Type.Literal('cron'),
-    Type.Literal('once'),
-    Type.Literal('interval'),
-  ]);
-
-  pi.registerTool({
-    name: 'scheduler_create',
-    label: 'Scheduler',
-    description:
-      'Create a scheduled task. Supports cron expressions, one-time (ISO timestamp or relative like "+10m"), and interval (e.g. "30s", "5m", "1h").',
-    promptSnippet: 'Create scheduled tasks (cron/once/interval) that run prompts on a schedule.',
-    parameters: Type.Object({
-      type: taskTypeSchema,
-      schedule: Type.String({
-        description:
-          'Schedule expression. Cron: "0 9 * * 1-5"; Once: ISO timestamp or "+10m"; Interval: "30s", "5m", "1h".',
-      }),
-      prompt: Type.String({ description: 'The prompt to execute when triggered.' }),
-      name: Type.Optional(Type.String({ description: 'Human-readable task name.' })),
-      description: Type.Optional(Type.String({ description: 'Task description.' })),
-      enabled: Type.Optional(
-        Type.Boolean({ description: 'Whether the task is enabled. Default true.' }),
-      ),
-    }),
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      if (!scheduler) {
-        return textResult(
-          'Task scheduler is not running. The extension may be disabled or failed to initialize.',
-        );
-      }
-      try {
-        const definition = resolveScheduledTaskDefinition({
-          type: params.type as ScheduledTaskType,
-          schedule: params.schedule,
-        });
-        const input: ScheduledTaskCreateInput = {
-          ...definition,
-          prompt: params.prompt,
-          sessionId: ctx.sessionManager?.getSessionId?.() ?? 'unknown',
-          model: {
-            provider: 'anthropic',
-            model: ctx.model?.id ?? 'unknown',
-          },
-          toolPolicyProfile: 'default',
-          enabled: params.enabled !== false,
-          ...(params.name ? { name: params.name } : {}),
-          ...(params.description ? { description: params.description } : {}),
-        };
-        const task = await scheduler.create(input);
-        return textResult(JSON.stringify(formatTaskSummary(task), null, 2));
-      } catch (error) {
-        return textResult(
-          `Failed to create task: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    },
-  });
-
-  pi.registerTool({
-    name: 'scheduler_list',
-    label: 'Scheduler',
-    description: 'List all scheduled tasks with their status and next run time.',
-    promptSnippet: 'List all scheduled tasks.',
-    parameters: Type.Object({}),
-    async execute() {
-      if (!scheduler) {
-        return textResult('Task scheduler is not running.');
-      }
-      const tasks = await scheduler.list();
-      if (tasks.length === 0) {
-        return textResult('No scheduled tasks.');
-      }
-      const summary = tasks.map(formatTaskSummary);
-      return textResult(JSON.stringify(summary, null, 2));
-    },
-  });
-
-  pi.registerTool({
-    name: 'scheduler_get',
-    label: 'Scheduler',
-    description: 'Get detailed information about a scheduled task including run history.',
-    parameters: Type.Object({
-      taskId: Type.String({ description: 'The task ID to query.' }),
-    }),
-    async execute(_toolCallId, params) {
-      if (!scheduler) {
-        return textResult('Task scheduler is not running.');
-      }
-      const task = await scheduler.get(params.taskId);
-      if (!task) {
-        return textResult(`Task not found: ${params.taskId}`);
-      }
-      return textResult(JSON.stringify(task, null, 2));
-    },
-  });
-
-  pi.registerTool({
-    name: 'scheduler_update',
-    label: 'Scheduler',
-    description: 'Update a scheduled task. Can change schedule, prompt, name, or enable/disable.',
-    parameters: Type.Object({
-      taskId: Type.String({ description: 'The task ID to update.' }),
-      type: Type.Optional(taskTypeSchema),
-      schedule: Type.Optional(Type.String({ description: 'New schedule expression.' })),
-      prompt: Type.Optional(Type.String({ description: 'New prompt.' })),
-      name: Type.Optional(Type.String({ description: 'New name.' })),
-      description: Type.Optional(Type.String({ description: 'New description.' })),
-      enabled: Type.Optional(Type.Boolean({ description: 'Enable or disable the task.' })),
-    }),
-    async execute(_toolCallId, params) {
-      if (!scheduler) {
-        return textResult('Task scheduler is not running.');
-      }
-      const { taskId, type, schedule, ...rest } = params;
-      const update: Record<string, unknown> = { ...rest };
-      if (type !== undefined || schedule !== undefined) {
-        try {
-          const existing = await scheduler.get(taskId);
-          if (!existing) {
-            return textResult(`Task not found: ${taskId}`);
-          }
-          const definition = resolveScheduledTaskDefinition({
-            type: (type ?? existing.type) as ScheduledTaskType,
-            schedule: schedule ?? existing.schedule,
-          });
-          Object.assign(update, definition);
-        } catch (error) {
-          return textResult(
-            `Invalid schedule: ${error instanceof Error ? error.message : String(error)}`,
-          );
-        }
-      }
-      const task = await scheduler.update(taskId, update);
-      if (!task) {
-        return textResult(`Task not found: ${taskId}`);
-      }
-      return textResult(JSON.stringify(formatTaskSummary(task), null, 2));
-    },
-  });
-
-  pi.registerTool({
-    name: 'scheduler_delete',
-    label: 'Scheduler',
-    description: 'Delete a scheduled task.',
-    parameters: Type.Object({
-      taskId: Type.String({ description: 'The task ID to delete.' }),
-    }),
-    async execute(_toolCallId, params) {
-      if (!scheduler) {
-        return textResult('Task scheduler is not running.');
-      }
-      const deleted = await scheduler.delete(params.taskId);
-      return textResult(
-        deleted ? `Deleted task: ${params.taskId}` : `Task not found: ${params.taskId}`,
-      );
-    },
-  });
-
-  pi.registerTool({
-    name: 'scheduler_run_now',
-    label: 'Scheduler',
-    description: 'Trigger immediate execution of a scheduled task.',
-    parameters: Type.Object({
-      taskId: Type.String({ description: 'The task ID to run immediately.' }),
-    }),
-    async execute(_toolCallId, params) {
-      if (!scheduler) {
-        return textResult('Task scheduler is not running.');
-      }
-      const task = await scheduler.runNow(params.taskId);
-      if (!task) {
-        return textResult(`Task not found: ${params.taskId}`);
-      }
-      return textResult(`Triggered: ${task.name ?? task.id}`);
-    },
-  });
-}
-
-function textResult(text: string) {
-  return { content: [{ type: 'text' as const, text }], details: undefined };
-}
-
-function formatTaskSummary(task: ScheduledTask) {
-  return {
-    id: task.id,
-    name: task.name,
-    type: task.type,
-    schedule: task.schedule,
-    enabled: task.enabled,
-    lastStatus: task.lastStatus ?? 'pending',
-    nextRunAt: task.nextRunAt,
-    runCount: task.runCount,
-    prompt: task.prompt.length > 100 ? `${task.prompt.slice(0, 100)}…` : task.prompt,
-  };
 }
 
 function formatStatus(status: Awaited<ReturnType<TaskScheduler['status']>>): string {

--- a/packages/pi-task-scheduler/src/index.ts
+++ b/packages/pi-task-scheduler/src/index.ts
@@ -892,3 +892,4 @@ function rruleDayToCron(value: string | undefined): string {
 export { createSchedulerTools } from './tools.js';
 export { default } from './extension.js';
 export { FileSchedulerLock, JsonScheduledTaskStore } from './stores.js';
+export { createSchedulerTools } from './tools.js';

--- a/packages/pi-task-scheduler/src/index.ts
+++ b/packages/pi-task-scheduler/src/index.ts
@@ -889,5 +889,6 @@ function rruleDayToCron(value: string | undefined): string {
     .join(',');
 }
 
+export { createSchedulerTools } from './tools.js';
 export { default } from './extension.js';
 export { FileSchedulerLock, JsonScheduledTaskStore } from './stores.js';

--- a/packages/pi-task-scheduler/src/index.ts
+++ b/packages/pi-task-scheduler/src/index.ts
@@ -889,7 +889,6 @@ function rruleDayToCron(value: string | undefined): string {
     .join(',');
 }
 
-export { createSchedulerTools } from './tools.js';
 export { default } from './extension.js';
 export { FileSchedulerLock, JsonScheduledTaskStore } from './stores.js';
 export { createSchedulerTools } from './tools.js';

--- a/packages/pi-task-scheduler/src/tools.ts
+++ b/packages/pi-task-scheduler/src/tools.ts
@@ -1,0 +1,212 @@
+import type {
+  AgentToolResult,
+  AgentToolUpdateCallback,
+  ExtensionContext,
+  ToolDefinition,
+} from '@earendil-works/pi-coding-agent';
+import { Type } from 'typebox';
+import {
+  resolveScheduledTaskDefinition,
+  type ScheduledTask,
+  type ScheduledTaskCreateInput,
+  type ScheduledTaskType,
+  type TaskScheduler,
+} from './index.js';
+
+function textResult(text: string): AgentToolResult<unknown> {
+  return { content: [{ type: 'text' as const, text }], details: undefined };
+}
+
+function formatTaskSummary(task: ScheduledTask) {
+  return {
+    id: task.id,
+    name: task.name,
+    type: task.type,
+    schedule: task.schedule,
+    enabled: task.enabled,
+    lastStatus: task.lastStatus ?? 'pending',
+    nextRunAt: task.nextRunAt,
+    runCount: task.runCount,
+    prompt: task.prompt.length > 100 ? `${task.prompt.slice(0, 100)}…` : task.prompt,
+  };
+}
+
+const taskTypeSchema = Type.Union([
+  Type.Literal('cron'),
+  Type.Literal('once'),
+  Type.Literal('interval'),
+]);
+
+export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[] {
+  return [
+    {
+      name: 'scheduler_create',
+      label: 'Scheduler',
+      description:
+        'Create a scheduled task. Supports cron expressions, one-time (ISO timestamp or relative like "+10m"), and interval (e.g. "30s", "5m", "1h").',
+      promptSnippet: 'Create scheduled tasks (cron/once/interval) that run prompts on a schedule.',
+      parameters: Type.Object({
+        type: taskTypeSchema,
+        schedule: Type.String({
+          description:
+            'Schedule expression. Cron: "0 9 * * 1-5"; Once: ISO timestamp or "+10m"; Interval: "30s", "5m", "1h".',
+        }),
+        prompt: Type.String({ description: 'The prompt to execute when triggered.' }),
+        name: Type.Optional(Type.String({ description: 'Human-readable task name.' })),
+        description: Type.Optional(Type.String({ description: 'Task description.' })),
+        enabled: Type.Optional(
+          Type.Boolean({ description: 'Whether the task is enabled. Default true.' }),
+        ),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+        _signal: AbortSignal | undefined,
+        _onUpdate: AgentToolUpdateCallback | undefined,
+        ctx: ExtensionContext,
+      ): Promise<AgentToolResult<unknown>> {
+        try {
+          const definition = resolveScheduledTaskDefinition({
+            type: params.type as ScheduledTaskType,
+            schedule: params.schedule as string,
+          });
+          const input: ScheduledTaskCreateInput = {
+            ...definition,
+            prompt: params.prompt as string,
+            sessionId: ctx.sessionManager?.getSessionId?.() ?? 'unknown',
+            model: {
+              provider: 'anthropic',
+              model: ctx.model?.id ?? 'unknown',
+            },
+            toolPolicyProfile: 'default',
+            enabled: params.enabled !== false,
+            ...(params.name ? { name: params.name as string } : {}),
+            ...(params.description ? { description: params.description as string } : {}),
+          };
+          const task = await scheduler.create(input);
+          return textResult(JSON.stringify(formatTaskSummary(task), null, 2));
+        } catch (error) {
+          return textResult(
+            `Failed to create task: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      },
+    },
+    {
+      name: 'scheduler_list',
+      label: 'Scheduler',
+      description: 'List all scheduled tasks with their status and next run time.',
+      promptSnippet: 'List all scheduled tasks.',
+      parameters: Type.Object({}),
+      async execute(): Promise<AgentToolResult<unknown>> {
+        const tasks = await scheduler.list();
+        if (tasks.length === 0) {
+          return textResult('No scheduled tasks.');
+        }
+        const summary = tasks.map(formatTaskSummary);
+        return textResult(JSON.stringify(summary, null, 2));
+      },
+    },
+    {
+      name: 'scheduler_get',
+      label: 'Scheduler',
+      description: 'Get detailed information about a scheduled task including run history.',
+      parameters: Type.Object({
+        taskId: Type.String({ description: 'The task ID to query.' }),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const task = await scheduler.get(params.taskId as string);
+        if (!task) {
+          return textResult(`Task not found: ${params.taskId}`);
+        }
+        return textResult(JSON.stringify(task, null, 2));
+      },
+    },
+    {
+      name: 'scheduler_update',
+      label: 'Scheduler',
+      description: 'Update a scheduled task. Can change schedule, prompt, name, or enable/disable.',
+      parameters: Type.Object({
+        taskId: Type.String({ description: 'The task ID to update.' }),
+        type: Type.Optional(taskTypeSchema),
+        schedule: Type.Optional(Type.String({ description: 'New schedule expression.' })),
+        prompt: Type.Optional(Type.String({ description: 'New prompt.' })),
+        name: Type.Optional(Type.String({ description: 'New name.' })),
+        description: Type.Optional(Type.String({ description: 'New description.' })),
+        enabled: Type.Optional(Type.Boolean({ description: 'Enable or disable the task.' })),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const { taskId, type, schedule, ...rest } = params as {
+          taskId: string;
+          type?: string;
+          schedule?: string;
+          [key: string]: unknown;
+        };
+        const update: Record<string, unknown> = { ...rest };
+        if (type !== undefined || schedule !== undefined) {
+          try {
+            const existing = await scheduler.get(taskId);
+            if (!existing) {
+              return textResult(`Task not found: ${taskId}`);
+            }
+            const definition = resolveScheduledTaskDefinition({
+              type: (type ?? existing.type) as ScheduledTaskType,
+              schedule: schedule ?? existing.schedule,
+            });
+            Object.assign(update, definition);
+          } catch (error) {
+            return textResult(
+              `Invalid schedule: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+        }
+        const task = await scheduler.update(taskId, update);
+        if (!task) {
+          return textResult(`Task not found: ${taskId}`);
+        }
+        return textResult(JSON.stringify(formatTaskSummary(task), null, 2));
+      },
+    },
+    {
+      name: 'scheduler_delete',
+      label: 'Scheduler',
+      description: 'Delete a scheduled task.',
+      parameters: Type.Object({
+        taskId: Type.String({ description: 'The task ID to delete.' }),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const taskId = params.taskId as string;
+        const deleted = await scheduler.delete(taskId);
+        return textResult(deleted ? `Deleted task: ${taskId}` : `Task not found: ${taskId}`);
+      },
+    },
+    {
+      name: 'scheduler_run_now',
+      label: 'Scheduler',
+      description: 'Trigger immediate execution of a scheduled task.',
+      parameters: Type.Object({
+        taskId: Type.String({ description: 'The task ID to run immediately.' }),
+      }),
+      async execute(
+        _toolCallId: string,
+        params: Record<string, unknown>,
+      ): Promise<AgentToolResult<unknown>> {
+        const taskId = params.taskId as string;
+        const task = await scheduler.runNow(taskId);
+        if (!task) {
+          return textResult(`Task not found: ${taskId}`);
+        }
+        return textResult(`Triggered: ${task.name ?? task.id}`);
+      },
+    },
+  ];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.4
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -1778,6 +1781,11 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4378,6 +4386,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  husky@9.1.7: {}
 
   iconv-lite@0.7.2:
     dependencies:


### PR DESCRIPTION
… host integration

Move 6 LLM tool definitions from extension.ts into standalone tools.ts factory. Hosts can now import createSchedulerTools(scheduler) to register tools directly without going through extension auto-discovery.