### PR TITLE
fix(pi-computer-use): align analyze_screenshot params & add storage updateSessionTitle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Pi extension for browser automation via chrome-devtools-mcp with browser_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-channels",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Pi extension for native messaging channels including Feishu, WeCom, and webhooks.",
   "keywords": ["pi-package", "pi", "extension", "channels", "feishu", "wecom", "webhooks"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Pi extension for desktop automation via cua-driver-rs with computer_use_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "computer-use", "desktop", "automation", "cua-driver", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/src/__tests__/index.test.ts
+++ b/packages/pi-computer-use/src/__tests__/index.test.ts
@@ -449,6 +449,171 @@ describe('binary permissions', () => {
   });
 });
 
+describe('analyze_screenshot', () => {
+  beforeEach(() => {
+    registeredTools.clear();
+    for (const k of Object.keys(eventHandlers)) delete eventHandlers[k];
+    mockNotify.mockClear();
+  });
+
+  test('passes window_id to underlying screenshot tool', async () => {
+    let capturedArgs: Record<string, unknown> = {};
+    await initExtension(
+      { visionModel: { provider: 'openai', model: 'gpt-4o' } },
+      (name: string, args: Record<string, unknown>) => {
+        if (name === 'check_permissions') {
+          return {
+            content: [{ type: 'text', text: 'All granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          };
+        }
+        if (name === 'screenshot') {
+          capturedArgs = args;
+          return {
+            content: [{ type: 'image', data: 'fakebase64', mimeType: 'image/png' }],
+          };
+        }
+        return { content: [{ type: 'text', text: 'ok' }] };
+      },
+    );
+
+    const tool = registeredTools.get('computer_use_analyze_screenshot')!;
+    // execute will fail at vision model call, but we can verify screenshot args were passed
+    try {
+      await tool.execute('id', { window_id: 12345 }, undefined, undefined, mockCtx);
+    } catch {
+      // vision model not available in test, that's fine
+    }
+    expect(capturedArgs.window_id).toBe(12345);
+  });
+
+  test('passes format and quality to underlying screenshot tool', async () => {
+    let capturedArgs: Record<string, unknown> = {};
+    await initExtension(
+      { visionModel: { provider: 'openai', model: 'gpt-4o' } },
+      (name: string, args: Record<string, unknown>) => {
+        if (name === 'check_permissions') {
+          return {
+            content: [{ type: 'text', text: 'All granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          };
+        }
+        if (name === 'screenshot') {
+          capturedArgs = args;
+          return {
+            content: [{ type: 'image', data: 'fakebase64', mimeType: 'image/jpeg' }],
+          };
+        }
+        return { content: [{ type: 'text', text: 'ok' }] };
+      },
+    );
+
+    const tool = registeredTools.get('computer_use_analyze_screenshot')!;
+    try {
+      await tool.execute(
+        'id',
+        { window_id: 99, format: 'jpeg', quality: 80 },
+        undefined,
+        undefined,
+        mockCtx,
+      );
+    } catch {
+      // vision model not available in test
+    }
+    expect(capturedArgs).toEqual({ window_id: 99, format: 'jpeg', quality: 80 });
+  });
+
+  test('returns error text from cua-driver when screenshot fails', async () => {
+    await initExtension(
+      { visionModel: { provider: 'openai', model: 'gpt-4o' } },
+      (name: string) => {
+        if (name === 'check_permissions') {
+          return {
+            content: [{ type: 'text', text: 'All granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          };
+        }
+        if (name === 'screenshot') {
+          return {
+            content: [{ type: 'text', text: 'screencapture failed: window not found' }],
+            isError: true,
+          };
+        }
+        return { content: [{ type: 'text', text: 'ok' }] };
+      },
+    );
+
+    const tool = registeredTools.get('computer_use_analyze_screenshot')!;
+    const result = (await tool.execute(
+      'id',
+      { window_id: 999 },
+      undefined,
+      undefined,
+      mockCtx,
+    )) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Screenshot failed for window 999');
+  });
+
+  test('returns sc_not_granted hint when screen recording denied', async () => {
+    await initExtension(
+      { visionModel: { provider: 'openai', model: 'gpt-4o' } },
+      (name: string) => {
+        if (name === 'check_permissions') {
+          return {
+            content: [{ type: 'text', text: 'All granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          };
+        }
+        if (name === 'screenshot') {
+          return {
+            content: [{ type: 'text', text: 'sc_not_granted' }],
+            isError: true,
+          };
+        }
+        return { content: [{ type: 'text', text: 'ok' }] };
+      },
+    );
+
+    const tool = registeredTools.get('computer_use_analyze_screenshot')!;
+    const result = (await tool.execute(
+      'id',
+      { window_id: 1 },
+      undefined,
+      undefined,
+      mockCtx,
+    )) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Screen Recording permission not granted');
+  });
+
+  test('returns connect error when cua-driver is not running', async () => {
+    const connectFail = async () => {
+      throw new Error('Connection refused');
+    };
+
+    await initExtension(
+      { visionModel: { provider: 'openai', model: 'gpt-4o' } },
+      undefined,
+      connectFail,
+    );
+
+    const tool = registeredTools.get('computer_use_analyze_screenshot')!;
+    const result = (await tool.execute(
+      'id',
+      { window_id: 1 },
+      undefined,
+      undefined,
+      mockCtx,
+    )) as any;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Failed to connect to cua-driver');
+  });
+});
+
 describe('connect failure resilience', () => {
   beforeEach(() => {
     registeredTools.clear();

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -488,12 +488,27 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
       name: `${TOOL_PREFIX}analyze_screenshot`,
       label: `${TOOL_PREFIX}analyze_screenshot`,
       description:
-        'Take a screenshot and analyze it visually using a vision model. Use when you need to identify elements by visual attributes (color, layout, position) or need precise pixel coordinates.',
+        'Capture a screenshot using ScreenCaptureKit and analyze it visually using a vision model. Returns analysis for a single window in the requested format (default png).\n\n`window_id` is required. Get window ids from `list_windows`.\n\nRequires the Screen Recording TCC grant — call `check_permissions` first if unsure.',
       parameters: Type.Object({
+        window_id: Type.Number({
+          description: 'Required CGWindowID / kCGWindowNumber to capture.',
+        }),
         instruction: Type.Optional(
           Type.String({
             description:
               'What to identify or analyze visually (e.g., "Find the coordinates of the blue submit button").',
+          }),
+        ),
+        format: Type.Optional(
+          Type.Union([Type.Literal('png'), Type.Literal('jpeg')], {
+            description: 'Image format. Default: png.',
+          }),
+        ),
+        quality: Type.Optional(
+          Type.Number({
+            description: 'JPEG quality 1-95; ignored for png.',
+            minimum: 1,
+            maximum: 95,
           }),
         ),
       }),
@@ -521,12 +536,22 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
           };
         }
 
-        const screenshotResult = await client!.callTool('screenshot', {});
+        const screenshotArgs: Record<string, unknown> = { window_id: params.window_id };
+        if (params.format) screenshotArgs.format = params.format;
+        if (params.quality) screenshotArgs.quality = params.quality;
+
+        const screenshotResult = await client!.callTool('screenshot', screenshotArgs);
         const imageContent = screenshotResult.content?.find((c) => c.type === 'image' && c.data);
 
         if (!imageContent?.data) {
+          const errorText =
+            screenshotResult.content
+              ?.filter((c) => c.type === 'text' && c.text)
+              .map((c) => c.text)
+              .join('\n') || 'Failed to capture screenshot.';
+          const formatted = formatToolError('screenshot', errorText, params);
           return {
-            content: [{ type: 'text' as const, text: 'Failed to capture screenshot.' }],
+            content: [{ type: 'text' as const, text: formatted ?? errorText }],
             details: undefined,
             isError: true,
           };

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Pi extension for resource-aware security policy engine and tool authorization",
   "keywords": ["pi-package", "pi", "extension", "security", "policy", "authorization", "access-control"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Pi extension for cron-based scheduled task management with LLM-callable tools",
   "keywords": ["pi-package", "pi", "extension", "scheduler", "cron", "tasks"],
   "license": "Apache-2.0",

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-teamwork",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Pi extension for team collaboration and issue management via Multica",
   "keywords": ["pi-package", "pi", "extension", "teamwork", "issues", "project-management", "multica"],
   "license": "Apache-2.0",

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "description": "Pi extension for runtime telemetry with Langfuse and OpenTelemetry exporters",
   "keywords": ["pi-package", "pi", "extension", "telemetry", "observability", "langfuse", "opentelemetry", "tracing"],
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -99,6 +99,7 @@ export type ConversationHistoryStore = {
     scope: RuntimeScope,
     sessions: RuntimeSession[],
   ): Promise<RuntimeSessionSummary[]>;
+  updateSessionTitle?(scope: RuntimeScope, sessionId: string, title: string): Promise<void>;
 };
 
 export type RuntimeSessionStore = Omit<ConversationStore, 'getRuntimeSession'> & {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.8",
+  "version": "0.1.2-beta.9",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/storage/src/db-runtime-storage.ts
+++ b/packages/storage/src/db-runtime-storage.ts
@@ -361,6 +361,13 @@ class DbTranscriptStore implements TranscriptStore {
       summaryFromPrismaSession(session, bySessionId.get(session.sessionId)),
     );
   }
+
+  async updateSessionTitle(scope: RuntimeScope, sessionId: string, title: string): Promise<void> {
+    await this.db.prisma.piAgentSession.updateMany({
+      where: { sessionId, deletedAt: null, ...sessionScopeWhere(scope) },
+      data: { title, updatedAt: new Date() },
+    });
+  }
 }
 
 class DbRuntimeTimelineEventStore implements RuntimeTimelineEventStore {

--- a/packages/storage/src/session-stores.ts
+++ b/packages/storage/src/session-stores.ts
@@ -128,6 +128,16 @@ export class JsonFileTranscriptStore implements TranscriptStore {
       }));
   }
 
+  async updateSessionTitle(scope: RuntimeScope, sessionId: string, title: string): Promise<void> {
+    void scope;
+    await this.update((state) => {
+      const summary = state.sessionSummaries[sessionId];
+      if (summary) {
+        summary.title = title;
+      }
+    });
+  }
+
   private async update(mutator: (state: JsonConversationHistoryState) => void): Promise<void> {
     const pending = this.writeTail.then(async () => {
       await this.load();


### PR DESCRIPTION
## Summary
- **fix(pi-computer-use):** `analyze_screenshot` 工具参数对齐底层 `screenshot` 工具，新增必填 `window_id`、可选 `format`/`quality` 参数，并透传 cua-driver 的真实错误信息
- **feat(storage):** 新增 `updateSessionTitle` 到 `ConversationHistoryStore`
- **chore:** 版本号 0.1.2-beta.8 -> 0.1.2-beta.9

## Test plan
- [x] `pi-computer-use` 单元测试全部通过（含新增的 5 个 analyze_screenshot 测试用例）
- [x] 全量 371 测试通过
- [x] lint / typecheck / build 通过