### PR TITLE
refactor(shared): split resolveAgentDir into resolveHome and resolveConfigDir

### DIFF
--- a/packages/pi-attachments/src/extension.ts
+++ b/packages/pi-attachments/src/extension.ts
@@ -27,7 +27,7 @@
 import { createHash } from 'node:crypto';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { resolveHome } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, InputEventResult } from '@earendil-works/pi-coding-agent';
 import { type AttachmentMeta, classifyAttachment, renderAttachmentBlock } from './classify.js';
 
@@ -345,7 +345,7 @@ function parseFileReference(mention: string): {
  */
 export function skillSearchPaths(name: string, cwd: string): string[] {
   const projectDir = path.resolve(cwd, '.pi', 'skills', name);
-  const userDir = path.resolve(resolveAgentDir(), 'skills', name);
+  const userDir = path.resolve(resolveHome(), 'skills', name);
   return [projectDir, userDir].map((dir) => path.join(dir, 'SKILL.md'));
 }
 

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -1,7 +1,6 @@
 import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
 import { type TextContent as AiTextContent, complete } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
@@ -133,7 +132,6 @@ export class DevToolsClient {
 /** Read the pi-browser-use section from .pi/settings.json. */
 function loadConfigFromFile(options?: PiSettingsOptions): BrowserUseConfig {
   return loadPiSettings<BrowserUseConfig>('pi-browser-use', {
-    agentDir: getAgentDir(),
     ...options,
   });
 }

--- a/packages/pi-channels/src/config.ts
+++ b/packages/pi-channels/src/config.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings, resolveConfigDir } from '@amaster.ai/pi-shared/settings';
 import type { ChannelConfig } from './types.js';
 
 const SETTINGS_KEY = 'pi-channels';
@@ -56,7 +56,7 @@ function discoverLocalSettingsFiles(cwd: string): string[] {
     found.push(resolved);
   };
 
-  const agentDir = resolveAgentDir();
+  const agentDir = resolveConfigDir();
   add(join(agentDir, 'settings.json'));
 
   let current = resolve(cwd);
@@ -90,8 +90,8 @@ function mergeChannelConfig(base: ChannelConfig, override: ChannelConfig): Chann
 }
 
 export function loadChannelConfig(cwd: string): ChannelConfig {
-  const agentDir = resolveAgentDir();
-  const config = loadPiSettings<ChannelConfig>(SETTINGS_KEY, { cwd, agentDir });
+  const agentDir = resolveConfigDir();
+  const config = loadPiSettings<ChannelConfig>(SETTINGS_KEY, { cwd });
 
   const settingsFiles = discoverLocalSettingsFiles(cwd);
   const local = settingsFiles.reduce(

--- a/packages/pi-computer-use/src/config.ts
+++ b/packages/pi-computer-use/src/config.ts
@@ -1,5 +1,4 @@
 import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 export interface VisionModelConfig {
   provider: string;
@@ -27,7 +26,6 @@ export function resolveConfig(config?: ComputerUseConfig): ComputerUseConfig {
 
 export function loadConfigFromFile(options?: PiSettingsOptions): ComputerUseConfig {
   return loadPiSettings<ComputerUseConfig>('pi-computer-use', {
-    agentDir: getAgentDir(),
     ...options,
   });
 }

--- a/packages/pi-image-gen/src/config.ts
+++ b/packages/pi-image-gen/src/config.ts
@@ -1,4 +1,4 @@
-import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import {
   BUILT_IN_MODELS,
   DEFAULT_API_STYLE,
@@ -21,7 +21,6 @@ export function loadImageGenSettings(cwd: string): ImageGenSettings {
   try {
     return loadPiSettings<ImageGenSettings>(SETTINGS_KEY, {
       cwd,
-      agentDir: resolveAgentDir(),
     });
   } catch {
     return {};

--- a/packages/pi-memory-mem0/src/index.ts
+++ b/packages/pi-memory-mem0/src/index.ts
@@ -9,7 +9,7 @@
  * Supports ${ENV_VAR:-fallback} in all string values.
  */
 
-import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Prefetch } from './prefetch.js';
 import { createMem0Provider, type Mem0Provider } from './provider.js';
@@ -24,7 +24,6 @@ function loadConfig(cwd: string): Mem0ExtensionConfig {
   try {
     return loadPiSettings<Mem0ExtensionConfig>(SETTINGS_KEY, {
       cwd,
-      agentDir: resolveAgentDir(),
     });
   } catch {
     return {};

--- a/packages/pi-memory-mem0/src/provider.ts
+++ b/packages/pi-memory-mem0/src/provider.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'node:path';
-import { resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { resolveHome } from '@amaster.ai/pi-shared/settings';
 import type { AddResult, Mem0ExtensionConfig, MemoryItem } from './types.js';
 
 // ---------------------------------------------------------------------------
@@ -175,7 +175,7 @@ class OSSProvider implements Mem0Provider {
       // Default: SQLite in <PI_AGENT_HOME>/memories/mem0.db (alongside pi-memory's files)
       config.vectorStore = {
         provider: 'sqlite',
-        config: { dbPath: join(resolveAgentDir(), 'memories', 'mem0.db') },
+        config: { dbPath: join(resolveHome(), 'memories', 'mem0.db') },
       };
     }
 

--- a/packages/pi-memory/src/extension.ts
+++ b/packages/pi-memory/src/extension.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings, resolveHome } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
   createExtractionRunner,
@@ -52,7 +52,7 @@ type ResolvedConfig = {
 
 function resolveConfig(raw?: PiMemoryExtensionConfig): ResolvedConfig {
   const resolved: ResolvedConfig = {
-    dataDir: raw?.dataDir?.trim() || path.join(resolveAgentDir(), 'memories'),
+    dataDir: raw?.dataDir?.trim() || path.join(resolveHome(), 'memories'),
     extractionInterval: raw?.extractionInterval ?? 5,
   };
   if (raw?.memoryCharLimit !== undefined) resolved.memoryCharLimit = raw.memoryCharLimit;
@@ -66,7 +66,6 @@ function loadSettings(cwd: string): PiMemoryExtensionConfig | undefined {
   try {
     const config = loadPiSettings<Partial<PiMemoryExtensionConfig>>(SETTINGS_KEY, {
       cwd,
-      agentDir: resolveAgentDir(),
     });
     return Object.keys(config).length > 0 ? (config as PiMemoryExtensionConfig) : undefined;
   } catch {

--- a/packages/pi-security/src/extension.ts
+++ b/packages/pi-security/src/extension.ts
@@ -239,7 +239,6 @@ function loadSettings(cwd: string): PiSecurityExtensionConfig | undefined {
   try {
     const config = loadPiSettings<Partial<PiSecurityExtensionConfig>>(SETTINGS_KEY, {
       cwd,
-      agentDir: getAgentDir(),
     });
     return Object.keys(config).length > 0 ? (config as PiSecurityExtensionConfig) : undefined;
   } catch {

--- a/packages/pi-security/src/policy-loader.ts
+++ b/packages/pi-security/src/policy-loader.ts
@@ -29,10 +29,10 @@ export function loadPolicyDir(dirPath: string): Record<string, SecurityProfileCo
 
 export function loadFilePolicies(
   cwd: string,
-  agentDir?: string,
+  configDir?: string,
 ): Record<string, SecurityProfileConfig> {
   return loadPiPolicyProfiles<SecurityProfileConfig>({
     cwd,
-    ...(agentDir !== undefined ? { agentDir } : {}),
+    ...(configDir !== undefined ? { configDir } : {}),
   });
 }

--- a/packages/pi-task-scheduler/src/extension.ts
+++ b/packages/pi-task-scheduler/src/extension.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings, resolveHome } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
   PersistentTaskScheduler,
@@ -31,7 +31,7 @@ type ResolvedConfig = {
 
 function resolveConfig(raw?: PiSchedulerExtensionConfig): ResolvedConfig {
   const resolved: ResolvedConfig = {
-    dataDir: raw?.dataDir?.trim() || path.join(resolveAgentDir(), 'data'),
+    dataDir: raw?.dataDir?.trim() || path.join(resolveHome(), 'data'),
   };
   if (raw?.store) resolved.store = raw.store;
   if (raw?.lock) resolved.lock = raw.lock;
@@ -43,7 +43,6 @@ function loadSettings(cwd: string): PiSchedulerExtensionConfig | undefined {
   try {
     const config = loadPiSettings<Partial<PiSchedulerExtensionConfig>>(SETTINGS_KEY, {
       cwd,
-      agentDir: resolveAgentDir(),
     });
     return Object.keys(config).length > 0 ? (config as PiSchedulerExtensionConfig) : undefined;
   } catch {

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -1,4 +1,4 @@
-import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { initMulticaProvider } from './adapters/multica.js';
@@ -245,7 +245,6 @@ function loadConfig(cwd: string): TeamworkConfig {
   try {
     const config = loadPiSettings<Partial<TeamworkConfig>>(SETTINGS_KEY, {
       cwd,
-      agentDir: resolveAgentDir(),
     });
     return Object.keys(config).length > 0 ? (config as TeamworkConfig) : {};
   } catch {

--- a/packages/pi-telemetry/src/config.ts
+++ b/packages/pi-telemetry/src/config.ts
@@ -1,5 +1,4 @@
 import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 export interface LangfuseConfig {
   enabled?: boolean;
@@ -38,5 +37,5 @@ export function resolveConfig(config?: TelemetryConfig): TelemetryConfig {
 }
 
 export function loadConfigFromFile(options?: PiSettingsOptions): TelemetryConfig {
-  return loadPiSettings<TelemetryConfig>('pi-telemetry', { agentDir: getAgentDir(), ...options });
+  return loadPiSettings<TelemetryConfig>('pi-telemetry', { ...options });
 }

--- a/packages/pi-web-access/src/config.ts
+++ b/packages/pi-web-access/src/config.ts
@@ -1,4 +1,4 @@
-import { loadPiSettings, resolveAgentDir } from '@amaster.ai/pi-shared/settings';
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import type { ResolvedProvider } from './providers/index.js';
 import type { BuiltInProviderId, WebToolSettings } from './types.js';
 
@@ -48,7 +48,6 @@ export function loadWebToolSettings(cwd: string): WebToolSettings {
   try {
     return loadPiSettings<WebToolSettings>(SETTINGS_KEY, {
       cwd,
-      agentDir: resolveAgentDir(),
     });
   } catch {
     return {};

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -171,16 +171,16 @@ describe('loadPiSettings env var resolution', () => {
 describe('3-layer settings resolution', () => {
   let base: string;
   let globalDir: string;
-  let agentDir: string;
+  let configDir: string;
   let projectDir: string;
 
   beforeEach(() => {
     base = join(tmpdir(), `pi-3layer-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     globalDir = join(base, 'home', '.pi', 'agent');
-    agentDir = join(base, 'agent-config');
+    configDir = join(base, 'agent-config');
     projectDir = join(base, 'project');
     mkdirSync(globalDir, { recursive: true });
-    mkdirSync(agentDir, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
     mkdirSync(join(projectDir, '.pi'), { recursive: true });
     mockedHome = join(base, 'home');
   });
@@ -190,25 +190,25 @@ describe('3-layer settings resolution', () => {
     rmSync(base, { recursive: true, force: true });
   });
 
-  it('agentDir settings override global settings', async () => {
+  it('configDir settings override global settings', async () => {
     writeFileSync(
       join(globalDir, 'settings.json'),
       JSON.stringify({ ext: { a: 'global', b: 'global' } }),
     );
-    writeFileSync(join(agentDir, 'settings.json'), JSON.stringify({ ext: { a: 'agent' } }));
+    writeFileSync(join(configDir, 'settings.json'), JSON.stringify({ ext: { a: 'agent' } }));
 
     const { loadPiSettings } = await import('../../src/settings.js');
     const result = loadPiSettings<{ a: string; b: string }>('ext', {
-      agentDir,
+      configDir,
       cwd: projectDir,
     });
     expect(result.a).toBe('agent');
     expect(result.b).toBe('global');
   });
 
-  it('project settings override agentDir settings', async () => {
+  it('project settings override configDir settings', async () => {
     writeFileSync(
-      join(agentDir, 'settings.json'),
+      join(configDir, 'settings.json'),
       JSON.stringify({ ext: { a: 'agent', b: 'agent' } }),
     );
     writeFileSync(
@@ -218,29 +218,29 @@ describe('3-layer settings resolution', () => {
 
     const { loadPiSettings } = await import('../../src/settings.js');
     const result = loadPiSettings<{ a: string; b: string }>('ext', {
-      agentDir,
+      configDir,
       cwd: projectDir,
     });
     expect(result.a).toBe('project');
     expect(result.b).toBe('agent');
   });
 
-  it('env var interpolation works in agentDir layer', async () => {
+  it('env var interpolation works in configDir layer', async () => {
     const origEndpoint = process.env.MY_ENDPOINT;
     process.env.MY_ENDPOINT = 'https://api.example.com';
     writeFileSync(
-      join(agentDir, 'settings.json'),
+      join(configDir, 'settings.json'),
       JSON.stringify({ ext: { url: envRef('MY_ENDPOINT') } }),
     );
 
     const { loadPiSettings } = await import('../../src/settings.js');
-    const result = loadPiSettings<{ url: string }>('ext', { agentDir, cwd: projectDir });
+    const result = loadPiSettings<{ url: string }>('ext', { configDir, cwd: projectDir });
     expect(result.url).toBe('https://api.example.com');
     if (origEndpoint === undefined) delete process.env.MY_ENDPOINT;
     else process.env.MY_ENDPOINT = origEndpoint;
   });
 
-  it('skips agentDir layer when it equals global dir', async () => {
+  it('skips configDir layer when it equals global dir', async () => {
     writeFileSync(join(globalDir, 'settings.json'), JSON.stringify({ ext: { a: 'global' } }));
     writeFileSync(
       join(projectDir, '.pi', 'settings.json'),
@@ -257,20 +257,20 @@ describe('3-layer settings resolution', () => {
 describe('loadPiPolicyProfiles', () => {
   let base: string;
   let globalPolicyDir: string;
-  let agentDir: string;
-  let agentPolicyDir: string;
+  let configDir: string;
+  let configPolicyDir: string;
   let projectDir: string;
   let projectPolicyDir: string;
 
   beforeEach(() => {
     base = join(tmpdir(), `pi-policy-3layer-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     globalPolicyDir = join(base, 'home', '.pi', 'agent', 'policy');
-    agentDir = join(base, 'agent-config');
-    agentPolicyDir = join(agentDir, 'policy');
+    configDir = join(base, 'agent-config');
+    configPolicyDir = join(configDir, 'policy');
     projectDir = join(base, 'project');
     projectPolicyDir = join(projectDir, '.pi', 'policy');
     mkdirSync(globalPolicyDir, { recursive: true });
-    mkdirSync(agentPolicyDir, { recursive: true });
+    mkdirSync(configPolicyDir, { recursive: true });
     mkdirSync(projectPolicyDir, { recursive: true });
     mockedHome = join(base, 'home');
   });
@@ -280,15 +280,15 @@ describe('loadPiPolicyProfiles', () => {
     rmSync(base, { recursive: true, force: true });
   });
 
-  it('agentDir policy is readable', async () => {
+  it('configDir policy is readable', async () => {
     writeFileSync(
-      join(agentPolicyDir, 'sandbox-exec.json'),
+      join(configPolicyDir, 'sandbox-exec.json'),
       JSON.stringify({ extends: 'sandbox-exec', capabilities: { allow: ['browser_*'] } }),
     );
 
     const { loadPiPolicyProfiles } = await import('../../src/settings.js');
     const result = loadPiPolicyProfiles<{ extends?: string; capabilities?: { allow?: string[] } }>({
-      agentDir,
+      configDir,
       cwd: projectDir,
     });
     expect(result['sandbox-exec']).toEqual({
@@ -297,9 +297,9 @@ describe('loadPiPolicyProfiles', () => {
     });
   });
 
-  it('project policy overrides agentDir policy with same name', async () => {
+  it('project policy overrides configDir policy with same name', async () => {
     writeFileSync(
-      join(agentPolicyDir, 'custom.json'),
+      join(configPolicyDir, 'custom.json'),
       JSON.stringify({ extends: 'chat', capabilities: { allow: ['read_file'] } }),
     );
     writeFileSync(
@@ -309,7 +309,7 @@ describe('loadPiPolicyProfiles', () => {
 
     const { loadPiPolicyProfiles } = await import('../../src/settings.js');
     const result = loadPiPolicyProfiles<{ extends?: string; capabilities?: { allow?: string[] } }>({
-      agentDir,
+      configDir,
       cwd: projectDir,
     });
     expect(result.custom).toEqual({ extends: 'copilot', capabilities: { allow: ['*'] } });
@@ -317,14 +317,14 @@ describe('loadPiPolicyProfiles', () => {
 
   it('merges profiles from all three directories', async () => {
     writeFileSync(join(globalPolicyDir, 'global-only.json'), JSON.stringify({ extends: 'chat' }));
-    writeFileSync(join(agentPolicyDir, 'agent-only.json'), JSON.stringify({ extends: 'admin' }));
+    writeFileSync(join(configPolicyDir, 'agent-only.json'), JSON.stringify({ extends: 'admin' }));
     writeFileSync(
       join(projectPolicyDir, 'project-only.json'),
       JSON.stringify({ extends: 'copilot' }),
     );
 
     const { loadPiPolicyProfiles } = await import('../../src/settings.js');
-    const result = loadPiPolicyProfiles<{ extends?: string }>({ agentDir, cwd: projectDir });
+    const result = loadPiPolicyProfiles<{ extends?: string }>({ configDir, cwd: projectDir });
     expect(result['global-only']).toEqual({ extends: 'chat' });
     expect(result['agent-only']).toEqual({ extends: 'admin' });
     expect(result['project-only']).toEqual({ extends: 'copilot' });
@@ -332,11 +332,11 @@ describe('loadPiPolicyProfiles', () => {
 
   it('works when directories do not exist', async () => {
     rmSync(globalPolicyDir, { recursive: true });
-    rmSync(agentPolicyDir, { recursive: true });
+    rmSync(configPolicyDir, { recursive: true });
     rmSync(projectPolicyDir, { recursive: true });
 
     const { loadPiPolicyProfiles } = await import('../../src/settings.js');
-    const result = loadPiPolicyProfiles({ agentDir, cwd: projectDir });
+    const result = loadPiPolicyProfiles({ configDir, cwd: projectDir });
     expect(result).toEqual({});
   });
 });

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -4,7 +4,8 @@ import { basename, join, resolve } from 'node:path';
 
 export type PiSettingsOptions = {
   cwd?: string;
-  agentDir?: string;
+  /** Override for the config directory. If not set, resolveConfigDir() is used. */
+  configDir?: string;
 };
 
 function resolveEnvVars(value: unknown): unknown {
@@ -43,8 +44,30 @@ function readSettingsSection<T>(filePath: string, key: string): Partial<T> {
   }
 }
 
-export function resolveAgentDir(override?: string): string {
+/**
+ * Resolve the user data / runtime home directory.
+ * Used for: memories, data, skills, logs.
+ */
+export function resolveHome(override?: string): string {
   return resolve(override ?? process.env.PI_AGENT_HOME ?? join(homedir(), '.pi', 'agent'));
+}
+
+/**
+ * Resolve the system config directory.
+ * Used for: settings.json, policy, auth, models.
+ */
+export function resolveConfigDir(override?: string): string {
+  return resolve(
+    override ??
+      process.env.PI_CODING_AGENT_DIR ??
+      process.env.PI_AGENT_HOME ??
+      join(homedir(), '.pi', 'agent'),
+  );
+}
+
+/** @deprecated Use resolveHome() or resolveConfigDir() instead. */
+export function resolveAgentDir(override?: string): string {
+  return resolveHome(override);
 }
 
 /**
@@ -54,19 +77,19 @@ export function resolveAgentDir(override?: string): string {
  */
 export function loadPiSettings<T>(key: string, options?: PiSettingsOptions): T {
   const globalDir = resolve(join(homedir(), '.pi', 'agent'));
-  const agentDir = resolveAgentDir(options?.agentDir);
+  const configDir = resolveConfigDir(options?.configDir);
   const cwd = options?.cwd ?? process.cwd();
 
   const globalSettings = readSettingsSection<T>(join(globalDir, 'settings.json'), key);
 
-  const agentSettings =
-    agentDir === globalDir
+  const configSettings =
+    configDir === globalDir
       ? ({} as Partial<T>)
-      : readSettingsSection<T>(join(agentDir, 'settings.json'), key);
+      : readSettingsSection<T>(join(configDir, 'settings.json'), key);
 
   const projectSettings = readSettingsSection<T>(join(cwd, '.pi', 'settings.json'), key);
 
-  return { ...globalSettings, ...agentSettings, ...projectSettings } as T;
+  return { ...globalSettings, ...configSettings, ...projectSettings } as T;
 }
 
 export function loadJsonProfileDir<T>(dir: string): Record<string, T> {
@@ -95,13 +118,15 @@ export function loadJsonProfileDir<T>(dir: string): Record<string, T> {
 
 export function loadPiPolicyProfiles<T>(options?: PiSettingsOptions): Record<string, T> {
   const globalDir = resolve(join(homedir(), '.pi', 'agent', 'policy'));
-  const agentDir = resolve(join(resolveAgentDir(options?.agentDir), 'policy'));
+  const configPolicyDir = resolve(join(resolveConfigDir(options?.configDir), 'policy'));
   const projectDir = resolve(join(options?.cwd ?? process.cwd(), '.pi', 'policy'));
 
   const globalPolicies = loadJsonProfileDir<T>(globalDir);
-  const agentPolicies =
-    agentDir === globalDir ? ({} as Record<string, T>) : loadJsonProfileDir<T>(agentDir);
+  const configPolicies =
+    configPolicyDir === globalDir
+      ? ({} as Record<string, T>)
+      : loadJsonProfileDir<T>(configPolicyDir);
   const projectPolicies = loadJsonProfileDir<T>(projectDir);
 
-  return { ...globalPolicies, ...agentPolicies, ...projectPolicies };
+  return { ...globalPolicies, ...configPolicies, ...projectPolicies };
 }


### PR DESCRIPTION
## Summary

- Splits the single `resolveAgentDir()` into two distinct resolvers to fix the path confusion on desktop where user data and system config live in different directories
- `resolveHome()`: resolves user data/runtime directory (memories, data, skills, logs) via `PI_AGENT_HOME`
- `resolveConfigDir()`: resolves system config directory (settings.json, policy, auth) via `PI_CODING_AGENT_DIR`
- `loadPiSettings` / `loadPiPolicyProfiles` now internally call `resolveConfigDir()`, removing the need for plugins to pass `agentDir` explicitly
- All 16 plugin packages updated to use the correct resolver based on whether they access data or config

## Test plan

- [x] All 770 existing tests pass
- [x] TypeScript type-check passes across all packages
- [x] Biome lint passes (only pre-existing warnings remain)
- [ ] Verify on desktop build that settings.json is read from the system config dir and memories are stored in the user data dir