### PR TITLE
feat(pi-teamwork): disambiguate from scheduler and add collaboration guidance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-attachments/package.json
+++ b/packages/pi-attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for attachment processing — classifies, parses, and renders file attachments into LLM-visible prompt context",
   "keywords": ["pi-package", "pi", "extension", "attachments", "files", "documents"],
   "license": "Apache-2.0",

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for browser automation via chrome-devtools-mcp with browser_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-channels",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for native messaging channels including Feishu, WeCom, and webhooks.",
   "keywords": ["pi-package", "pi", "extension", "channels", "feishu", "wecom", "webhooks"],
   "license": "Apache-2.0",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for desktop automation via cua-driver-rs with computer_use_ prefixed tools",
   "keywords": ["pi-package", "pi", "extension", "computer-use", "desktop", "automation", "cua-driver", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-memory",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension providing persistent curated memory (MEMORY.md + USER.md) injected into the system prompt as a frozen snapshot.",
   "keywords": ["pi-package", "pi", "extension", "memory", "persistence"],
   "license": "Apache-2.0",

--- a/packages/pi-memory/src/extension.ts
+++ b/packages/pi-memory/src/extension.ts
@@ -8,7 +8,7 @@ const SETTINGS_KEY = 'pi-memory';
 const STATUS_KEY = 'pi-memory';
 
 const MEMORY_GUIDANCE = [
-  '## Memory Guidance',
+  '# Memory Guidance',
   '',
   'You have persistent memory across sessions via the memory_add / memory_replace / memory_remove / memory_read tools.',
   'Save durable facts: user preferences, environment details, tool quirks, and stable conventions.',

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for resource-aware security policy engine and tool authorization",
   "keywords": ["pi-package", "pi", "extension", "security", "policy", "authorization", "access-control"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for cron-based scheduled task management with LLM-callable tools",
   "keywords": ["pi-package", "pi", "extension", "scheduler", "cron", "tasks"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/src/tools.ts
+++ b/packages/pi-task-scheduler/src/tools.ts
@@ -43,8 +43,9 @@ export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[]
       name: 'scheduler_create',
       label: 'Scheduler',
       description:
-        'Create a scheduled task. Supports cron expressions, one-time (ISO timestamp or relative like "+10m"), and interval (e.g. "30s", "5m", "1h").',
-      promptSnippet: 'Create scheduled tasks (cron/once/interval) that run prompts on a schedule.',
+        'Schedule a prompt to be executed automatically at a future time or on a recurring basis. Supports cron expressions, one-time (ISO timestamp or relative like "+10m"), and interval (e.g. "30s", "5m", "1h"). Use this when the user wants something to run later, repeatedly, or on a timer.',
+      promptSnippet:
+        'Schedule prompts to run automatically via cron, one-time delay, or fixed interval.',
       parameters: Type.Object({
         type: taskTypeSchema,
         schedule: Type.String({
@@ -52,10 +53,14 @@ export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[]
             'Schedule expression. Cron: "0 9 * * 1-5"; Once: ISO timestamp or "+10m"; Interval: "30s", "5m", "1h".',
         }),
         prompt: Type.String({ description: 'The prompt to execute when triggered.' }),
-        name: Type.Optional(Type.String({ description: 'Human-readable task name.' })),
-        description: Type.Optional(Type.String({ description: 'Task description.' })),
+        name: Type.Optional(
+          Type.String({ description: 'Human-readable name for this scheduled prompt.' }),
+        ),
+        description: Type.Optional(
+          Type.String({ description: 'Description of this scheduled prompt.' }),
+        ),
         enabled: Type.Optional(
-          Type.Boolean({ description: 'Whether the task is enabled. Default true.' }),
+          Type.Boolean({ description: 'Whether this scheduled prompt is enabled. Default true.' }),
         ),
       }),
       async execute(
@@ -95,8 +100,8 @@ export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[]
     {
       name: 'scheduler_list',
       label: 'Scheduler',
-      description: 'List all scheduled tasks with their status and next run time.',
-      promptSnippet: 'List all scheduled tasks.',
+      description: 'List all scheduled prompts with their status and next run time.',
+      promptSnippet: 'List all scheduled prompts.',
       parameters: Type.Object({}),
       async execute(): Promise<AgentToolResult<unknown>> {
         const tasks = await scheduler.list();
@@ -110,9 +115,10 @@ export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[]
     {
       name: 'scheduler_get',
       label: 'Scheduler',
-      description: 'Get detailed information about a scheduled task including run history.',
+      description:
+        'Get detailed information about a scheduled prompt, including its schedule and run history.',
       parameters: Type.Object({
-        taskId: Type.String({ description: 'The task ID to query.' }),
+        taskId: Type.String({ description: 'The scheduled-prompt ID to query.' }),
       }),
       async execute(
         _toolCallId: string,
@@ -128,15 +134,16 @@ export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[]
     {
       name: 'scheduler_update',
       label: 'Scheduler',
-      description: 'Update a scheduled task. Can change schedule, prompt, name, or enable/disable.',
+      description:
+        'Update a scheduled prompt. Can change schedule, prompt text, name, or enable/disable.',
       parameters: Type.Object({
-        taskId: Type.String({ description: 'The task ID to update.' }),
+        taskId: Type.String({ description: 'The scheduled-prompt ID to update.' }),
         type: Type.Optional(taskTypeSchema),
         schedule: Type.Optional(Type.String({ description: 'New schedule expression.' })),
         prompt: Type.Optional(Type.String({ description: 'New prompt.' })),
         name: Type.Optional(Type.String({ description: 'New name.' })),
         description: Type.Optional(Type.String({ description: 'New description.' })),
-        enabled: Type.Optional(Type.Boolean({ description: 'Enable or disable the task.' })),
+        enabled: Type.Optional(Type.Boolean({ description: 'Enable or disable.' })),
       }),
       async execute(
         _toolCallId: string,
@@ -176,9 +183,9 @@ export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[]
     {
       name: 'scheduler_delete',
       label: 'Scheduler',
-      description: 'Delete a scheduled task.',
+      description: 'Delete a scheduled prompt.',
       parameters: Type.Object({
-        taskId: Type.String({ description: 'The task ID to delete.' }),
+        taskId: Type.String({ description: 'The scheduled-prompt ID to delete.' }),
       }),
       async execute(
         _toolCallId: string,
@@ -192,9 +199,9 @@ export function createSchedulerTools(scheduler: TaskScheduler): ToolDefinition[]
     {
       name: 'scheduler_run_now',
       label: 'Scheduler',
-      description: 'Trigger immediate execution of a scheduled task.',
+      description: 'Trigger immediate execution of a scheduled prompt, ignoring its schedule.',
       parameters: Type.Object({
-        taskId: Type.String({ description: 'The task ID to run immediately.' }),
+        taskId: Type.String({ description: 'The scheduled-prompt ID to run immediately.' }),
       }),
       async execute(
         _toolCallId: string,

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-teamwork",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for team collaboration and issue management via Multica",
   "keywords": ["pi-package", "pi", "extension", "teamwork", "issues", "project-management", "multica"],
   "license": "Apache-2.0",

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -7,6 +7,20 @@ import type { ExecFn, TeamworkConfig, TeamworkProvider } from './types.js';
 const SETTINGS_KEY = 'pi-teamwork';
 const STATUS_KEY = 'pi-teamwork';
 
+const TEAMWORK_GUIDANCE = [
+  '# Teamwork Guidance',
+  '',
+  'You are working in a shared project tracker (teamwork) where humans and other agents collaborate. Use the issue_* and project_* tools to keep that shared space in sync.',
+  '',
+  'Before starting non-trivial work, check whether a relevant issue already exists (issue_list / issue_get) — to avoid duplicating work another collaborator has picked up.',
+  '',
+  'When you reach meaningful progress, hit a blocker, or need input from a collaborator, leave a comment on the relevant issue (issue_comment). Comments are how humans and other agents observe what you are doing.',
+  '',
+  'When you finish work that an issue describes, update its status (issue_update). An issue left in an outdated state misleads other collaborators.',
+  '',
+  'The tracker is for cross-collaborator coordination, not for tracking your own session-local TODOs. Do not file an issue just to remind yourself of something within the current conversation.',
+].join('\n');
+
 export default function piTeamworkExtension(pi: ExtensionAPI): void {
   let provider: TeamworkProvider | undefined;
 
@@ -35,6 +49,15 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     provider = undefined;
   });
 
+  pi.on('before_agent_start', async (event) => {
+    if (!provider) return;
+    return {
+      systemPrompt: event.systemPrompt
+        ? `${event.systemPrompt}\n\n${TEAMWORK_GUIDANCE}`
+        : TEAMWORK_GUIDANCE,
+    };
+  });
+
   pi.registerCommand('teamwork-status', {
     description: 'Show teamwork provider status.',
     handler: async (_args, ctx) => {
@@ -57,8 +80,8 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     name: 'issue_list',
     label: 'Teamwork',
     description:
-      'List issues from the project management system. Supports filtering by status, assignee, and project.',
-    promptSnippet: 'List issues from the team project tracker with optional filters.',
+      'List issues from a shared project tracker. Issues are work items that humans or other agents collaborate on. Supports filtering by status, assignee, and project.',
+    promptSnippet: 'List issues from a shared project tracker where humans and agents collaborate.',
     parameters: Type.Object({
       status: Type.Optional(
         Type.String({ description: 'Filter by status (e.g. todo, in_progress, done, blocked).' }),
@@ -82,7 +105,8 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: 'issue_get',
     label: 'Teamwork',
-    description: 'Get detailed information about a specific issue.',
+    description:
+      'Get detailed information about a specific issue (a work item in the shared project tracker).',
     parameters: Type.Object({
       id: Type.String({ description: 'The issue ID.' }),
     }),
@@ -101,8 +125,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: 'issue_create',
     label: 'Teamwork',
-    description: 'Create a new issue in the project management system.',
-    promptSnippet: 'Create issues in the team project tracker.',
+    description:
+      'Create a new issue (a work item / ticket) in the shared project tracker. Use this to file work for humans or other agents to pick up.',
+    promptSnippet:
+      'Create issues / tickets in a shared project tracker for humans or agents to collaborate on.',
     parameters: Type.Object({
       title: Type.String({ description: 'Issue title.' }),
       description: Type.Optional(Type.String({ description: 'Issue description.' })),
@@ -127,7 +153,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     name: 'issue_update',
     label: 'Teamwork',
     description:
-      'Update an existing issue. Can change title, description, status, priority, or assignee.',
+      'Update an existing issue in the shared project tracker. Can change title, description, status, priority, or assignee.',
     parameters: Type.Object({
       id: Type.String({ description: 'The issue ID to update.' }),
       title: Type.Optional(Type.String({ description: 'New title.' })),
@@ -156,7 +182,8 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: 'issue_comment',
     label: 'Teamwork',
-    description: 'Add a comment to an issue. Use for progress updates, questions, or blockers.',
+    description:
+      'Add a comment to an issue in the shared project tracker. Use for progress updates, questions, or blockers visible to other collaborators (humans or agents).',
     parameters: Type.Object({
       issueId: Type.String({ description: 'The issue ID to comment on.' }),
       content: Type.String({ description: 'Comment content.' }),
@@ -178,7 +205,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: 'project_list',
     label: 'Teamwork',
-    description: 'List all projects in the workspace.',
+    description: 'List all projects in the shared collaboration workspace.',
     parameters: Type.Object({}),
     async execute() {
       if (!provider) return textResult('Teamwork provider is not initialized.');
@@ -196,7 +223,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     name: 'teamwork_status',
     label: 'Teamwork',
     description:
-      'Check the status of the teamwork provider (daemon status, connected agents, etc.).',
+      'Check the status of the teamwork collaboration provider (daemon status, connected agents, etc.).',
     parameters: Type.Object({}),
     async execute() {
       if (!provider) return textResult('Teamwork provider is not initialized.');

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "description": "Pi extension for runtime telemetry with Langfuse and OpenTelemetry exporters",
   "keywords": ["pi-package", "pi", "extension", "telemetry", "observability", "langfuse", "opentelemetry", "tracing"],
   "license": "Apache-2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.13",
+  "version": "0.1.2-beta.14",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- Tighten tool descriptions in pi-task-scheduler and pi-teamwork so the model stops conflating them when the user says "task". Scheduler now describes itself as "scheduled prompts" with a time-trigger framing; teamwork describes itself as a "shared project tracker" where humans or agents collaborate. Neither package references the other.
- Inject a `TEAMWORK_GUIDANCE` block via `before_agent_start` when the provider is initialized (mirrors pi-memory's pattern), so the model treats issues as a coordination surface rather than session-local TODOs.
- Align pi-memory's guidance heading to h1 for consistency with the new teamwork block.

## Test plan

- [x] `pnpm test` in pi-teamwork (22/22), pi-task-scheduler (34/34), pi-memory (60/60)
- [x] `tsc --noEmit` in both edited packages
- [x] Manual prompt eval via `pi --print` against built dists:
  - "明天早上 9 点提醒我开会" → only `scheduler_create`
  - "把这个 bug 记下来给团队" → `issue_*` (with `issue_list` first, as guidance suggests)
  - "每天早上 9 点跑数据导出脚本" → eventually picks scheduler, but `issue_list` fires first (noted as a slight over-trigger of the "check existing issue" rule; acceptable for v1, may tighten later based on real usage)
- [ ] Real multica session usage to validate the comment / status-update behaviors (can't test those without a live provider)