### PR TITLE
refactor(pi-security): simplify profile model + add example configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,23 @@ product-specific UI.
 
 ## Packages
 
-| Package | Purpose |
-| --- | --- |
-| `@amaster.ai/pi-shared` | Shared runtime types, contracts, and utilities (settings loader, event types, artifact types). |
-| `@amaster.ai/pi-storage` | JSON-file and MySQL/Prisma persistence adapters for sessions, transcripts, events, memory, artifacts, subagents, and scheduled tasks. |
-| `@amaster.ai/pi-attachments` | Attachment normalization, local/remote upload handling, document parsing, and model-readable attachment prompts. |
-| `@amaster.ai/pi-telemetry` | Runtime telemetry contracts plus Langfuse and generic OTLP/HTTP exporters. |
-| `@amaster.ai/pi-browser-use` | Browser automation extension wrapping chrome-devtools-mcp with `browser_` prefixed tools. |
-| `@amaster.ai/pi-computer-use` | Computer-use extension for CUA computer-server with desktop automation tools. |
-| `@amaster.ai/pi-turns` | Turn concurrency, queueing, cancellation, active-turn handling, prompt timeout guards, and runtime event observation. |
-| `@amaster.ai/pi-subagents` | Subagent spawning, child-session orchestration, role-aware prompts, routing hints, and cancellation helpers. |
-| `@amaster.ai/pi-task-scheduler` | Scheduled task domain types, schedule parsing, process-local timers, runner hooks, and lock-aware task execution. |
+| Category | Package | Purpose |
+| --- | --- | --- |
+| Core | `@amaster.ai/pi-shared` | Shared runtime types and contracts: settings loader, session/event/artifact types, turn and subagent types. |
+| Core | `@amaster.ai/pi-storage` | JSON-file and MySQL/Prisma persistence adapters for sessions, transcripts, events, memory, artifacts, subagents, and scheduled tasks. |
+| Extension | `@amaster.ai/pi-attachments` | Attachment normalization, local/remote upload handling, document parsing, and model-readable attachment prompts. |
+| Extension | `@amaster.ai/pi-telemetry` | Runtime telemetry with Langfuse and OpenTelemetry exporters. |
+| Extension | `@amaster.ai/pi-task-scheduler` | Cron-based scheduled task management with LLM-callable tools. |
+| Extension | `@amaster.ai/pi-browser-use` | Browser automation wrapping chrome-devtools-mcp with `browser_`-prefixed tools. |
+| Extension | `@amaster.ai/pi-computer-use` | Computer-use extension for CUA computer-server with desktop automation tools. |
+| Extension | `@amaster.ai/pi-channels` | Native messaging channels: Feishu, WeCom, and webhooks. |
+| Extension | `@amaster.ai/pi-memory` | Persistent curated memory (`MEMORY.md` + `USER.md`) injected into the system prompt as a frozen snapshot. |
+| Extension | `@amaster.ai/pi-security` | Resource-aware security policy engine and tool authorization. |
+| Extension | `@amaster.ai/pi-teamwork` | Team collaboration and issue management via Multica. |
+
+Core packages provide types and persistence used by every host application.
+Extension packages each register Pi runtime extensions via their `./extension`
+subpath entry point and are loaded on demand.
 
 Every package is ESM-only and published under the `@amaster.ai` npm scope.
 
@@ -80,7 +86,12 @@ import { JsonRuntimeStorage } from "@amaster.ai/pi-storage/json";
 import { loadPiSettings } from "@amaster.ai/pi-shared/settings";
 import { createLangfuseExporter } from "@amaster.ai/pi-telemetry/langfuse";
 import { createOtelExporter } from "@amaster.ai/pi-telemetry/otel";
+import memoryExtension from "@amaster.ai/pi-memory/extension";
 ```
+
+Extension packages register themselves through their `./extension` subpath
+entry point. Host applications import these and pass them to the Pi runtime
+during setup.
 
 See each package README for package-specific examples and public API notes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-attachments/package.json
+++ b/packages/pi-attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for attachment processing — classifies, parses, and renders file attachments into LLM-visible prompt context",
   "keywords": ["pi-package", "pi", "extension", "attachments", "files", "documents"],
   "license": "Apache-2.0",

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for browser automation via chrome-devtools-mcp with browser_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-channels/README.md
+++ b/packages/pi-channels/README.md
@@ -147,6 +147,7 @@ enterprise.
 
 ```text
 /channel list
+/channel reload
 /channel bridge on
 /channel bridge off
 /channel bridge status

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-channels",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for native messaging channels including Feishu, WeCom, and webhooks.",
   "keywords": ["pi-package", "pi", "extension", "channels", "feishu", "wecom", "webhooks"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for desktop automation via cua-driver-rs with computer_use_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "computer-use", "desktop", "automation", "cua-driver", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -543,6 +543,21 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
         const screenshotResult = await client!.callTool('screenshot', screenshotArgs);
         const imageContent = screenshotResult.content?.find((c) => c.type === 'image' && c.data);
 
+        console.error(
+          '[pi-computer-use analyze_screenshot] screenshot result',
+          JSON.stringify(
+            {
+              window_id: params.window_id,
+              isError: screenshotResult.isError,
+              contentTypes: screenshotResult.content?.map((c) => c.type),
+              imageDataLength: imageContent?.data?.length,
+              imageMimeType: imageContent?.mimeType,
+            },
+            null,
+            2,
+          ),
+        );
+
         if (!imageContent?.data) {
           const errorText =
             screenshotResult.content
@@ -565,6 +580,18 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
           instruction,
           imageContent.data,
           imageContent.mimeType ?? 'image/png',
+        );
+
+        console.error(
+          '[pi-computer-use analyze_screenshot] vision analysis',
+          JSON.stringify(
+            {
+              analysisLength: analysis.length,
+              analysisPreview: analysis.slice(0, 200),
+            },
+            null,
+            2,
+          ),
         );
 
         return {

--- a/packages/pi-computer-use/src/vision.ts
+++ b/packages/pi-computer-use/src/vision.ts
@@ -69,6 +69,33 @@ export function createPiVisionCaller(
       options,
     );
 
+    const contentShape = result.content.map((c) => {
+      const block = c as unknown as Record<string, unknown>;
+      const type = typeof block.type === 'string' ? block.type : 'unknown';
+      const text = typeof block.text === 'string' ? block.text : undefined;
+      return {
+        type,
+        textLength: text?.length,
+        textPreview: text ? text.slice(0, 200) : undefined,
+        keys: Object.keys(block),
+      };
+    });
+    console.error(
+      '[pi-computer-use vision] complete() returned',
+      JSON.stringify(
+        {
+          provider: visionConfig.provider,
+          model: visionConfig.model,
+          imageBase64Length: imageBase64.length,
+          mimeType,
+          blockCount: result.content.length,
+          contentShape,
+        },
+        null,
+        2,
+      ),
+    );
+
     return result.content
       .filter((c): c is AiTextContent => c.type === 'text')
       .map((c) => c.text)

--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-memory",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension providing persistent curated memory (MEMORY.md + USER.md) injected into the system prompt as a frozen snapshot.",
   "keywords": ["pi-package", "pi", "extension", "memory", "persistence"],
   "license": "Apache-2.0",

--- a/packages/pi-security/README.md
+++ b/packages/pi-security/README.md
@@ -1,8 +1,8 @@
 # Pi Security
 
-`@amaster.ai/pi-security` provides a resource-aware security policy engine and a Pi extension entry point.
+`@amaster.ai/pi-security` provides a sandbox-aware security policy engine and a Pi extension entry point.
 
-The core engine classifies tool calls into resources such as files, shell commands, network access, memory writes, MCP calls, and subagent spawns. It then applies profile rules to decide whether a call is allowed, denied, sandbox-only, allowed with constraints, or requires human approval.
+The core engine classifies tool calls into resources (files, shell commands, network access), assesses risk, and applies profile rules to decide whether a call is allowed, denied, or requires human approval. Profiles are built from two orthogonal axes — **sandbox** (what tools are exposed) and **approval** (when to ask the user) — inspired by Codex.
 
 ## Pi extension
 
@@ -12,22 +12,9 @@ Install the extension entry point `@amaster.ai/pi-security/extension` and load t
 {
   "pi-security": {
     "enabled": true,
-    "profile": "auto-review",
+    "profile": "default",
     "approvals": {
       "allowSessionGrants": true
-    },
-    "security": {
-      "profiles": {
-        "auto-review": {
-          "rules": [
-            {
-              "id": "ask-file-writes",
-              "tools": ["write_file", "edit_file"],
-              "decision": { "kind": "ask", "reason": "File modifications require approval." }
-            }
-          ]
-        }
-      }
     }
   }
 }
@@ -35,42 +22,90 @@ Install the extension entry point `@amaster.ai/pi-security/extension` and load t
 
 The extension listens to Pi `tool_call` and `user_bash` events. It does not register an LLM-callable tool that can bypass policy. Human approvals are requested through Pi UI primitives when UI is available; non-interactive contexts fail closed when a rule requires approval.
 
-## Security profiles
+## Built-in profiles
 
-Built-in profiles and their capability policies:
+Profiles are derived from a `sandbox` × `approval` matrix. Pick one as a starting point and override either axis in your own profiles.
 
-| Profile | Mode | Description |
-|---------|------|-------------|
-| `auto-review` | Denylist (`allow: ['*']`) | All tools exposed by default; risk-based rules gate dangerous ops |
-| `admin` / `full-access` | Denylist (`allow: ['*']`) | All tools allowed, no security rules |
-| `sandbox-exec` / `copilot` | Allowlist | Core tools + MCP allowed |
-| `workspace-write` | Allowlist | File R/W, no shell |
-| `workspace-read` | Allowlist | Read-only file access |
-| `chat` | Allowlist | Memory search only |
-| `scheduled` | Allowlist | Read + MCP, no mutations |
-| `subagent` | Allowlist | Like sandbox-exec but no memory_write/sessions_spawn |
+| Profile        | Sandbox            | Approval     | Use case                                                |
+|----------------|--------------------|--------------|---------------------------------------------------------|
+| `read-only`    | `read-only`        | `never`      | Read-only inspection, no modifications                  |
+| `default`      | `workspace-write`  | `on-request` | Workspace edits with approval for writes (recommended)  |
+| `auto`         | `workspace-write`  | `on-failure` | Autonomous edits, only ask when risk is high            |
+| `full-access`  | `full-access`      | `never`      | Trusted automation, no gating (use with care)           |
 
-### Denylist vs Allowlist
+### Sandbox modes
 
-- **Denylist mode** (`allow: ['*']`): All capabilities exposed; use `deny` array and security rules to block specific tools or risky operations. `auto-review` uses this mode — new tools are automatically available without config changes.
-- **Allowlist mode** (explicit `allow` list): Only listed capabilities are exposed; unlisted tools are denied.
+| Mode               | Allowed tools                                  | Denied tools          |
+|--------------------|------------------------------------------------|-----------------------|
+| `read-only`        | `read`, `ls`, `find`, `grep`                   | `write`, `edit`, `bash` |
+| `workspace-write`  | `read`, `ls`, `find`, `grep`, `write`, `edit`  | `bash`                |
+| `full-access`      | `*` (all tools)                                | —                     |
 
-Custom profiles can override capability policies via settings:
+Tool names align with the pi-coding-agent built-in tools: `bash`, `read`, `write`, `edit`, `ls`, `find`, `grep`.
 
-```json
-{
-  "pi-security": {
-    "security": {
-      "profiles": {
-        "auto-review": {
-          "capabilities": {
-            "deny": ["sessions_spawn"]
-          }
-        }
-      }
-    }
-  }
-}
+### Approval modes
+
+| Mode          | Behavior                                                                  |
+|---------------|---------------------------------------------------------------------------|
+| `never`       | No approval prompts (deny rules still apply, e.g. for secrets).           |
+| `on-failure`  | Ask only on high/critical risk operations.                                |
+| `on-request`  | Ask on workspace writes/deletes (in addition to high-risk ops).           |
+| `untrusted`   | Ask on workspace writes plus high-risk ops; default decision is also ask. |
+
+Baseline secret protection (denying `.ssh/`, `.env`, `*.pem`, `*.key`, etc.) is always enabled, regardless of profile.
+
+## Custom profiles
+
+Profiles can be defined in three places. Higher-priority sources override lower-priority ones with the same name:
+
+1. **Project**: `<cwd>/.pi/policy/<name>.json` (highest priority)
+2. **Agent**: `<agentDir>/policy/<name>.json`
+3. **User**: `~/.pi/agent/policy/<name>.json`
+4. **Settings**: under `pi-security.security.profiles` in `pi.json`
+
+Each JSON file defines a single profile; the filename (without `.json`) is the profile name.
+
+### JSON config examples
+
+Ready-to-copy samples live under [`examples/`](./examples) and are exercised by the test suite:
+
+- [`examples/reviewer.json`](./examples/reviewer.json) — a project-level file policy. Drop into `<project>/.pi/policy/reviewer.json`. Starts from `read-only`, opens to `workspace-write`, asks on `bash`, denies external network.
+- [`examples/auto-review.settings.json`](./examples/auto-review.settings.json) — a `pi.json` snippet that defines a custom `auto-review` profile inline. Extends `default` and asks before package-manager installs (`npm/pnpm/yarn/pip install|add`) via `argsRegex`.
+
+### Profile schema
+
+```ts
+type SecurityProfileConfig = {
+  extends?: string;                   // built-in profile name or another custom profile
+  sandbox?: 'read-only' | 'workspace-write' | 'full-access';
+  approval?: 'never' | 'on-failure' | 'on-request' | 'untrusted';
+  rules?: SecurityRule[];             // appended after parent rules
+  defaultDecision?: SecurityDecision; // overrides parent default for unmatched tools
+};
+```
+
+### Rule schema
+
+Rules are evaluated in priority order (descending); the first match wins.
+
+```ts
+type SecurityRule = {
+  id: string;
+  enabled?: boolean;
+  priority?: number;                  // default 300 for user rules
+  tools?: string[];                   // tool name patterns ('*', 'mcp_*', 'bash')
+  sources?: ToolSource[];             // 'builtin' | 'mcp' | 'runtime'
+  triggers?: Array<'user' | 'agent' | 'scheduler'>;
+  senderTrusts?: Array<'owner' | 'trusted' | 'untrusted'>;
+  args?: Record<string, string>;      // exact/glob match against args
+  argsRegex?: Record<string, string>; // regex match against args
+  resources?: ('file' | 'shell' | 'network')[];
+  operations?: ('read' | 'write' | 'execute' | 'delete' | 'connect' | 'search')[];
+  scopes?: ('workspace' | 'home' | 'system' | 'external' | 'unknown')[];
+  sensitivity?: ('normal' | 'source' | 'config' | 'secret' | 'credential')[];
+  risk?: ('low' | 'medium' | 'high' | 'critical')[];
+  decision: { kind: 'allow' } | { kind: 'deny'; reason: string } | { kind: 'ask'; reason: string; prompt?: string };
+};
 ```
 
 ## Commands
@@ -81,6 +116,6 @@ Custom profiles can override capability policies via settings:
 
 ## Trust model
 
-This module is an execution gate, not a filesystem sandbox by itself. Deny and approval decisions are enforceable because they run before Pi tool execution. Constraint decisions must be paired with a runtime that actually enforces the returned constraints.
+This module is an execution gate, not a filesystem sandbox by itself. Deny and approval decisions are enforceable because they run before Pi tool execution; sandbox enforcement still depends on the runtime that executes the tool.
 
-Sensitive paths such as SSH keys, `.env`, credentials, tokens, private keys, and secret files are denied by baseline policy. Audit entries include tool names, resource summaries, risk level, and decision metadata, but they should not include plaintext secrets.
+Sensitive paths such as SSH keys, `.env`, credentials, tokens, private keys, and `secrets/` directories are denied by baseline policy across all profiles. Audit entries include tool names, resource summaries, risk level, and decision metadata, but they should not include plaintext secrets.

--- a/packages/pi-security/README.md
+++ b/packages/pi-security/README.md
@@ -91,7 +91,6 @@ Rules are evaluated in priority order (descending); the first match wins.
 ```ts
 type SecurityRule = {
   id: string;
-  enabled?: boolean;
   priority?: number;                  // default 300 for user rules
   tools?: string[];                   // tool name patterns ('*', 'mcp_*', 'bash')
   sources?: ToolSource[];             // 'builtin' | 'mcp' | 'runtime'

--- a/packages/pi-security/examples/auto-review.settings.json
+++ b/packages/pi-security/examples/auto-review.settings.json
@@ -1,0 +1,24 @@
+{
+  "pi-security": {
+    "enabled": true,
+    "profile": "auto-review",
+    "security": {
+      "profiles": {
+        "auto-review": {
+          "extends": "default",
+          "rules": [
+            {
+              "id": "ask-package-install",
+              "priority": 450,
+              "tools": ["bash"],
+              "argsRegex": {
+                "command": "(npm|pnpm|yarn|pip)\\s+(install|add)"
+              },
+              "decision": { "kind": "ask", "reason": "Approve package install?" }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/packages/pi-security/examples/reviewer.json
+++ b/packages/pi-security/examples/reviewer.json
@@ -1,0 +1,19 @@
+{
+  "extends": "read-only",
+  "sandbox": "workspace-write",
+  "approval": "on-request",
+  "rules": [
+    {
+      "id": "ask-bash",
+      "priority": 400,
+      "tools": ["bash"],
+      "decision": { "kind": "ask", "reason": "Shell needs approval" }
+    },
+    {
+      "id": "deny-network",
+      "priority": 500,
+      "resources": ["network"],
+      "decision": { "kind": "deny", "reason": "External network is blocked" }
+    }
+  ]
+}

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for resource-aware security policy engine and tool authorization",
   "keywords": ["pi-package", "pi", "extension", "security", "policy", "authorization", "access-control"],
   "license": "Apache-2.0",

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "dist",
+    "examples",
     "README.md"
   ],
   "pi": {

--- a/packages/pi-security/src/__tests__/policy-loader.test.ts
+++ b/packages/pi-security/src/__tests__/policy-loader.test.ts
@@ -21,16 +21,16 @@ describe('loadPolicyDir', () => {
     writeFileSync(
       join(dir, 'reviewer.json'),
       JSON.stringify({
-        extends: 'workspace-read',
-        capabilities: { allow: ['mcp__github__*'] },
+        extends: 'read-only',
+        sandbox: 'workspace-write',
       }),
     );
-    writeFileSync(join(dir, 'minimal.json'), JSON.stringify({ extends: 'copilot' }));
+    writeFileSync(join(dir, 'minimal.json'), JSON.stringify({ extends: 'full-access' }));
 
     const result = loadPolicyDir(dir);
     expect(result).toEqual({
-      reviewer: { extends: 'workspace-read', capabilities: { allow: ['mcp__github__*'] } },
-      minimal: { extends: 'copilot' },
+      reviewer: { extends: 'read-only', sandbox: 'workspace-write' },
+      minimal: { extends: 'full-access' },
     });
   });
 
@@ -40,15 +40,15 @@ describe('loadPolicyDir', () => {
 
   it('skips malformed JSON files', () => {
     writeFileSync(join(dir, 'bad.json'), '{ invalid json !!!');
-    writeFileSync(join(dir, 'good.json'), JSON.stringify({ extends: 'chat' }));
+    writeFileSync(join(dir, 'good.json'), JSON.stringify({ extends: 'read-only' }));
 
     const result = loadPolicyDir(dir);
-    expect(result).toEqual({ good: { extends: 'chat' } });
+    expect(result).toEqual({ good: { extends: 'read-only' } });
   });
 
   it('skips non-JSON files', () => {
     writeFileSync(join(dir, 'notes.txt'), 'not a policy');
-    writeFileSync(join(dir, 'valid.json'), JSON.stringify({ extends: 'admin' }));
+    writeFileSync(join(dir, 'valid.json'), JSON.stringify({ extends: 'full-access' }));
 
     const result = loadPolicyDir(dir);
     expect(Object.keys(result)).toEqual(['valid']);
@@ -69,10 +69,10 @@ describe('loadPolicyDir', () => {
   });
 
   it('uses filename without extension as profile name', () => {
-    writeFileSync(join(dir, 'my-custom-profile.json'), JSON.stringify({ extends: 'chat' }));
+    writeFileSync(join(dir, 'my-custom-profile.json'), JSON.stringify({ extends: 'read-only' }));
 
     const result = loadPolicyDir(dir);
-    expect(result['my-custom-profile']).toEqual({ extends: 'chat' });
+    expect(result['my-custom-profile']).toEqual({ extends: 'read-only' });
     expect(result['my-custom-profile.json']).toBeUndefined();
   });
 
@@ -80,8 +80,9 @@ describe('loadPolicyDir', () => {
     writeFileSync(
       join(dir, 'full.json'),
       JSON.stringify({
-        extends: 'workspace-read',
-        capabilities: { allow: ['read_file'], deny: ['run_shell'] },
+        extends: 'read-only',
+        sandbox: 'workspace-write',
+        approval: 'untrusted',
         rules: [
           {
             id: 'custom-rule',
@@ -96,8 +97,9 @@ describe('loadPolicyDir', () => {
 
     const result = loadPolicyDir(dir);
     expect(result.full).toMatchObject({
-      extends: 'workspace-read',
-      capabilities: { allow: ['read_file'], deny: ['run_shell'] },
+      extends: 'read-only',
+      sandbox: 'workspace-write',
+      approval: 'untrusted',
       rules: [{ id: 'custom-rule' }],
       defaultDecision: { kind: 'deny', reason: 'locked' },
     });
@@ -135,40 +137,46 @@ describe('loadFilePolicies', () => {
   it('project-level policies override user-level policies', () => {
     writeFileSync(
       join(userDir, 'custom.json'),
-      JSON.stringify({ extends: 'chat', capabilities: { allow: ['memory_search'] } }),
+      JSON.stringify({ extends: 'read-only', sandbox: 'read-only' }),
     );
     writeFileSync(
       join(projectDir, 'custom.json'),
-      JSON.stringify({ extends: 'copilot', capabilities: { allow: ['*'] } }),
+      JSON.stringify({ extends: 'full-access', sandbox: 'full-access' }),
     );
 
     const result = loadFilePolicies(cwd);
-    expect(result.custom).toEqual({ extends: 'copilot', capabilities: { allow: ['*'] } });
+    expect(result.custom).toEqual({ extends: 'full-access', sandbox: 'full-access' });
   });
 
   it('merges profiles from both directories', () => {
-    writeFileSync(join(userDir, 'user-only.json'), JSON.stringify({ extends: 'chat' }));
-    writeFileSync(join(projectDir, 'project-only.json'), JSON.stringify({ extends: 'admin' }));
+    writeFileSync(join(userDir, 'user-only.json'), JSON.stringify({ extends: 'read-only' }));
+    writeFileSync(
+      join(projectDir, 'project-only.json'),
+      JSON.stringify({ extends: 'full-access' }),
+    );
 
     const result = loadFilePolicies(cwd);
-    expect(result['user-only']).toEqual({ extends: 'chat' });
-    expect(result['project-only']).toEqual({ extends: 'admin' });
+    expect(result['user-only']).toEqual({ extends: 'read-only' });
+    expect(result['project-only']).toEqual({ extends: 'full-access' });
   });
 
   it('works when only user-level directory exists', () => {
     rmSync(projectDir, { recursive: true });
-    writeFileSync(join(userDir, 'only-user.json'), JSON.stringify({ extends: 'chat' }));
+    writeFileSync(join(userDir, 'only-user.json'), JSON.stringify({ extends: 'read-only' }));
 
     const result = loadFilePolicies(cwd);
-    expect(result['only-user']).toEqual({ extends: 'chat' });
+    expect(result['only-user']).toEqual({ extends: 'read-only' });
   });
 
   it('works when only project-level directory exists', () => {
     rmSync(userDir, { recursive: true });
-    writeFileSync(join(projectDir, 'only-project.json'), JSON.stringify({ extends: 'admin' }));
+    writeFileSync(
+      join(projectDir, 'only-project.json'),
+      JSON.stringify({ extends: 'full-access' }),
+    );
 
     const result = loadFilePolicies(cwd);
-    expect(result['only-project']).toEqual({ extends: 'admin' });
+    expect(result['only-project']).toEqual({ extends: 'full-access' });
   });
 
   it('returns empty when neither directory exists', () => {
@@ -210,38 +218,44 @@ describe('loadFilePolicies 3-layer with agentDir', () => {
 
   it('agentDir policy is loaded via loadFilePolicies', () => {
     writeFileSync(
-      join(agentPolicyDir, 'sandbox-exec.json'),
+      join(agentPolicyDir, 'agent-profile.json'),
       JSON.stringify({
-        capabilities: { allow: ['browser_*'] },
+        sandbox: 'workspace-write',
+        approval: 'on-request',
       }),
     );
 
     const result = loadFilePolicies(cwd, agentDir);
-    expect(result['sandbox-exec']).toEqual({
-      capabilities: { allow: ['browser_*'] },
+    expect(result['agent-profile']).toEqual({
+      sandbox: 'workspace-write',
+      approval: 'on-request',
     });
   });
 
   it('project policy overrides agentDir policy', () => {
-    writeFileSync(join(agentPolicyDir, 'custom.json'), JSON.stringify({ extends: 'chat' }));
-    writeFileSync(join(projectPolicyDir, 'custom.json'), JSON.stringify({ extends: 'admin' }));
+    writeFileSync(join(agentPolicyDir, 'custom.json'), JSON.stringify({ extends: 'read-only' }));
+    writeFileSync(
+      join(projectPolicyDir, 'custom.json'),
+      JSON.stringify({ extends: 'full-access' }),
+    );
 
     const result = loadFilePolicies(cwd, agentDir);
-    expect(result.custom).toEqual({ extends: 'admin' });
+    expect(result.custom).toEqual({ extends: 'full-access' });
   });
 
-  it('sandbox-exec.json merges browser_* into built-in sandbox-exec capabilities', () => {
+  it('agentDir profile resolves to expected capabilities', () => {
     writeFileSync(
-      join(agentPolicyDir, 'sandbox-exec.json'),
+      join(agentPolicyDir, 'agent-profile.json'),
       JSON.stringify({
-        capabilities: { allow: ['browser_*'] },
+        extends: 'read-only',
+        sandbox: 'workspace-write',
       }),
     );
 
     const filePolicies = loadFilePolicies(cwd, agentDir);
-    const policy = resolveCapabilityPolicy('sandbox-exec', {}, filePolicies);
-    expect(isCapabilityExposed('browser_list_pages', policy)).toBe(true);
-    expect(isCapabilityExposed('read_file', policy)).toBe(true);
-    expect(isCapabilityExposed('run_shell', policy)).toBe(true);
+    const policy = resolveCapabilityPolicy('agent-profile', {}, filePolicies);
+    expect(isCapabilityExposed('read', policy)).toBe(true);
+    expect(isCapabilityExposed('write', policy)).toBe(true);
+    expect(isCapabilityExposed('bash', policy)).toBe(false);
   });
 });

--- a/packages/pi-security/src/__tests__/readme-examples.test.ts
+++ b/packages/pi-security/src/__tests__/readme-examples.test.ts
@@ -1,0 +1,141 @@
+import { copyFileSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { RuntimeRequestContext, ToolCallRequest } from '@amaster.ai/pi-shared';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createSecurityPolicyEngineForProfile,
+  isCapabilityExposed,
+  resolveCapabilityPolicy,
+  type SecurityConfig,
+} from '../index.js';
+import { loadFilePolicies } from '../policy-loader.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EXAMPLES_DIR = resolve(__dirname, '..', '..', 'examples');
+
+const request: RuntimeRequestContext = {
+  sessionId: 'session-1',
+  conversationId: 'conversation-1',
+  trigger: 'user',
+  senderTrust: 'owner',
+  interactive: true,
+  model: { provider: 'test', model: 'test-model' },
+};
+
+function tool(
+  name: string,
+  source: ToolCallRequest['source'],
+  args: ToolCallRequest['args'],
+): ToolCallRequest {
+  return { id: `${name}-1`, name, source, args };
+}
+
+describe('examples/reviewer.json', () => {
+  let cwd: string;
+  let projectPolicyDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    const base = join(tmpdir(), `pi-readme-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    cwd = join(base, 'project');
+    projectPolicyDir = join(cwd, '.pi', 'policy');
+    mkdirSync(projectPolicyDir, { recursive: true });
+    mkdirSync(join(base, 'home'), { recursive: true });
+    originalHome = process.env.HOME;
+    process.env.HOME = join(base, 'home');
+
+    copyFileSync(join(EXAMPLES_DIR, 'reviewer.json'), join(projectPolicyDir, 'reviewer.json'));
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    }
+    rmSync(join(cwd, '..'), { recursive: true, force: true });
+  });
+
+  it('exposes workspace-write capabilities (read + write, not bash)', () => {
+    const filePolicies = loadFilePolicies(cwd);
+    const policy = resolveCapabilityPolicy('reviewer', {}, filePolicies);
+    expect(isCapabilityExposed('read', policy)).toBe(true);
+    expect(isCapabilityExposed('write', policy)).toBe(true);
+    expect(isCapabilityExposed('edit', policy)).toBe(true);
+    expect(isCapabilityExposed('bash', policy)).toBe(false);
+  });
+
+  it('asks for approval on bash via custom rule', () => {
+    const filePolicies = loadFilePolicies(cwd);
+    const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
+    const result = engine.evaluate({
+      request,
+      toolCall: tool('bash', 'builtin', { command: 'ls' }),
+    });
+    expect(result.decision).toMatchObject({ kind: 'ask', reason: 'Shell needs approval' });
+    expect(result.matchedRuleIds).toContain('ask-bash');
+  });
+
+  it('denies bash commands that touch external network', () => {
+    const filePolicies = loadFilePolicies(cwd);
+    const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
+    const result = engine.evaluate({
+      request,
+      toolCall: tool('bash', 'builtin', { command: 'curl https://example.test' }),
+    });
+    expect(result.decision).toMatchObject({ kind: 'deny', reason: 'External network is blocked' });
+    expect(result.matchedRuleIds).toContain('deny-network');
+  });
+
+  it('asks for approval on workspace writes (inherited from on-request approval)', () => {
+    const filePolicies = loadFilePolicies(cwd);
+    const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
+    const result = engine.evaluate({
+      request,
+      workspaceDir: cwd,
+      toolCall: tool('write', 'builtin', { path: join(cwd, 'a.txt'), content: 'x' }),
+    });
+    expect(result.decision.kind).toBe('ask');
+    expect(result.matchedRuleIds).toContain('ask-workspace-write');
+  });
+
+  it('still denies secret reads (baseline rule inherited from read-only)', () => {
+    const filePolicies = loadFilePolicies(cwd);
+    const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
+    const result = engine.evaluate({
+      request,
+      toolCall: tool('read', 'builtin', {
+        path: `${process.env.HOME ?? '/Users/me'}/.ssh/id_rsa`,
+      }),
+    });
+    expect(result.decision).toMatchObject({ kind: 'deny' });
+    expect(result.matchedRuleIds).toContain('deny-secrets');
+  });
+});
+
+describe('examples/auto-review.settings.json', () => {
+  const settings = JSON.parse(
+    readFileSync(join(EXAMPLES_DIR, 'auto-review.settings.json'), 'utf-8'),
+  ) as { 'pi-security': { profile: string; security: SecurityConfig } };
+  const profileName = settings['pi-security'].profile;
+  const config = settings['pi-security'].security;
+
+  it('asks for approval on matching package install commands', () => {
+    const engine = createSecurityPolicyEngineForProfile(profileName, config);
+    const result = engine.evaluate({
+      request,
+      toolCall: tool('bash', 'builtin', { command: 'pnpm install lodash' }),
+    });
+    expect(result.decision).toMatchObject({ kind: 'ask', reason: 'Approve package install?' });
+    expect(result.matchedRuleIds).toContain('ask-package-install');
+  });
+
+  it('does not match unrelated bash commands via argsRegex', () => {
+    const engine = createSecurityPolicyEngineForProfile(profileName, config);
+    const result = engine.evaluate({
+      request,
+      toolCall: tool('bash', 'builtin', { command: 'ls -la' }),
+    });
+    expect(result.matchedRuleIds).not.toContain('ask-package-install');
+  });
+});

--- a/packages/pi-security/src/extension.ts
+++ b/packages/pi-security/src/extension.ts
@@ -137,7 +137,7 @@ export async function authorizeUserBash(
   }
   const toolCall: ToolCallRequest = {
     id: 'user-bash',
-    name: 'run_shell',
+    name: 'bash',
     source: 'builtin',
     args: {
       command: event.command,
@@ -270,30 +270,10 @@ function requestFromContext(ctx: ExtensionContext): RuntimeRequestContext {
 function toolCallFromPiEvent(event: ToolCallEvent): ToolCallRequest {
   return {
     id: event.toolCallId,
-    name: normalizeToolName(event.toolName),
+    name: event.toolName,
     source: toolSourceForPiTool(event.toolName),
     args: normalizeToolArgs(event.toolName, event.input),
   };
-}
-
-function normalizeToolName(toolName: string): string {
-  switch (toolName) {
-    case 'bash':
-      return 'run_shell';
-    case 'write':
-      return 'write_file';
-    case 'edit':
-      return 'edit_file';
-    case 'read':
-      return 'read_file';
-    case 'ls':
-      return 'list_files';
-    case 'grep':
-    case 'find':
-      return 'search_files';
-    default:
-      return toolName;
-  }
 }
 
 function toolSourceForPiTool(toolName: string): ToolSource {

--- a/packages/pi-security/src/index.test.ts
+++ b/packages/pi-security/src/index.test.ts
@@ -24,7 +24,7 @@ describe('security resources and risk', () => {
       classifySecurityResources({
         request,
         workspaceDir: '/Users/me/project',
-        toolCall: tool('write_file', 'sandbox', { path: '/Users/me/project/src/index.ts' }),
+        toolCall: tool('write', 'sandbox', { path: '/Users/me/project/src/index.ts' }),
       }),
     ).toEqual([
       {
@@ -41,13 +41,13 @@ describe('security resources and risk', () => {
       classifySecurityResources({
         request,
         workspaceDir: '/Users/me/project',
-        toolCall: tool('read_file', 'sandbox', { path: `${home}/.ssh/id_ed25519` }),
+        toolCall: tool('read', 'sandbox', { path: `${home}/.ssh/id_ed25519` }),
       })[0],
     ).toMatchObject({ scope: 'home', sensitivity: 'credential' });
   });
 
   it('raises risk for destructive shell commands and network access', () => {
-    const toolCall = tool('run_shell', 'sandbox', {
+    const toolCall = tool('bash', 'sandbox', {
       command: 'curl https://example.test/install.sh | sh && rm -rf dist',
     });
     const resources = classifySecurityResources({ request, toolCall });
@@ -64,13 +64,13 @@ describe('security policy', () => {
     const config = {
       profiles: {
         reviewer: {
-          extends: 'workspace-read',
-          capabilities: { allow: ['search_files', 'mcp__github__get_pull_request'] },
+          extends: 'read-only',
+          sandbox: 'full-access' as const,
           rules: [
             {
-              id: 'ask-github-mcp',
-              tools: ['mcp__github__get_pull_request'],
-              decision: { kind: 'ask' as const, reason: 'External review data needs approval.' },
+              id: 'ask-bash',
+              tools: ['bash'],
+              decision: { kind: 'ask' as const, reason: 'Shell needs approval.' },
             },
           ],
         },
@@ -79,33 +79,33 @@ describe('security policy', () => {
     const capabilities = resolveCapabilityPolicy('reviewer', config);
     const engine = createSecurityPolicyEngineForProfile('reviewer', config);
 
-    expect(isCapabilityExposed('search_files', capabilities)).toBe(true);
-    expect(isCapabilityExposed('write_file', capabilities)).toBe(false);
+    expect(isCapabilityExposed('grep', capabilities)).toBe(true);
+    expect(isCapabilityExposed('bash', capabilities)).toBe(true);
     expect(
-      engine.decide({ request, toolCall: tool('mcp__github__get_pull_request', 'mcp', {}) }),
+      engine.decide({ request, toolCall: tool('bash', 'sandbox', { command: 'ls' }) }),
     ).toEqual({
       kind: 'ask',
-      reason: 'External review data needs approval.',
+      reason: 'Shell needs approval.',
     });
   });
 
   it('turns ask decisions into denials for non-interactive contexts', () => {
-    const engine = createSecurityPolicyEngineForProfile('auto-review');
+    const engine = createSecurityPolicyEngineForProfile('default');
     const decision = engine.decide({
       request: { ...request, interactive: false },
       workspaceDir: '/repo',
-      toolCall: tool('write_file', 'sandbox', { path: 'a.txt', content: 'x' }),
+      toolCall: tool('write', 'sandbox', { path: 'a.txt', content: 'x' }),
     });
 
     expect(decision.kind).toBe('deny');
   });
 
   it('applies baseline secret protection to read-oriented profiles', () => {
-    const engine = createSecurityPolicyEngineForProfile('workspace-read');
+    const engine = createSecurityPolicyEngineForProfile('read-only');
     expect(
       engine.decide({
         request,
-        toolCall: tool('read_file', 'sandbox', {
+        toolCall: tool('read', 'sandbox', {
           path: `${process.env.HOME ?? '/Users/me'}/.ssh/id_rsa`,
         }),
       }),
@@ -117,7 +117,7 @@ describe('SecurityGate', () => {
   it('orchestrates approval and emits audit details', async () => {
     const audits: unknown[] = [];
     const gate = new SecurityGate({
-      profile: 'auto-review',
+      profile: 'default',
       approvalHandler: async ({ decision }) => ({
         kind: 'allow',
         reason: `approved: ${decision.reason}`,
@@ -130,7 +130,7 @@ describe('SecurityGate', () => {
     const evaluation = await gate.authorize({
       request,
       workspaceDir: '/repo',
-      toolCall: tool('write_file', 'sandbox', { path: 'a.txt', content: 'x' }),
+      toolCall: tool('write', 'sandbox', { path: 'a.txt', content: 'x' }),
     });
 
     expect(evaluation.decision).toEqual({
@@ -154,48 +154,47 @@ function tool(
 describe('file-based policy resolution', () => {
   it('file policies take priority over settings profiles', () => {
     const filePolicies = {
-      custom: { capabilities: { allow: ['read_file'] } },
+      custom: { sandbox: 'read-only' as const },
     };
     const config = {
-      profiles: { custom: { capabilities: { allow: ['write_file', 'run_shell'] } } },
+      profiles: { custom: { sandbox: 'full-access' as const } },
     };
 
     const policy = resolveCapabilityPolicy('custom', config, filePolicies);
-    expect(policy.allow).toContain('read_file');
-    expect(policy.allow).not.toContain('write_file');
+    expect(policy.allow).toContain('read');
+    expect(policy.allow).not.toContain('*');
   });
 
   it('file policy extends built-in profile', () => {
     const filePolicies = {
-      'my-profile': { extends: 'admin', capabilities: { deny: ['run_shell'] } },
+      'my-profile': { extends: 'full-access' as const, approval: 'untrusted' as const },
     };
 
     const policy = resolveCapabilityPolicy('my-profile', {}, filePolicies);
     expect(policy.allow).toContain('*');
-    expect(policy.deny).toContain('run_shell');
   });
 
   it('file policy extends another file policy', () => {
     const filePolicies = {
-      base: { capabilities: { allow: ['read_file', 'list_files'] } },
-      child: { extends: 'base', capabilities: { allow: ['write_file'] } },
+      base: { sandbox: 'read-only' as const },
+      child: { extends: 'base', sandbox: 'workspace-write' as const },
     };
 
     const policy = resolveCapabilityPolicy('child', {}, filePolicies);
-    expect(policy.allow).toContain('read_file');
-    expect(policy.allow).toContain('list_files');
-    expect(policy.allow).toContain('write_file');
+    expect(policy.allow).toContain('read');
+    expect(policy.allow).toContain('ls');
+    expect(policy.allow).toContain('write');
   });
 
   it('falls back to built-in when no file or settings profile exists', () => {
-    const policy = resolveCapabilityPolicy('admin', {}, {});
+    const policy = resolveCapabilityPolicy('full-access', {}, {});
     expect(policy.allow).toContain('*');
   });
 
   it('engine uses file policies for authorization', () => {
     const filePolicies = {
       strict: {
-        capabilities: { allow: ['read_file'] },
+        sandbox: 'read-only' as const,
         defaultDecision: { kind: 'deny' as const, reason: 'Strict profile' },
       },
     };
@@ -203,53 +202,52 @@ describe('file-based policy resolution', () => {
     const engine = createSecurityPolicyEngineForProfile('strict', {}, filePolicies);
     const allowed = engine.evaluate({
       request,
-      toolCall: tool('read_file', 'sandbox', { path: '/a.txt' }),
+      toolCall: tool('read', 'sandbox', { path: '/a.txt' }),
     });
     expect(allowed.decision.kind).toBe('allow');
 
     const denied = engine.evaluate({
       request,
-      toolCall: tool('write_file', 'sandbox', { path: '/a.txt', content: '' }),
+      toolCall: tool('write', 'sandbox', { path: '/a.txt', content: '' }),
     });
     expect(denied.decision.kind).toBe('deny');
   });
 
   it('circular extends in file policies returns safe default', () => {
     const filePolicies = {
-      a: { extends: 'b', capabilities: { allow: ['read_file'] } },
-      b: { extends: 'a', capabilities: { allow: ['write_file'] } },
+      a: { extends: 'b', sandbox: 'read-only' as const },
+      b: { extends: 'a', sandbox: 'full-access' as const },
     };
 
     const policy = resolveCapabilityPolicy('a', {}, filePolicies);
     expect(policy).toBeDefined();
-    expect(policy.deny).toContain('run_shell');
+    expect(policy.deny).toContain('bash');
   });
 
   it('file policy extends a settings profile', () => {
     const filePolicies = {
-      custom: { extends: 'from-settings', capabilities: { allow: ['run_shell'] } },
+      custom: { extends: 'from-settings', approval: 'untrusted' as const },
     };
     const config = {
       profiles: {
-        'from-settings': { capabilities: { allow: ['read_file', 'write_file'] } },
+        'from-settings': { sandbox: 'workspace-write' as const },
       },
     };
 
     const policy = resolveCapabilityPolicy('custom', config, filePolicies);
-    expect(policy.allow).toContain('read_file');
-    expect(policy.allow).toContain('write_file');
-    expect(policy.allow).toContain('run_shell');
+    expect(policy.allow).toContain('read');
+    expect(policy.allow).toContain('write');
   });
 
   it('file policy with custom rules are appended to parent rules', () => {
     const filePolicies = {
       'with-rules': {
-        extends: 'admin',
+        extends: 'full-access' as const,
         rules: [
           {
             id: 'ask-shell',
             priority: 400,
-            tools: ['run_shell'],
+            tools: ['bash'],
             decision: { kind: 'ask' as const, reason: 'Shell needs approval' },
           },
         ],
@@ -259,7 +257,7 @@ describe('file-based policy resolution', () => {
     const engine = createSecurityPolicyEngineForProfile('with-rules', {}, filePolicies);
     const result = engine.evaluate({
       request,
-      toolCall: tool('run_shell', 'sandbox', { command: 'ls' }),
+      toolCall: tool('bash', 'sandbox', { command: 'ls' }),
     });
     expect(result.decision.kind).toBe('ask');
     expect(result.matchedRuleIds).toContain('ask-shell');
@@ -268,7 +266,7 @@ describe('file-based policy resolution', () => {
   it('file policy defaultDecision overrides parent', () => {
     const filePolicies = {
       strict: {
-        extends: 'workspace-read',
+        extends: 'read-only' as const,
         defaultDecision: { kind: 'deny' as const, reason: 'Strict deny by default' },
       },
     };
@@ -276,7 +274,7 @@ describe('file-based policy resolution', () => {
     const engine = createSecurityPolicyEngineForProfile('strict', {}, filePolicies);
     const result = engine.evaluate({
       request,
-      toolCall: tool('run_shell', 'sandbox', { command: 'echo hi' }),
+      toolCall: tool('unknown_tool', 'sandbox', {}),
     });
     expect(result.decision.kind).toBe('deny');
     expect(result.decision).toMatchObject({ reason: 'Strict deny by default' });
@@ -285,7 +283,7 @@ describe('file-based policy resolution', () => {
   it('SecurityGate accepts filePolicies option', async () => {
     const filePolicies = {
       locked: {
-        capabilities: { allow: ['read_file'] },
+        sandbox: 'read-only' as const,
         defaultDecision: { kind: 'deny' as const, reason: 'Locked profile' },
       },
     };
@@ -297,33 +295,30 @@ describe('file-based policy resolution', () => {
 
     const allowed = await gate.authorize({
       request,
-      toolCall: tool('read_file', 'sandbox', { path: '/a.txt' }),
+      toolCall: tool('read', 'sandbox', { path: '/a.txt' }),
     });
     expect(allowed.decision.kind).toBe('allow');
 
     const denied = await gate.authorize({
       request,
-      toolCall: tool('write_file', 'sandbox', { path: '/a.txt', content: '' }),
+      toolCall: tool('write', 'sandbox', { path: '/a.txt', content: '' }),
     });
     expect(denied.decision.kind).toBe('deny');
   });
 
   it('three-level extends chain: file → file → built-in', () => {
     const filePolicies = {
-      grandchild: { extends: 'child', capabilities: { allow: ['run_code'] } },
-      child: { extends: 'workspace-read', capabilities: { allow: ['search_files'] } },
+      grandchild: { extends: 'child', sandbox: 'full-access' as const },
+      child: { extends: 'read-only' as const, approval: 'untrusted' as const },
     };
 
     const policy = resolveCapabilityPolicy('grandchild', {}, filePolicies);
-    expect(policy.allow).toContain('read_file');
-    expect(policy.allow).toContain('list_files');
-    expect(policy.allow).toContain('search_files');
-    expect(policy.allow).toContain('run_code');
+    expect(policy.allow).toContain('*');
   });
 
   it('empty file policies object has no effect on resolution', () => {
-    const withEmpty = resolveCapabilityPolicy('copilot', {}, {});
-    const without = resolveCapabilityPolicy('copilot', {});
+    const withEmpty = resolveCapabilityPolicy('default', {}, {});
+    const without = resolveCapabilityPolicy('default', {});
     expect(withEmpty).toEqual(without);
   });
 });

--- a/packages/pi-security/src/index.ts
+++ b/packages/pi-security/src/index.ts
@@ -41,7 +41,6 @@ export type RiskAssessment = {
 
 export type SecurityRule = {
   id: string;
-  enabled?: boolean;
   priority?: number;
   tools?: string[];
   sources?: ToolSource[];
@@ -579,18 +578,13 @@ function resolveSecurityProfile(
 }
 
 function normalizeConfiguredRules(rules: SecurityRule[] | undefined): SecurityRule[] {
-  return (rules ?? [])
-    .filter((rule) => rule.enabled !== false)
-    .map((rule) => ({
-      ...rule,
-      priority: rule.priority ?? 300,
-    }));
+  return (rules ?? []).map((rule) => ({
+    ...rule,
+    priority: rule.priority ?? 300,
+  }));
 }
 
 function matchesSecurityRule(rule: SecurityRule, context: SecurityEvaluationContext): boolean {
-  if (rule.enabled === false) {
-    return false;
-  }
   if (
     rule.tools?.length &&
     !rule.tools.some((tool) => matchesPattern(context.toolCall.name, tool))

--- a/packages/pi-security/src/index.ts
+++ b/packages/pi-security/src/index.ts
@@ -10,50 +10,18 @@ import type {
 export type SecurityDecision =
   | { kind: 'allow'; reason?: string }
   | { kind: 'deny'; reason: string }
-  | { kind: 'ask'; reason: string; prompt?: string }
-  | { kind: 'sandbox_only'; reason: string; sandboxProfile: string }
-  | { kind: 'allow_with_constraints'; reason?: string; constraints: RuntimeConstraints };
-
-export type RuntimeConstraints = {
-  filesystem?: {
-    read?: 'workspace' | 'all' | 'deny';
-    write?: 'workspace' | 'all' | 'deny';
-    allowPaths?: string[];
-    denyPaths?: string[];
-  };
-  network?: {
-    mode: 'deny' | 'allowlist' | 'unrestricted';
-    allowedDomains?: string[];
-  };
-  shell?: {
-    timeoutMs?: number;
-    requireSandbox?: boolean;
-    denyPatterns?: string[];
-  };
-  output?: {
-    redactFields?: string[];
-    maxBytes?: number;
-  };
-};
+  | { kind: 'ask'; reason: string; prompt?: string };
 
 export type CapabilityPolicy = {
   allow?: string[];
   deny?: string[];
 };
 
-export type ConfiguredCapabilityPolicy = CapabilityPolicy & {
-  mode?: 'merge' | 'replace';
-};
+export type SandboxMode = 'read-only' | 'workspace-write' | 'full-access';
+export type ApprovalMode = 'never' | 'on-failure' | 'on-request' | 'untrusted';
 
-export type SecurityResourceKind = 'file' | 'shell' | 'network' | 'memory' | 'mcp' | 'subagent';
-export type SecurityOperation =
-  | 'read'
-  | 'write'
-  | 'execute'
-  | 'delete'
-  | 'connect'
-  | 'spawn'
-  | 'search';
+export type SecurityResourceKind = 'file' | 'shell' | 'network';
+export type SecurityOperation = 'read' | 'write' | 'execute' | 'delete' | 'connect' | 'search';
 export type SecurityScope = 'workspace' | 'home' | 'system' | 'external' | 'unknown';
 export type SecuritySensitivity = 'normal' | 'source' | 'config' | 'secret' | 'credential';
 export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
@@ -76,13 +44,9 @@ export type SecurityRule = {
   enabled?: boolean;
   priority?: number;
   tools?: string[];
-  tool?: string;
   sources?: ToolSource[];
-  source?: ToolSource;
   triggers?: Array<RuntimeRequestContext['trigger']>;
-  trigger?: RuntimeRequestContext['trigger'];
   senderTrusts?: Array<RuntimeRequestContext['senderTrust']>;
-  senderTrust?: RuntimeRequestContext['senderTrust'];
   args?: Record<string, string>;
   argsRegex?: Record<string, string>;
   resources?: SecurityResourceKind[];
@@ -100,7 +64,8 @@ export type SecurityPolicyEngineOptions = {
 
 export type SecurityProfileConfig = {
   extends?: string;
-  capabilities?: ConfiguredCapabilityPolicy;
+  sandbox?: SandboxMode;
+  approval?: ApprovalMode;
   rules?: SecurityRule[];
   defaultDecision?: SecurityDecision;
 };
@@ -166,137 +131,86 @@ const DEFAULT_DECISION: SecurityDecision = {
   reason: 'No security rule matched this tool call.',
 };
 
-const OPEN_SANDBOX_CAPABILITIES = [
-  'read_file',
-  'list_files',
-  'search_files',
-  'write_file',
-  'edit_file',
-  'run_shell',
-  'run_code',
-  'memory_search',
-  'memory_write',
-  'sessions_spawn',
-  'mcp:*',
-  'mcp_*',
-  'mcp__*',
-];
-
-const DEFAULT_CAPABILITY_POLICY: CapabilityPolicy = {
-  allow: ['memory_search'],
-  deny: ['run_shell', 'run_code', 'write_file'],
-};
-
-const BUILTIN_CAPABILITY_POLICIES: Record<string, CapabilityPolicy> = {
-  chat: DEFAULT_CAPABILITY_POLICY,
-  assistant: {
-    allow: ['memory_search', 'memory_write', 'mcp:*', 'mcp_*', 'mcp__*', 'scheduler:create'],
-    deny: ['run_shell', 'run_code'],
-  },
-  'workspace-read': {
-    allow: ['read_file', 'list_files', 'search_files', 'memory_search'],
-    deny: ['write_file', 'edit_file'],
+const SANDBOX_CAPABILITIES: Record<SandboxMode, CapabilityPolicy> = {
+  'read-only': {
+    allow: ['read', 'ls', 'find', 'grep'],
+    deny: ['write', 'edit', 'bash'],
   },
   'workspace-write': {
-    allow: ['read_file', 'list_files', 'search_files', 'write_file', 'edit_file', 'memory_search'],
-    deny: ['run_shell', 'run_code'],
+    allow: ['read', 'ls', 'find', 'grep', 'write', 'edit'],
+    deny: ['bash'],
   },
-  'sandbox-exec': { allow: ['*'] },
-  copilot: { allow: OPEN_SANDBOX_CAPABILITIES },
-  'auto-review': { allow: ['*'] },
-  default: {
-    allow: ['read_file', 'list_files', 'search_files', 'write_file', 'edit_file', 'memory_search'],
-    deny: ['run_shell', 'run_code'],
-  },
-  subagent: {
-    allow: OPEN_SANDBOX_CAPABILITIES.filter(
-      (capability) => capability !== 'memory_write' && capability !== 'sessions_spawn',
-    ),
-    deny: ['memory_write', 'sessions_spawn'],
-  },
-  scheduled: {
-    allow: ['memory_search', 'read_file', 'list_files', 'search_files', 'mcp:*', 'mcp_*', 'mcp__*'],
-    deny: ['scheduler:create', 'run_shell', 'run_code', 'write_file', 'edit_file'],
-  },
-  admin: { allow: ['*'] },
   'full-access': { allow: ['*'] },
 };
 
-const BASELINE_SECURITY_RULES: SecurityRule[] = [denySecretsRule()];
-
-const BUILTIN_SECURITY_RULES: Record<string, SecurityRule[]> = {
-  default: [
-    ...BASELINE_SECURITY_RULES,
-    {
-      id: 'ask-workspace-write',
-      priority: 260,
-      resources: ['file'],
-      operations: ['write', 'delete'],
-      scopes: ['workspace'],
-      decision: {
-        kind: 'ask',
-        reason: 'Workspace file modifications require approval.',
-        prompt: 'Approve this file modification?',
-      },
-    },
-  ],
-  'auto-review': [
-    ...BASELINE_SECURITY_RULES,
-    {
-      id: 'ask-critical-risk',
-      priority: 500,
-      risk: ['critical'],
-      decision: { kind: 'ask', reason: 'Critical risk operation requires approval.' },
-    },
-    {
-      id: 'ask-high-risk',
-      priority: 420,
-      risk: ['high'],
-      decision: { kind: 'ask', reason: 'High risk operation requires approval.' },
-    },
-    {
-      id: 'ask-workspace-write',
-      priority: 260,
-      resources: ['file'],
-      operations: ['write', 'delete'],
-      scopes: ['workspace'],
-      decision: {
-        kind: 'ask',
-        reason: 'Workspace file modifications require approval.',
-        prompt: 'Approve this file modification?',
-      },
-    },
-  ],
-  scheduled: [
-    ...BASELINE_SECURITY_RULES,
-    {
-      id: 'deny-non-read-scheduled',
-      priority: 420,
-      operations: ['write', 'execute', 'delete', 'spawn'],
-      decision: {
-        kind: 'deny',
-        reason: 'Scheduled runs cannot perform mutating or executable actions by default.',
-      },
-    },
-  ],
-  subagent: [
-    ...BASELINE_SECURITY_RULES,
-    {
-      id: 'deny-recursive-subagent-spawn',
-      priority: 500,
-      tools: ['sessions_spawn'],
-      decision: { kind: 'deny', reason: 'Subagents cannot spawn child sessions by default.' },
-    },
-    {
-      id: 'deny-subagent-memory-write',
-      priority: 420,
-      tools: ['memory_write'],
-      decision: { kind: 'deny', reason: 'Subagents cannot write durable memory by default.' },
-    },
-  ],
-  admin: [],
-  'full-access': [],
+const BUILTIN_PROFILES: Record<string, { sandbox: SandboxMode; approval: ApprovalMode }> = {
+  'read-only': { sandbox: 'read-only', approval: 'never' },
+  default: { sandbox: 'workspace-write', approval: 'on-request' },
+  auto: { sandbox: 'workspace-write', approval: 'on-failure' },
+  'full-access': { sandbox: 'full-access', approval: 'never' },
 };
+
+const DEFAULT_BUILTIN_PROFILE = BUILTIN_PROFILES.default as {
+  sandbox: SandboxMode;
+  approval: ApprovalMode;
+};
+
+const DENY_SECRETS_RULE: SecurityRule = {
+  id: 'deny-secrets',
+  priority: 600,
+  sensitivity: ['secret', 'credential'],
+  decision: { kind: 'deny', reason: 'Secret or credential resources are protected.' },
+};
+
+const BASELINE_SECURITY_RULES: SecurityRule[] = [DENY_SECRETS_RULE];
+
+const ASK_WORKSPACE_WRITE_RULE: SecurityRule = {
+  id: 'ask-workspace-write',
+  priority: 260,
+  resources: ['file'],
+  operations: ['write', 'delete'],
+  scopes: ['workspace'],
+  decision: {
+    kind: 'ask',
+    reason: 'Workspace file modifications require approval.',
+    prompt: 'Approve this file modification?',
+  },
+};
+
+const ASK_HIGH_RISK_RULES: SecurityRule[] = [
+  {
+    id: 'ask-critical-risk',
+    priority: 500,
+    risk: ['critical'],
+    decision: { kind: 'ask', reason: 'Critical risk operation requires approval.' },
+  },
+  {
+    id: 'ask-high-risk',
+    priority: 420,
+    risk: ['high'],
+    decision: { kind: 'ask', reason: 'High risk operation requires approval.' },
+  },
+];
+
+function builtinRulesForApproval(approval: ApprovalMode): SecurityRule[] {
+  switch (approval) {
+    case 'never':
+      return [...BASELINE_SECURITY_RULES];
+    case 'on-failure':
+      return [...BASELINE_SECURITY_RULES, ...ASK_HIGH_RISK_RULES];
+    case 'on-request':
+      return [...BASELINE_SECURITY_RULES, ASK_WORKSPACE_WRITE_RULE];
+    case 'untrusted':
+      return [...BASELINE_SECURITY_RULES, ...ASK_HIGH_RISK_RULES, ASK_WORKSPACE_WRITE_RULE];
+  }
+}
+
+function defaultDecisionForApproval(approval: ApprovalMode): SecurityDecision {
+  if (approval === 'untrusted') {
+    return { kind: 'ask', reason: 'Untrusted profile requires approval for unknown tool calls.' };
+  }
+  return { kind: 'allow' };
+}
 
 export class SecurityPolicyEngine {
   private readonly entries: SecurityRule[];
@@ -383,9 +297,6 @@ export class SecurityGate {
       decision: evaluation.decision,
       evaluation,
     });
-    if (resolved.kind === 'ask') {
-      return resolved;
-    }
     return resolved;
   }
 
@@ -430,8 +341,6 @@ export async function assertSecurityAllowed(input: {
 export function assertSecurityDecisionAllowed(decision: SecurityDecision): void {
   switch (decision.kind) {
     case 'allow':
-    case 'allow_with_constraints':
-    case 'sandbox_only':
       return;
     case 'ask':
       throw new Error(`Tool call requires approval: ${decision.reason}`);
@@ -465,19 +374,27 @@ export function createSecurityPolicyEngineForProfile(
   filePolicies: Record<string, SecurityProfileConfig> = {},
 ): SecurityPolicyEngine {
   const resolvedProfile = resolveSecurityProfile(profile, config, [], filePolicies);
-  const capabilityRules: SecurityRule[] =
+  const denyCapabilityRules: SecurityRule[] =
+    resolvedProfile.capabilities.deny?.map((toolName) => ({
+      id: `deny-capability-${profile}-${toolName}`,
+      priority: 110,
+      tools: [toolName],
+      decision: {
+        kind: 'deny',
+        reason: `Tool '${toolName}' is denied by sandbox '${resolvedProfile.sandbox}'.`,
+      },
+    })) ?? [];
+  const allowCapabilityRules: SecurityRule[] =
     resolvedProfile.capabilities.allow?.map((toolName) => ({
       id: `allow-capability-${profile}-${toolName}`,
       priority: 100,
-      tool: toolName,
+      tools: [toolName],
       decision: { kind: 'allow' },
     })) ?? [];
   return new SecurityPolicyEngine({
-    rules: resolvedProfile.rules.concat(capabilityRules),
-    defaultDecision: resolvedProfile.defaultDecision ?? {
-      kind: 'deny',
-      reason: `Tool is not exposed by security profile: ${profile}`,
-    },
+    rules: resolvedProfile.rules.concat(denyCapabilityRules).concat(allowCapabilityRules),
+    defaultDecision:
+      resolvedProfile.defaultDecision ?? defaultDecisionForApproval(resolvedProfile.approval),
   });
 }
 
@@ -487,13 +404,13 @@ export function classifySecurityResources(input: {
   workspaceDir?: string;
 }): SecurityResource[] {
   const { toolCall } = input;
-  if (toolCall.name === 'read_file') {
+  if (toolCall.name === 'read') {
     return [fileResource('read', stringArg(toolCall.args, 'path'), input.workspaceDir)];
   }
-  if (toolCall.name === 'list_files') {
+  if (toolCall.name === 'ls') {
     return [fileResource('read', stringArg(toolCall.args, 'path'), input.workspaceDir)];
   }
-  if (toolCall.name === 'search_files') {
+  if (toolCall.name === 'find' || toolCall.name === 'grep') {
     return [
       fileResource(
         'search',
@@ -502,12 +419,11 @@ export function classifySecurityResources(input: {
       ),
     ];
   }
-  if (toolCall.name === 'write_file' || toolCall.name === 'edit_file') {
+  if (toolCall.name === 'write' || toolCall.name === 'edit') {
     return [fileResource('write', stringArg(toolCall.args, 'path'), input.workspaceDir)];
   }
-  if (toolCall.name === 'run_shell' || toolCall.name === 'run_code') {
-    const command =
-      stringArg(toolCall.args, 'command') ?? stringArg(toolCall.args, 'code') ?? toolCall.name;
+  if (toolCall.name === 'bash') {
+    const command = stringArg(toolCall.args, 'command') ?? toolCall.name;
     const resources: SecurityResource[] = [
       {
         kind: 'shell',
@@ -527,30 +443,6 @@ export function classifySecurityResources(input: {
       });
     }
     return resources;
-  }
-  if (toolCall.name === 'memory_search') {
-    return [{ kind: 'memory', operation: 'search', scope: 'unknown', sensitivity: 'normal' }];
-  }
-  if (toolCall.name === 'memory_write') {
-    return [{ kind: 'memory', operation: 'write', scope: 'unknown', sensitivity: 'normal' }];
-  }
-  if (toolCall.name === 'sessions_spawn') {
-    return [{ kind: 'subagent', operation: 'spawn', scope: 'unknown', sensitivity: 'normal' }];
-  }
-  if (
-    toolCall.source === 'mcp' ||
-    toolCall.name.startsWith('mcp_') ||
-    toolCall.name.startsWith('mcp__')
-  ) {
-    return [
-      {
-        kind: 'mcp',
-        operation: 'connect',
-        target: toolCall.name,
-        scope: 'external',
-        sensitivity: 'normal',
-      },
-    ];
   }
   return [
     {
@@ -606,15 +498,6 @@ export function assessRisk(input: {
     if (resource.kind === 'network') {
       raise('high', 'External network access');
     }
-    if (resource.kind === 'memory' && resource.operation === 'write') {
-      raise('medium', 'Durable memory write');
-    }
-    if (resource.kind === 'subagent') {
-      raise('medium', 'Subagent spawn');
-    }
-    if (resource.kind === 'mcp') {
-      raise('medium', 'External MCP tool call');
-    }
   }
   return {
     level,
@@ -638,72 +521,60 @@ export function securityEvaluationDetails(evaluation: SecurityEvaluationResult):
   };
 }
 
+type ResolvedProfile = {
+  sandbox: SandboxMode;
+  approval: ApprovalMode;
+  capabilities: CapabilityPolicy;
+  rules: SecurityRule[];
+  defaultDecision?: SecurityDecision;
+};
+
+function resolvedFromBuiltin(name: string): ResolvedProfile {
+  const builtin = BUILTIN_PROFILES[name] ?? DEFAULT_BUILTIN_PROFILE;
+  return {
+    sandbox: builtin.sandbox,
+    approval: builtin.approval,
+    capabilities: SANDBOX_CAPABILITIES[builtin.sandbox],
+    rules: builtinRulesForApproval(builtin.approval),
+  };
+}
+
 function resolveSecurityProfile(
   profile: string,
   config: SecurityConfig,
   seen: string[] = [],
   filePolicies: Record<string, SecurityProfileConfig> = {},
-): { capabilities: CapabilityPolicy; rules: SecurityRule[]; defaultDecision?: SecurityDecision } {
+): ResolvedProfile {
   const normalizedProfile = profile.trim();
   if (seen.includes(normalizedProfile)) {
-    return { capabilities: DEFAULT_CAPABILITY_POLICY, rules: [] };
+    return resolvedFromBuiltin('default');
   }
   const configured = filePolicies[normalizedProfile] ?? config.profiles?.[normalizedProfile];
-  const parent = configured?.extends
+  const parent: ResolvedProfile = configured?.extends
     ? resolveSecurityProfile(
         configured.extends,
         config,
         seen.concat(normalizedProfile),
         filePolicies,
       )
-    : {
-        capabilities: BUILTIN_CAPABILITY_POLICIES[normalizedProfile] ?? DEFAULT_CAPABILITY_POLICY,
-        rules: BUILTIN_SECURITY_RULES[normalizedProfile] ?? BASELINE_SECURITY_RULES,
-      };
+    : resolvedFromBuiltin(normalizedProfile);
   if (!configured) {
     return parent;
   }
+  const sandbox = configured.sandbox ?? parent.sandbox;
+  const approval = configured.approval ?? parent.approval;
+  const sandboxChanged = configured.sandbox !== undefined && configured.sandbox !== parent.sandbox;
+  const approvalChanged =
+    configured.approval !== undefined && configured.approval !== parent.approval;
+  const inheritedDefault = configured.defaultDecision ?? parent.defaultDecision;
   return {
-    capabilities: mergeCapabilityPolicy(parent.capabilities, configured.capabilities),
-    rules: parent.rules.concat(normalizeConfiguredRules(configured.rules)),
-    ...((configured.defaultDecision ?? parent.defaultDecision)
-      ? { defaultDecision: configured.defaultDecision ?? parent.defaultDecision }
-      : {}),
-  };
-}
-
-function denySecretsRule(): SecurityRule {
-  return {
-    id: 'deny-secrets',
-    priority: 600,
-    sensitivity: ['secret', 'credential'],
-    decision: { kind: 'deny', reason: 'Secret or credential resources are protected.' },
-  };
-}
-
-function mergeCapabilityPolicy(
-  base: CapabilityPolicy,
-  override: ConfiguredCapabilityPolicy | undefined,
-): CapabilityPolicy {
-  if (!override) {
-    return copyCapabilityPolicy(base);
-  }
-  if (override.mode === 'replace') {
-    return {
-      ...(override.allow ? { allow: uniqueStrings(override.allow) } : {}),
-      ...(override.deny ? { deny: uniqueStrings(override.deny) } : {}),
-    };
-  }
-  return {
-    allow: uniqueStrings([...(base.allow ?? []), ...(override.allow ?? [])]),
-    deny: uniqueStrings([...(base.deny ?? []), ...(override.deny ?? [])]),
-  };
-}
-
-function copyCapabilityPolicy(policy: CapabilityPolicy): CapabilityPolicy {
-  return {
-    ...(policy.allow ? { allow: [...policy.allow] } : {}),
-    ...(policy.deny ? { deny: [...policy.deny] } : {}),
+    sandbox,
+    approval,
+    capabilities: sandboxChanged ? SANDBOX_CAPABILITIES[sandbox] : parent.capabilities,
+    rules: (approvalChanged ? builtinRulesForApproval(approval) : parent.rules).concat(
+      normalizeConfiguredRules(configured.rules),
+    ),
+    ...(inheritedDefault ? { defaultDecision: inheritedDefault } : {}),
   };
 }
 
@@ -726,25 +597,13 @@ function matchesSecurityRule(rule: SecurityRule, context: SecurityEvaluationCont
   ) {
     return false;
   }
-  if (rule.tool && !matchesPattern(context.toolCall.name, rule.tool)) {
-    return false;
-  }
   if (rule.sources?.length && !rule.sources.includes(context.toolCall.source)) {
-    return false;
-  }
-  if (rule.source && rule.source !== context.toolCall.source) {
     return false;
   }
   if (rule.triggers?.length && !rule.triggers.includes(context.request.trigger)) {
     return false;
   }
-  if (rule.trigger && rule.trigger !== context.request.trigger) {
-    return false;
-  }
   if (rule.senderTrusts?.length && !rule.senderTrusts.includes(context.request.senderTrust)) {
-    return false;
-  }
-  if (rule.senderTrust && rule.senderTrust !== context.request.senderTrust) {
     return false;
   }
   if (rule.args && !matchesArgs(rule.args, context.toolCall.args)) {
@@ -914,10 +773,6 @@ function stringArg(args: JsonObject, key: string): string | undefined {
 
 function riskRank(level: RiskLevel): number {
   return { low: 1, medium: 2, high: 3, critical: 4 }[level];
-}
-
-function uniqueStrings(values: string[]): string[] {
-  return [...new Set(values)];
 }
 
 function summarizeTarget(value: string): string {

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for cron-based scheduled task management with LLM-callable tools",
   "keywords": ["pi-package", "pi", "extension", "scheduler", "cron", "tasks"],
   "license": "Apache-2.0",

--- a/packages/pi-teamwork/README.md
+++ b/packages/pi-teamwork/README.md
@@ -8,7 +8,11 @@ Pi extension for team collaboration and project management. Provides LLM-callabl
 
 ## Configuration
 
-Add to `.pi/settings.json`:
+This extension does **not** manage multica's setup or credentials — those live with the multica CLI itself. Pick one of two modes:
+
+### Mode 1 — Pre-configured environment (recommended)
+
+Run `multica setup` once on the machine and finish login through multica's normal flow. The extension will reuse that state, and you can leave the auth fields empty:
 
 ```json
 {
@@ -16,21 +20,37 @@ Add to `.pi/settings.json`:
     "enabled": true,
     "provider": "multica",
     "multica": {
-      "binary": "multica",
-      "workspace": "",
-      "token": ""
+      "workspace": ""
     }
   }
 }
 ```
+
+### Mode 2 — Headless token
+
+For CI or non-interactive environments where you can't run `multica setup`. Issue a long-lived token from your multica server, and the extension will run `multica login --token <token>` on every `session_start`:
+
+```json
+{
+  "pi-teamwork": {
+    "enabled": true,
+    "provider": "multica",
+    "multica": {
+      "token": "<token-from-multica-server>"
+    }
+  }
+}
+```
+
+> ⚠️ `token` is a credential. Keep it out of version control — put it in a local-only settings file or inject via env-substituted config.
 
 | Field | Description |
 |-------|-------------|
 | `enabled` | Enable/disable the extension |
 | `provider` | Provider name (currently only `multica`) |
 | `multica.binary` | Path to multica binary (default: `multica`) |
-| `multica.workspace` | Workspace ID override |
-| `multica.token` | Auth token for headless login |
+| `multica.workspace` | Workspace ID override; leave empty to use multica's default |
+| `multica.token` | Headless-login token. Only set in mode 2; omit when multica is already logged in on the machine |
 
 ## Tools
 

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-teamwork",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for team collaboration and issue management via Multica",
   "keywords": ["pi-package", "pi", "extension", "teamwork", "issues", "project-management", "multica"],
   "license": "Apache-2.0",

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "description": "Pi extension for runtime telemetry with Langfuse and OpenTelemetry exporters",
   "keywords": ["pi-package", "pi", "extension", "telemetry", "observability", "langfuse", "opentelemetry", "tracing"],
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -53,4 +53,4 @@ const storage = createRuntimeStorage({
 
 ## Public API Policy
 
-Types and contracts live in `@amaster.ai/pi-types` and are re-exported from the root storage entry point. Concrete adapters are exposed through explicit subpath entry points so applications can depend on the smallest stable surface they need.
+Types and contracts live in `@amaster.ai/pi-shared` and are re-exported from the root storage entry point. Concrete adapters are exposed through explicit subpath entry points so applications can depend on the smallest stable surface they need.

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.12",
+  "version": "0.1.2-beta.13",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- **pi-security**: Collapse the profile system around two orthogonal axes — `sandbox` (what tools are exposed) and `approval` (when to ask the user) — inspired by Codex. Replaces the ad-hoc capability lists. Drops unused decision kinds (`sandbox_only`, `allow_with_constraints`), the `SecurityRule.enabled` flag, and singular rule fields. Builtin profiles consolidated to `read-only` / `default` / `auto` / `full-access`. Net `index.ts` shrinkage: ~145 lines.
- **pi-security**: Add `examples/{reviewer.json, auto-review.settings.json}` as canonical config samples, exercised end-to-end by `readme-examples.test.ts` so README and code stay in sync. README rewritten to match.
- **pi-computer-use**: Add stderr debug logs around the `analyze_screenshot` vision pipeline to help diagnose empty/malformed responses.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @amaster.ai/pi-security test` — 46/46 pass (7 new)
- [x] `pnpm --filter @amaster.ai/pi-security build` — green
- [ ] Smoke test `analyze_screenshot` end-to-end and inspect new debug logs