### PR TITLE
feat(pi-attachments): @skill: mentions, directory listings, README

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-attachments/README.md
+++ b/packages/pi-attachments/README.md
@@ -1,0 +1,58 @@
+# @amaster.ai/pi-attachments
+
+Pi extension that intercepts user input, resolves `@`-references to local resources, and injects their content into the prompt before the model sees it.
+
+Hooks the `input` event of `@earendil-works/pi-coding-agent`. When a recognized mention appears in the user message, the original mention is stripped and replaced with structured context (skill block, attachment listing, or `<system-reminder>`). Image attachments are passed through as multimodal `ImageContent`.
+
+## Recognized mentions
+
+| Syntax                          | Resolves to                                                       |
+|---------------------------------|-------------------------------------------------------------------|
+| `@path/to/file.ts`              | File contents (text/doc) or base64 image                          |
+| `@"/path with spaces/file.pdf"` | Same as above, supports whitespace in paths                       |
+| `@path/to/file.ts#L10-20`       | Line range syntax preserved in the reference (range applied downstream) |
+| `@path/to/dir`                  | Directory listing (files + subdirs, ignores `.git`/`node_modules`/build outputs) |
+| `@skill:<name>`                 | Loads `SKILL.md` for a registered skill                           |
+
+`@http(s)://...` is **not** treated as a file reference. Unknown namespaces (e.g. `@app:erp-prod`) are left alone — neither resolved as a skill nor as a file.
+
+## Skill resolution
+
+`@skill:<name>` searches in this order, first hit wins:
+
+1. `<cwd>/.pi/skills/<name>/SKILL.md` — project-level skill
+2. `<agentDir>/skills/<name>/SKILL.md` — user-level skill (resolved via `@amaster.ai/pi-shared`'s `resolveAgentDir()`, override with `PI_AGENT_HOME`)
+
+The order matches `loadSkillsFromAllLocations` in the pi-coding-agent SDK so a project skill overrides a user-installed one. Frontmatter is stripped; the body is wrapped in `<skill name="..." location="...">…</skill>` and prepended to the user message.
+
+## Output assembly
+
+When at least one mention resolves, the input is rewritten as three optional segments in this order:
+
+```
+<skill name="..." location="...">…</skill>   ← skill blocks (if any)
+
+<original user text with mentions stripped>
+
+<system-reminder>
+## file.ts: /abs/path/file.ts
+```text
+…contents…
+```
+</system-reminder>
+```
+
+Pure-text inputs with no resolvable mentions are left untouched (handler returns `undefined`).
+
+## Configuration
+
+| Env var                          | Default     | Meaning                                                  |
+|----------------------------------|-------------|----------------------------------------------------------|
+| `PI_ATTACHMENT_MAX_TEXT_CHARS`   | `128000`    | Max chars per text/doc attachment before truncation      |
+| `PI_AGENT_HOME`                  | (from pi-shared) | Override for user-level skill search root           |
+
+## Limits
+
+- **Directory listing**: capped at 200 entries per directory; remainder is summarized as `[Listing truncated: showing 200 of N entries]`.
+- **Ignored directory entries**: `.git`, `node_modules`, `.DS_Store`, `.next`, `.turbo`, `dist`, `build`, `.cache`.
+- **Mention ordering**: skills are matched before files, so the resolved `mentions[]` array groups by kind rather than preserving textual order. Downstream consumers must not rely on textual order.

--- a/packages/pi-attachments/package.json
+++ b/packages/pi-attachments/package.json
@@ -39,7 +39,9 @@
     "typecheck": "tsc -b --pretty false",
     "test": "vitest run src"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@amaster.ai/pi-shared": "workspace:*"
+  },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": ">=0.74.0"
   },

--- a/packages/pi-attachments/package.json
+++ b/packages/pi-attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for attachment processing — classifies, parses, and renders file attachments into LLM-visible prompt context",
   "keywords": ["pi-package", "pi", "extension", "attachments", "files", "documents"],
   "license": "Apache-2.0",

--- a/packages/pi-attachments/src/classify.test.ts
+++ b/packages/pi-attachments/src/classify.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';

--- a/packages/pi-attachments/src/classify.ts
+++ b/packages/pi-attachments/src/classify.ts
@@ -1,7 +1,9 @@
 /**
  * Attachment classification and prompt rendering utilities.
  */
-import { readFile } from 'node:fs/promises';
+import type { Dirent } from 'node:fs';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
 
 export type AttachmentKind = 'image' | 'text' | 'doc' | 'binary';
 
@@ -166,6 +168,10 @@ export async function renderAttachmentBlock(
     return `## ${name}${fsPath ? `: ${fsPath}` : ''}`;
   }
 
+  if (mimeType === 'inode/directory' && fsPath) {
+    return await renderDirectoryBlock(name, fsPath, maxTextChars);
+  }
+
   if (kind === 'text' && fsPath) {
     try {
       const buffer = await readFile(fsPath, 'utf8');
@@ -184,6 +190,77 @@ export async function renderAttachmentBlock(
   }
 
   return `## ${name}${fsPath ? `: ${fsPath}` : url ? `: ${url}` : ''}`;
+}
+
+const DIRECTORY_LISTING_LIMIT = 200;
+const DIRECTORY_IGNORE = new Set([
+  '.git',
+  'node_modules',
+  '.DS_Store',
+  '.next',
+  '.turbo',
+  'dist',
+  'build',
+  '.cache',
+]);
+
+async function renderDirectoryBlock(
+  name: string,
+  fsPath: string,
+  maxTextChars: number,
+): Promise<string> {
+  const heading = `## ${name}: ${fsPath} (directory)`;
+  let entries: Dirent[];
+  try {
+    entries = await readdir(fsPath, { withFileTypes: true });
+  } catch (error) {
+    return `${heading}\n[Failed to list directory: ${(error as Error).message}]`;
+  }
+
+  const filtered = entries
+    .filter((e) => !DIRECTORY_IGNORE.has(e.name))
+    .sort((a, b) => {
+      const ad = a.isDirectory() ? 0 : 1;
+      const bd = b.isDirectory() ? 0 : 1;
+      if (ad !== bd) return ad - bd;
+      return a.name.localeCompare(b.name);
+    });
+
+  const truncatedNote =
+    filtered.length > DIRECTORY_LISTING_LIMIT
+      ? `\n[Listing truncated: showing ${DIRECTORY_LISTING_LIMIT} of ${filtered.length} entries]`
+      : '';
+  const slice = filtered.slice(0, DIRECTORY_LISTING_LIMIT);
+
+  const lines: string[] = [];
+  for (const entry of slice) {
+    if (entry.isDirectory()) {
+      lines.push(`${entry.name}/`);
+      continue;
+    }
+    if (entry.isSymbolicLink()) {
+      lines.push(`${entry.name}@`);
+      continue;
+    }
+    let size: number | undefined;
+    try {
+      const s = await stat(path.join(fsPath, entry.name));
+      size = s.size;
+    } catch {
+      // ignore
+    }
+    lines.push(size !== undefined ? `${entry.name} (${formatBytes(size)})` : entry.name);
+  }
+
+  const body = truncateText(lines.join('\n'), maxTextChars);
+  return `${heading}\n\`\`\`\n${body}\n\`\`\`${truncatedNote}`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(1)}GB`;
 }
 
 export async function renderAttachmentContext(

--- a/packages/pi-attachments/src/extension.test.ts
+++ b/packages/pi-attachments/src/extension.test.ts
@@ -1,91 +1,312 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { extractMentions, skillSearchPaths, stripMentions } from './extension.js';
 
-// Test the core parsing/extraction logic directly
-const QUOTED_AT_RE = /(^|\s)@"([^"]+)"/g;
-const REGULAR_AT_RE = /(^|\s)@([^\s@"]+)/g;
-
-function extractAtMentions(content: string): string[] {
-  const mentions: string[] = [];
-  const seen = new Set<string>();
-  for (const match of content.matchAll(QUOTED_AT_RE)) {
-    const value = match[2]!;
-    if (!seen.has(value)) {
-      seen.add(value);
-      mentions.push(value);
-    }
-  }
-  for (const match of content.matchAll(REGULAR_AT_RE)) {
-    const value = match[2]!;
-    if (!seen.has(value) && !value.startsWith('http')) {
-      seen.add(value);
-      mentions.push(value);
-    }
-  }
-  return mentions;
-}
-
-function stripAtMentions(content: string): string {
-  return content.replace(QUOTED_AT_RE, '$1').replace(REGULAR_AT_RE, '$1').trim();
-}
-
-describe('extractAtMentions', () => {
-  it('extracts unquoted @path references', () => {
-    const result = extractAtMentions('check @src/main.ts please');
-    expect(result).toEqual(['src/main.ts']);
+describe('extractMentions', () => {
+  it('extracts unquoted @path file references', () => {
+    const { mentions } = extractMentions('check @src/main.ts please');
+    expect(mentions).toEqual([{ kind: 'file', ref: 'src/main.ts' }]);
   });
 
-  it('extracts quoted @"path" references', () => {
-    const result = extractAtMentions('review @"/path with spaces/file.ts"');
-    expect(result).toEqual(['/path with spaces/file.ts']);
+  it('extracts quoted @"path" file references', () => {
+    const { mentions } = extractMentions('review @"/path with spaces/file.ts"');
+    expect(mentions).toEqual([{ kind: 'file', ref: '/path with spaces/file.ts' }]);
   });
 
-  it('extracts multiple references', () => {
-    const result = extractAtMentions('@src/a.ts @src/b.ts explain these');
-    expect(result).toEqual(['src/a.ts', 'src/b.ts']);
-  });
-
-  it('deduplicates repeated references', () => {
-    const result = extractAtMentions('@foo.ts and @foo.ts again');
-    expect(result).toEqual(['foo.ts']);
+  it('extracts multiple file references and dedupes', () => {
+    const { mentions } = extractMentions('@src/a.ts @src/b.ts @src/a.ts');
+    expect(mentions).toEqual([
+      { kind: 'file', ref: 'src/a.ts' },
+      { kind: 'file', ref: 'src/b.ts' },
+    ]);
   });
 
   it('ignores http URLs', () => {
-    const result = extractAtMentions('see @https://example.com');
-    expect(result).toEqual([]);
+    const { mentions } = extractMentions('see @https://example.com');
+    expect(mentions).toEqual([]);
   });
 
-  it('handles line range syntax', () => {
-    const result = extractAtMentions('look at @src/main.ts#L10-20');
-    expect(result).toEqual(['src/main.ts#L10-20']);
+  it('keeps line range syntax in the file reference', () => {
+    const { mentions } = extractMentions('look at @src/main.ts#L10-20');
+    expect(mentions).toEqual([{ kind: 'file', ref: 'src/main.ts#L10-20' }]);
   });
 
-  it('returns empty for no mentions', () => {
-    const result = extractAtMentions('just a normal message');
-    expect(result).toEqual([]);
+  it('extracts @skill:name as a skill mention', () => {
+    const { mentions } = extractMentions('use @skill:react-page to draft a page');
+    expect(mentions).toEqual([{ kind: 'skill', name: 'react-page' }]);
+  });
+
+  it('does not double-count a skill mention as a file mention', () => {
+    const { mentions } = extractMentions('@skill:react-page');
+    expect(mentions).toEqual([{ kind: 'skill', name: 'react-page' }]);
+  });
+
+  it('mixes skill and file mentions in order', () => {
+    const { mentions } = extractMentions('load @skill:react-page and review @src/main.ts');
+    expect(mentions).toEqual([
+      { kind: 'skill', name: 'react-page' },
+      { kind: 'file', ref: 'src/main.ts' },
+    ]);
+  });
+
+  it('dedupes repeated skill mentions', () => {
+    const { mentions } = extractMentions('@skill:react-page and @skill:react-page again');
+    expect(mentions).toEqual([{ kind: 'skill', name: 'react-page' }]);
+  });
+
+  it('treats unknown namespaces as no-op (not as file mentions either)', () => {
+    const { mentions } = extractMentions('@app:erp-prod hello');
+    expect(mentions).toEqual([]);
   });
 
   it('handles @ at start of text', () => {
-    const result = extractAtMentions('@file.ts');
-    expect(result).toEqual(['file.ts']);
+    const { mentions } = extractMentions('@file.ts');
+    expect(mentions).toEqual([{ kind: 'file', ref: 'file.ts' }]);
+  });
+
+  it('groups skill mentions before file mentions regardless of textual order', () => {
+    // Implementation detail: skills are matched first, then files. This means
+    // the mentions array does NOT preserve the textual order — it groups by kind.
+    // Downstream consumers must not rely on textual order.
+    const { mentions } = extractMentions('review @src/main.ts then @skill:foo');
+    expect(mentions).toEqual([
+      { kind: 'skill', name: 'foo' },
+      { kind: 'file', ref: 'src/main.ts' },
+    ]);
+  });
+
+  it('matches @SKILL: case-insensitively', () => {
+    const { mentions } = extractMentions('use @SKILL:foo here');
+    expect(mentions).toEqual([{ kind: 'skill', name: 'foo' }]);
   });
 });
 
-describe('stripAtMentions', () => {
-  it('removes unquoted mentions', () => {
-    const result = stripAtMentions('check @src/main.ts please');
-    expect(result).toBe('check  please');
+describe('stripMentions', () => {
+  it('removes file mentions', () => {
+    expect(stripMentions('check @src/main.ts please')).toBe('check  please');
   });
 
   it('removes quoted mentions', () => {
-    const result = stripAtMentions('review @"/tmp/file.ts" now');
-    expect(result).toBe('review  now');
+    expect(stripMentions('review @"/tmp/file.ts" now')).toBe('review  now');
   });
 
-  it('removes all mentions and trims', () => {
-    const result = stripAtMentions('@a.ts @b.ts explain');
-    expect(result).toBe('explain');
+  it('removes skill mentions', () => {
+    expect(stripMentions('use @skill:react-page now')).toBe('use  now');
+  });
+
+  it('removes mixed mentions and trims', () => {
+    expect(stripMentions('@skill:foo @a.ts @b.ts explain')).toBe('explain');
+  });
+
+  it('leaves text without mentions intact', () => {
+    expect(stripMentions('plain message')).toBe('plain message');
+  });
+});
+
+describe('skillSearchPaths', () => {
+  it('returns project path before user (agent dir) path', () => {
+    const cwd = '/tmp/fake-project';
+    const paths = skillSearchPaths('react-page', cwd);
+    expect(paths).toHaveLength(2);
+    expect(paths[0]).toBe(resolve(cwd, '.pi/skills/react-page/SKILL.md'));
+    expect(paths[1]!.endsWith(join('skills', 'react-page', 'SKILL.md'))).toBe(true);
+  });
+
+  it('honors PI_AGENT_HOME for user-level path', () => {
+    const original = process.env.PI_AGENT_HOME;
+    process.env.PI_AGENT_HOME = '/tmp/custom-agent';
+    try {
+      const paths = skillSearchPaths('foo', '/tmp/cwd');
+      expect(paths[1]).toBe('/tmp/custom-agent/skills/foo/SKILL.md');
+    } finally {
+      if (original === undefined) delete process.env.PI_AGENT_HOME;
+      else process.env.PI_AGENT_HOME = original;
+    }
+  });
+});
+
+describe('skill loading via extension input handler', () => {
+  let tmpRoot: string;
+  let cwd: string;
+  let agentDir: string;
+  let originalAgentHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), 'pi-attachments-test-'));
+    cwd = join(tmpRoot, 'project');
+    agentDir = join(tmpRoot, 'agent');
+    await mkdir(cwd, { recursive: true });
+    await mkdir(agentDir, { recursive: true });
+    originalAgentHome = process.env.PI_AGENT_HOME;
+    process.env.PI_AGENT_HOME = agentDir;
+  });
+
+  afterEach(async () => {
+    if (originalAgentHome === undefined) delete process.env.PI_AGENT_HOME;
+    else process.env.PI_AGENT_HOME = originalAgentHome;
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  async function loadExtension(): Promise<{
+    runInput: (text: string) => Promise<{ action: string; text?: string } | undefined>;
+  }> {
+    const ext = (await import('./extension.js')).default;
+    let handler:
+      | ((event: { text: string; images?: unknown[] }, ctx: { cwd: string }) => Promise<unknown>)
+      | undefined;
+    const fakeApi = {
+      on: (event: string, fn: typeof handler) => {
+        if (event === 'input') handler = fn;
+      },
+    };
+    ext(fakeApi as never);
+    if (!handler) throw new Error('input handler was not registered');
+    return {
+      runInput: async (text: string) => {
+        const result = await handler!({ text }, { cwd });
+        return result as { action: string; text?: string } | undefined;
+      },
+    };
+  }
+
+  it('loads SKILL.md from the user agent dir', async () => {
+    const skillDir = join(agentDir, 'skills', 'demo');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: demo\n---\nUse demo skill instructions.\n',
+      'utf8',
+    );
+
+    const { runInput } = await loadExtension();
+    const result = await runInput('@skill:demo do the thing');
+
+    expect(result?.action).toBe('transform');
+    const text = result?.text ?? '';
+    expect(text).toContain('<skill name="demo"');
+    expect(text).toContain('Use demo skill instructions.');
+    expect(text).not.toContain('---\nname: demo');
+    expect(text).toContain('do the thing');
+    expect(text).not.toContain('@skill:demo');
+  });
+
+  it('prefers project-level SKILL.md over user-level', async () => {
+    const userSkill = join(agentDir, 'skills', 'demo');
+    const projectSkill = join(cwd, '.pi', 'skills', 'demo');
+    await mkdir(userSkill, { recursive: true });
+    await mkdir(projectSkill, { recursive: true });
+    await writeFile(join(userSkill, 'SKILL.md'), 'USER VERSION', 'utf8');
+    await writeFile(join(projectSkill, 'SKILL.md'), 'PROJECT VERSION', 'utf8');
+
+    const { runInput } = await loadExtension();
+    const result = await runInput('@skill:demo');
+
+    expect(result?.text).toContain('PROJECT VERSION');
+    expect(result?.text).not.toContain('USER VERSION');
+  });
+
+  it('returns undefined when neither file mentions nor skill mentions resolve', async () => {
+    const { runInput } = await loadExtension();
+    const result = await runInput('@skill:does-not-exist hi');
+    // No skill block, no attachments, no images → handler returns undefined to leave input untouched
+    expect(result).toBeUndefined();
+  });
+
+  it('renders directory listings for @dir mentions', async () => {
+    const dir = join(cwd, 'mydir');
+    await mkdir(dir, { recursive: true });
+    await mkdir(join(dir, 'sub'), { recursive: true });
+    await writeFile(join(dir, 'a.txt'), 'hello', 'utf8');
+    await writeFile(join(dir, 'b.json'), '{}', 'utf8');
+
+    const { runInput } = await loadExtension();
+    const result = await runInput('look at @mydir');
+
+    expect(result?.action).toBe('transform');
+    const text = result?.text ?? '';
+    expect(text).toContain('(directory)');
+    expect(text).toContain('sub/');
+    expect(text).toContain('a.txt');
+    expect(text).toContain('b.json');
+    expect(text).toContain('look at');
+    expect(text).not.toContain('@mydir');
+  });
+
+  it('skips ignored directory entries (.git, node_modules)', async () => {
+    const dir = join(cwd, 'proj');
+    await mkdir(join(dir, '.git'), { recursive: true });
+    await mkdir(join(dir, 'node_modules'), { recursive: true });
+    await writeFile(join(dir, 'README.md'), '# hi', 'utf8');
+
+    const { runInput } = await loadExtension();
+    const result = await runInput('@proj');
+    const text = result?.text ?? '';
+
+    expect(text).toContain('README.md');
+    expect(text).not.toContain('.git/');
+    expect(text).not.toContain('node_modules/');
+  });
+
+  it('emits skill block before clean text before attachment reminder', async () => {
+    const skillDir = join(agentDir, 'skills', 'demo');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, 'SKILL.md'), 'SKILL BODY', 'utf8');
+    await writeFile(join(cwd, 'note.txt'), 'note contents', 'utf8');
+
+    const { runInput } = await loadExtension();
+    const result = await runInput('@skill:demo please summarise @note.txt');
+    const text = result?.text ?? '';
+
+    const skillIdx = text.indexOf('<skill name="demo"');
+    const cleanIdx = text.indexOf('please summarise');
+    const reminderIdx = text.indexOf('<system-reminder>');
+
+    expect(skillIdx).toBeGreaterThanOrEqual(0);
+    expect(cleanIdx).toBeGreaterThanOrEqual(0);
+    expect(reminderIdx).toBeGreaterThanOrEqual(0);
+    expect(skillIdx).toBeLessThan(cleanIdx);
+    expect(cleanIdx).toBeLessThan(reminderIdx);
+  });
+
+  it('renders SKILL.md with no frontmatter unchanged', async () => {
+    const skillDir = join(agentDir, 'skills', 'plain');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, 'SKILL.md'), '# Plain Title\n\nbody line\n', 'utf8');
+
+    const { runInput } = await loadExtension();
+    const result = await runInput('@skill:plain');
+    const text = result?.text ?? '';
+
+    expect(text).toContain('# Plain Title');
+    expect(text).toContain('body line');
+  });
+
+  it('preserves pre-existing event.images when only a skill is mentioned', async () => {
+    const skillDir = join(agentDir, 'skills', 'demo');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, 'SKILL.md'), 'BODY', 'utf8');
+
+    // Re-implement loadExtension inline so we can pass images through.
+    const ext = (await import('./extension.js')).default;
+    let handler:
+      | ((event: { text: string; images?: unknown[] }, ctx: { cwd: string }) => Promise<unknown>)
+      | undefined;
+    ext({
+      on: (e: string, fn: typeof handler) => {
+        if (e === 'input') handler = fn;
+      },
+    } as never);
+    if (!handler) throw new Error('input handler not registered');
+
+    const inputImage = { type: 'image', mimeType: 'image/png', data: 'AAAA' };
+    const result = (await handler(
+      { text: '@skill:demo look at this', images: [inputImage] },
+      { cwd },
+    )) as { action: string; text?: string; images?: unknown[] } | undefined;
+
+    expect(result?.action).toBe('transform');
+    expect(result?.images).toEqual([inputImage]);
   });
 });

--- a/packages/pi-attachments/src/extension.ts
+++ b/packages/pi-attachments/src/extension.ts
@@ -1,39 +1,56 @@
 /**
  * Pi Attachments Extension
  *
- * Intercepts user input containing @path references, reads the files,
- * classifies them, and injects their content into the prompt as context.
- * Image files are encoded as base64 ImageContent for multimodal input.
+ * Intercepts user input containing @-references, reads referenced resources,
+ * and injects their content into the prompt as context.
  *
- * Supports:
+ * Recognized references:
+ * - @skill:<name> — load SKILL.md for a registered skill (project > user > global agent dir)
  * - @path/to/file.ts — unquoted file reference
  * - @"/path with spaces/file.pdf" — quoted file reference
  * - @file.ts#L10-20 — line range (parsed but range applied by LLM tools)
+ *
+ * Image files are encoded as base64 ImageContent for multimodal input.
  */
-import { readdir, readFile, stat } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+import { resolveAgentDir } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, InputEventResult } from '@earendil-works/pi-coding-agent';
 import { type AttachmentMeta, classifyAttachment, renderAttachmentContext } from './classify.js';
 
 type ImageContent = { type: 'image'; mimeType: string; data: string };
 
+const SKILL_NAMESPACE = 'skill';
+const NAMESPACE_AT_RE = /(^|\s)@([a-z][a-z0-9_-]*):([^\s@"]+)/gi;
 const QUOTED_AT_RE = /(^|\s)@"([^"]+)"/g;
 const REGULAR_AT_RE = /(^|\s)@([^\s@"]+)/g;
+
+type Mention = { kind: 'skill'; name: string } | { kind: 'file'; ref: string };
 
 export default function piAttachmentsExtension(pi: ExtensionAPI): void {
   const maxTextChars = Number(process.env.PI_ATTACHMENT_MAX_TEXT_CHARS) || 128_000;
 
   pi.on('input', async (event, ctx): Promise<InputEventResult | undefined> => {
-    const mentions = extractAtMentions(event.text);
+    const { mentions } = extractMentions(event.text);
     if (mentions.length === 0) return;
 
     const cwd = ctx.cwd;
     const attachments: AttachmentMeta[] = [];
     const images: ImageContent[] = [...(event.images ?? [])];
+    const skillBlocks: string[] = [];
     const resolvedPaths = new Set<string>();
+    const resolvedSkills = new Set<string>();
 
     for (const mention of mentions) {
-      const { filename } = parseFileReference(mention);
+      if (mention.kind === 'skill') {
+        if (resolvedSkills.has(mention.name)) continue;
+        resolvedSkills.add(mention.name);
+        const block = await loadSkillBlock(mention.name, cwd);
+        if (block) skillBlocks.push(block);
+        continue;
+      }
+
+      const { filename } = parseFileReference(mention.ref);
       const absolutePath = path.isAbsolute(filename) ? filename : path.resolve(cwd, filename);
       if (resolvedPaths.has(absolutePath)) continue;
       resolvedPaths.add(absolutePath);
@@ -41,7 +58,6 @@ export default function piAttachmentsExtension(pi: ExtensionAPI): void {
       try {
         const stats = await stat(absolutePath);
         if (stats.isDirectory()) {
-          const entries = await readdir(absolutePath);
           attachments.push({
             id: absolutePath,
             name: path.basename(absolutePath),
@@ -80,19 +96,25 @@ export default function piAttachmentsExtension(pi: ExtensionAPI): void {
       }
     }
 
-    if (attachments.length === 0 && images.length === (event.images?.length ?? 0)) {
+    if (
+      attachments.length === 0 &&
+      skillBlocks.length === 0 &&
+      images.length === (event.images?.length ?? 0)
+    ) {
       return;
     }
 
-    const cleanText = stripAtMentions(event.text);
+    const cleanText = stripMentions(event.text);
     const context = await renderAttachmentContext(attachments, {
       maxTextChars,
       hasImages: images.length > 0,
     });
 
-    const text = context
-      ? `${cleanText}\n\n<system-reminder>\n${context}\n</system-reminder>`
-      : cleanText;
+    const parts: string[] = [];
+    if (skillBlocks.length > 0) parts.push(skillBlocks.join('\n\n'));
+    if (cleanText) parts.push(cleanText);
+    if (context) parts.push(`<system-reminder>\n${context}\n</system-reminder>`);
+    const text = parts.join('\n\n');
 
     return {
       action: 'transform',
@@ -102,31 +124,63 @@ export default function piAttachmentsExtension(pi: ExtensionAPI): void {
   });
 }
 
-function extractAtMentions(content: string): string[] {
-  const mentions: string[] = [];
-  const seen = new Set<string>();
+export function extractMentions(content: string): { mentions: Mention[]; raw: string[] } {
+  const mentions: Mention[] = [];
+  const raw: string[] = [];
+  const seenSkills = new Set<string>();
+  const seenFiles = new Set<string>();
+  const namespaceSpans: Array<[number, number]> = [];
+
+  for (const match of content.matchAll(NAMESPACE_AT_RE)) {
+    const ns = match[2]!.toLowerCase();
+    const value = match[3]!;
+    const start = match.index! + (match[1]?.length ?? 0);
+    namespaceSpans.push([start, start + 1 + ns.length + 1 + value.length]);
+    if (ns === SKILL_NAMESPACE) {
+      if (!seenSkills.has(value)) {
+        seenSkills.add(value);
+        mentions.push({ kind: 'skill', name: value });
+        raw.push(`@${ns}:${value}`);
+      }
+    }
+  }
+
+  const isInsideNamespace = (start: number, end: number) =>
+    namespaceSpans.some(([s, e]) => start >= s && end <= e);
 
   for (const match of content.matchAll(QUOTED_AT_RE)) {
     const value = match[2]!;
-    if (!seen.has(value)) {
-      seen.add(value);
-      mentions.push(value);
+    const start = match.index! + (match[1]?.length ?? 0);
+    const end = start + 2 + value.length + 1;
+    if (isInsideNamespace(start, end)) continue;
+    if (!seenFiles.has(value)) {
+      seenFiles.add(value);
+      mentions.push({ kind: 'file', ref: value });
+      raw.push(`@"${value}"`);
     }
   }
 
   for (const match of content.matchAll(REGULAR_AT_RE)) {
     const value = match[2]!;
-    if (!seen.has(value) && !value.startsWith('http')) {
-      seen.add(value);
-      mentions.push(value);
-    }
+    const start = match.index! + (match[1]?.length ?? 0);
+    const end = start + 1 + value.length;
+    if (isInsideNamespace(start, end)) continue;
+    if (value.startsWith('http')) continue;
+    if (seenFiles.has(value)) continue;
+    seenFiles.add(value);
+    mentions.push({ kind: 'file', ref: value });
+    raw.push(`@${value}`);
   }
 
-  return mentions;
+  return { mentions, raw };
 }
 
-function stripAtMentions(content: string): string {
-  return content.replace(QUOTED_AT_RE, '$1').replace(REGULAR_AT_RE, '$1').trim();
+export function stripMentions(content: string): string {
+  return content
+    .replace(NAMESPACE_AT_RE, '$1')
+    .replace(QUOTED_AT_RE, '$1')
+    .replace(REGULAR_AT_RE, '$1')
+    .trim();
 }
 
 function parseFileReference(mention: string): {
@@ -148,6 +202,53 @@ function parseFileReference(mention: string): {
     ...(lineStart ? { lineStart } : {}),
     ...(lineEnd ? { lineEnd } : {}),
   };
+}
+
+/**
+ * Search order for `@skill:<name>`: project-level (`<cwd>/.pi/skills`) before
+ * user-level (`<agentDir>/skills`). Matches `loadSkillsFromAllLocations` in
+ * the pi-coding-agent SDK so a project skill overrides a user-installed one.
+ */
+export function skillSearchPaths(name: string, cwd: string): string[] {
+  const projectDir = path.resolve(cwd, '.pi', 'skills', name);
+  const userDir = path.resolve(resolveAgentDir(), 'skills', name);
+  return [projectDir, userDir].map((dir) => path.join(dir, 'SKILL.md'));
+}
+
+async function loadSkillBlock(name: string, cwd: string): Promise<string | undefined> {
+  for (const filePath of skillSearchPaths(name, cwd)) {
+    try {
+      const content = await readFile(filePath, 'utf8');
+      const baseDir = path.dirname(filePath);
+      const body = stripFrontmatter(content).trim();
+      return [
+        `<skill name="${escapeXmlAttribute(name)}" location="${escapeXmlAttribute(filePath)}">`,
+        `References are relative to ${baseDir}.`,
+        '',
+        body,
+        '</skill>',
+      ].join('\n');
+    } catch {
+      // try next candidate
+    }
+  }
+  return undefined;
+}
+
+function stripFrontmatter(content: string): string {
+  if (!content.startsWith('---')) return content;
+  const close = content.indexOf('\n---', 3);
+  if (close === -1) return content;
+  const after = close + '\n---'.length;
+  return content.slice(content[after] === '\n' ? after + 1 : after);
+}
+
+function escapeXmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 const MIME_BY_EXT: Record<string, string> = {

--- a/packages/pi-attachments/tsconfig.json
+++ b/packages/pi-attachments/tsconfig.json
@@ -5,6 +5,9 @@
     "rootDir": "src",
     "outDir": "dist"
   },
+  "references": [
+    { "path": "../shared" }
+  ],
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for browser automation via chrome-devtools-mcp with browser_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-channels",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for native messaging channels including Feishu, WeCom, and webhooks.",
   "keywords": ["pi-package", "pi", "extension", "channels", "feishu", "wecom", "webhooks"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for desktop automation via cua-driver-rs with computer_use_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "computer-use", "desktop", "automation", "cua-driver", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-memory",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension providing persistent curated memory (MEMORY.md + USER.md) injected into the system prompt as a frozen snapshot.",
   "keywords": ["pi-package", "pi", "extension", "memory", "persistence"],
   "license": "Apache-2.0",

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for resource-aware security policy engine and tool authorization",
   "keywords": ["pi-package", "pi", "extension", "security", "policy", "authorization", "access-control"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for cron-based scheduled task management with LLM-callable tools",
   "keywords": ["pi-package", "pi", "extension", "scheduler", "cron", "tasks"],
   "license": "Apache-2.0",

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-teamwork",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for team collaboration and issue management via Multica",
   "keywords": ["pi-package", "pi", "extension", "teamwork", "issues", "project-management", "multica"],
   "license": "Apache-2.0",

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "description": "Pi extension for runtime telemetry with Langfuse and OpenTelemetry exporters",
   "keywords": ["pi-package", "pi", "extension", "telemetry", "observability", "langfuse", "opentelemetry", "tracing"],
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.11",
+  "version": "0.1.2-beta.12",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,10 @@ importers:
         version: 3.10.1
 
   packages/pi-attachments:
+    dependencies:
+      '@amaster.ai/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.74.0


### PR DESCRIPTION
## Summary

- Add `@skill:<name>` mention namespace — loads `SKILL.md` from `<cwd>/.pi/skills/` first, falling back to the user agent dir; strips frontmatter and wraps the body in a `<skill>` block prepended to the user message
- Render directory contents for `@dir` mentions (ignores `.git`/`node_modules`/build outputs, capped at 200 entries)
- Rewrite `extension.test.ts` against the real exports and add coverage for ordering, `@SKILL:` case-insensitivity, no-frontmatter SKILL.md, three-section assembly order, and image passthrough (56 tests pass)
- Add `packages/pi-attachments/README.md` documenting recognized mention syntax, skill resolution order, output assembly, and limits
- Repo-wide version bump 0.1.2-beta.11 → 0.1.2-beta.12

## Test plan

- [x] `pnpm --filter @amaster.ai/pi-attachments test` (56/56 passing)
- [x] `pnpm --filter @amaster.ai/pi-attachments typecheck`
- [x] Pre-commit lint + typecheck + test + build all green
- [ ] Manual smoke: `@skill:<name>` resolves project-level before user-level in a real session
- [ ] Manual smoke: `@some-dir` lists contents and skips ignored entries