### PR TITLE
fix(pi-computer-use): ship signed .app bundle + postinstall chmod

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "description": "Pi extension for browser automation via chrome-devtools-mcp with browser_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-channels",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "description": "Pi extension for native messaging channels including Feishu, WeCom, and webhooks.",
   "keywords": ["pi-package", "pi", "extension", "channels", "feishu", "wecom", "webhooks"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "description": "Pi extension for desktop automation via cua-driver-rs with computer_use_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "computer-use", "desktop", "automation", "cua-driver", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -20,6 +20,7 @@
   "files": [
     "dist",
     "bin",
+    "scripts",
     "README.md"
   ],
   "pi": {
@@ -38,7 +39,8 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc -b --pretty false",
-    "test": "vitest run src"
+    "test": "vitest run src",
+    "postinstall": "node scripts/postinstall.js"
   },
   "dependencies": {
     "@amaster.ai/pi-shared": "workspace:*",

--- a/packages/pi-computer-use/scripts/postinstall.js
+++ b/packages/pi-computer-use/scripts/postinstall.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { chmodSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const binDir = join(__dirname, '..', 'bin');
+
+const platform = process.platform === 'win32' ? 'win32-x64' : `${process.platform}-${process.arch}`;
+const platformDir = join(binDir, platform);
+
+if (process.platform === 'win32') {
+  process.exit(0);
+}
+
+let binPath;
+if (process.platform === 'darwin') {
+  binPath = join(platformDir, 'CuaDriver.app', 'Contents', 'MacOS', 'cua-driver');
+} else {
+  binPath = join(platformDir, 'cua-driver');
+}
+
+if (existsSync(binPath)) {
+  try {
+    chmodSync(binPath, 0o755);
+  } catch {
+    // Non-fatal: runtime will retry or prompt user
+  }
+}

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "description": "Pi extension for resource-aware security policy engine and tool authorization",
   "keywords": ["pi-package", "pi", "extension", "security", "policy", "authorization", "access-control"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "description": "Pi extension for cron-based scheduled task management with LLM-callable tools",
   "keywords": ["pi-package", "pi", "extension", "scheduler", "cron", "tasks"],
   "license": "Apache-2.0",

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-teamwork",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "description": "Pi extension for team collaboration and issue management via Multica",
   "keywords": ["pi-package", "pi", "extension", "teamwork", "issues", "project-management", "multica"],
   "license": "Apache-2.0",

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "description": "Pi extension for runtime telemetry with Langfuse and OpenTelemetry exporters",
   "keywords": ["pi-package", "pi", "extension", "telemetry", "observability", "langfuse", "opentelemetry", "tracing"],
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.7",
+  "version": "0.1.2-beta.8",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- macOS cua-driver binary switched from bare Mach-O (invalid signature, killed by Gatekeeper) to full signed `CuaDriver.app` bundle from `cua-driver-v0.2.0` universal release
- Added `postinstall` script to restore executable permissions that npm/pnpm strips during install — fixes EPERM in global installs where the directory is root-owned
- `mcp-client.ts` updated to resolve `.app` bundle path on darwin

## Test plan

- [x] `codesign --verify --deep --strict` passes on the bundled `.app`
- [x] MCP initialize handshake works locally (`cua-driver --version` → `0.2.0`)
- [x] All 28 unit tests pass
- [x] postinstall script sets 0755 correctly on darwin-arm64/x64