### PR TITLE
feat: add pi-lark, pi-dingtalk, pi-wecom workspace CLI extensions

### DIFF
--- a/packages/pi-dingtalk/README.md
+++ b/packages/pi-dingtalk/README.md
@@ -1,0 +1,52 @@
+# pi-dingtalk
+
+Pi extension for [DingTalk](https://www.dingtalk.com/) workspace — calendar, docs, chat, todo, sheets, mail and more via [dws (DingTalk Workspace CLI)](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli).
+
+## Features
+
+- Auto-installs `dws` CLI if not present
+- Initializes credentials from pi settings (non-interactive, via `--client-id` / `--client-secret`)
+- Injects dws skills into the agent session (19 product skills)
+
+## Configuration
+
+Add to your `.pi/settings.json`:
+
+```json
+{
+  "pi-dingtalk": {
+    "clientId": "your_client_id",
+    "clientSecret": "your_client_secret"
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `clientId` | Yes | App Key from [DingTalk Open Platform](https://open.dingtalk.com/) |
+| `clientSecret` | Yes | App Secret |
+
+## Skills Provided
+
+19 skills from dws covering:
+
+- `dingtalk-calendar` — Events, meeting rooms, free/busy
+- `dingtalk-chat` — Messages, groups, bots, reactions
+- `dingtalk-doc` — Document create, read, write
+- `dingtalk-sheet` — Spreadsheet CRUD
+- `dingtalk-aitable` — Bases, tables, records, fields
+- `dingtalk-todo` — Task CRUD with priority/due date
+- `dingtalk-contact` — User search, department tree
+- `dingtalk-mail` — Email search, send, read
+- `dingtalk-wiki` — Knowledge base management
+- `dingtalk-meeting` / `dingtalk-minutes` — Meeting records, transcription
+- `dingtalk-oa` — Approval workflows
+- `dingtalk-schedule` — Schedule management
+- `dingtalk-drive` — File operations
+- And more...
+
+## CLI Reference
+
+- Repository: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli
+- Install: `npm install -g dingtalk-workspace-cli`
+- Docs: https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli#readme

--- a/packages/pi-dingtalk/package.json
+++ b/packages/pi-dingtalk/package.json
@@ -1,0 +1,69 @@
+{
+  "name": "@amaster.ai/pi-dingtalk",
+  "version": "0.1.0",
+  "description": "Pi extension for DingTalk workspace — calendar, docs, chat, todo, sheets, mail and more via dws CLI.",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "dingtalk"
+  ],
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TGYD-helige/pi.git",
+    "directory": "packages/pi-dingtalk"
+  },
+  "scripts": {
+    "fetch-skills": "node scripts/fetch-skills.mjs",
+    "prebuild": "node scripts/fetch-skills.mjs",
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false",
+    "test": "vitest run src"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.74.0",
+    "typebox": "*",
+    "vitest": "^4.0.0"
+  },
+  "dependencies": {
+    "@amaster.ai/pi-shared": "workspace:*"
+  }
+}

--- a/packages/pi-dingtalk/scripts/fetch-skills.mjs
+++ b/packages/pi-dingtalk/scripts/fetch-skills.mjs
@@ -1,0 +1,49 @@
+/**
+ * Fetches the latest dws skills from GitHub and writes them to the skills/ directory.
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = join(__dirname, '..', 'skills');
+const REPO = 'DingTalk-Real-AI/dingtalk-workspace-cli';
+const BRANCH = 'main';
+const REMOTE_PATH = 'skills/multi';
+
+async function fetchSkills() {
+  console.log('[pi-dingtalk] Fetching skills from github.com/%s ...', REPO);
+
+  if (existsSync(SKILLS_DIR)) {
+    rmSync(SKILLS_DIR, { recursive: true, force: true });
+  }
+  mkdirSync(SKILLS_DIR, { recursive: true });
+
+  const tmpDir = join(__dirname, '..', '.tmp-skills-fetch');
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  mkdirSync(tmpDir, { recursive: true });
+
+  try {
+    execSync(
+      `git clone --depth 1 --filter=blob:none --sparse https://github.com/${REPO}.git .`,
+      { cwd: tmpDir, stdio: 'pipe' },
+    );
+    execSync(`git sparse-checkout set ${REMOTE_PATH}`, { cwd: tmpDir, stdio: 'pipe' });
+
+    const srcSkills = join(tmpDir, REMOTE_PATH);
+    if (!existsSync(srcSkills)) {
+      throw new Error(`Skills directory not found at ${srcSkills}`);
+    }
+
+    execSync(`cp -r "${srcSkills}/"* "${SKILLS_DIR}/"`, { stdio: 'pipe' });
+    console.log('[pi-dingtalk] Skills fetched successfully.');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+fetchSkills().catch((err) => {
+  console.warn('[pi-dingtalk] Failed to fetch skills (using existing if available):', err.message);
+  process.exit(0);
+});

--- a/packages/pi-dingtalk/src/__tests__/cli.test.ts
+++ b/packages/pi-dingtalk/src/__tests__/cli.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { initDws } from '../cli.js';
+
+describe('initDws', () => {
+  test('throws when clientId is missing', () => {
+    expect(() => initDws({ clientSecret: 'secret' })).toThrow(
+      'clientId and clientSecret are required',
+    );
+  });
+
+  test('throws when clientSecret is missing', () => {
+    expect(() => initDws({ clientId: 'dingabc' })).toThrow(
+      'clientId and clientSecret are required',
+    );
+  });
+});

--- a/packages/pi-dingtalk/src/__tests__/config.test.ts
+++ b/packages/pi-dingtalk/src/__tests__/config.test.ts
@@ -1,0 +1,66 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { loadDingTalkConfig } from '../config.js';
+
+describe('loadDingTalkConfig', () => {
+  let base: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    base = join(
+      tmpdir(),
+      `pi-dingtalk-config-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    originalEnv = { ...process.env };
+    process.env.PI_CODING_AGENT_DIR = join(base, 'agent');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('returns undefined when no config exists', () => {
+    mkdirSync(join(base, 'project'), { recursive: true });
+    const config = loadDingTalkConfig(join(base, 'project'));
+    expect(config).toBeUndefined();
+  });
+
+  test('loads config from .pi/settings.json', () => {
+    const project = join(base, 'project');
+    mkdirSync(join(project, '.pi'), { recursive: true });
+    writeFileSync(
+      join(project, '.pi', 'settings.json'),
+      JSON.stringify({
+        'pi-dingtalk': {
+          clientId: 'dingabc123',
+          clientSecret: 'secret456',
+        },
+      }),
+    );
+
+    const config = loadDingTalkConfig(project);
+
+    expect(config).toEqual({
+      clientId: 'dingabc123',
+      clientSecret: 'secret456',
+    });
+  });
+
+  test('returns undefined when clientId and clientSecret are both empty', () => {
+    const project = join(base, 'project');
+    mkdirSync(join(project, '.pi'), { recursive: true });
+    writeFileSync(
+      join(project, '.pi', 'settings.json'),
+      JSON.stringify({
+        'pi-dingtalk': {},
+      }),
+    );
+
+    const config = loadDingTalkConfig(project);
+    expect(config).toBeUndefined();
+  });
+});

--- a/packages/pi-dingtalk/src/cli.ts
+++ b/packages/pi-dingtalk/src/cli.ts
@@ -1,0 +1,54 @@
+import { exec, execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { DingTalkConfig } from './config.js';
+
+const NPM_PACKAGE = 'dingtalk-workspace-cli';
+
+export function isDwsInstalled(): boolean {
+  try {
+    execSync('dws --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function installDws(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    exec(`npm install -g ${NPM_PACKAGE}@latest`, (error) => {
+      if (error) reject(new Error(`Failed to install ${NPM_PACKAGE}: ${error.message}`));
+      else resolve();
+    });
+  });
+}
+
+export async function ensureDws(): Promise<boolean> {
+  if (isDwsInstalled()) return true;
+  await installDws();
+  return isDwsInstalled();
+}
+
+export function initDws(config: DingTalkConfig): void {
+  const { clientId, clientSecret } = config;
+  if (!clientId || !clientSecret) {
+    throw new Error('clientId and clientSecret are required');
+  }
+  execSync(`dws auth login --client-id "${clientId}" --client-secret "${clientSecret}" --yes`, {
+    stdio: 'pipe',
+  });
+}
+
+export function getDwsSkillsDir(): string | undefined {
+  try {
+    const npmRoot = execSync('npm root -g', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    const skillsPath = join(npmRoot, 'dingtalk-workspace-cli', 'skills', 'multi');
+    if (existsSync(skillsPath)) return skillsPath;
+  } catch {
+    // ignore
+  }
+  return undefined;
+}

--- a/packages/pi-dingtalk/src/config.ts
+++ b/packages/pi-dingtalk/src/config.ts
@@ -1,0 +1,14 @@
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+
+export type DingTalkConfig = {
+  clientId?: string;
+  clientSecret?: string;
+};
+
+const SETTINGS_KEY = 'pi-dingtalk';
+
+export function loadDingTalkConfig(cwd: string): DingTalkConfig | undefined {
+  const config = loadPiSettings<DingTalkConfig>(SETTINGS_KEY, { cwd });
+  if (!config || (!config.clientId && !config.clientSecret)) return undefined;
+  return config;
+}

--- a/packages/pi-dingtalk/src/index.ts
+++ b/packages/pi-dingtalk/src/index.ts
@@ -1,0 +1,69 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { ensureDws, getDwsSkillsDir, initDws, isDwsInstalled } from './cli.js';
+import { loadDingTalkConfig } from './config.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUNDLED_SKILLS_DIR = join(__dirname, '..', 'skills');
+
+function resolveSkillsDir(): string | undefined {
+  const cliSkills = getDwsSkillsDir();
+  if (cliSkills) return cliSkills;
+  if (existsSync(BUNDLED_SKILLS_DIR)) return BUNDLED_SKILLS_DIR;
+  return undefined;
+}
+
+export default function piDingTalkExtension(pi: ExtensionAPI): void {
+  let skillsDir: string | undefined;
+
+  pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
+    const config = loadDingTalkConfig(ctx.cwd);
+    if (!config?.clientId || !config?.clientSecret) return;
+
+    if (existsSync(BUNDLED_SKILLS_DIR)) {
+      skillsDir = BUNDLED_SKILLS_DIR;
+    }
+
+    if (isDwsInstalled()) {
+      try {
+        initDws(config);
+        skillsDir = resolveSkillsDir();
+        ctx.ui.setStatus?.('pi-dingtalk', 'dws: ready');
+      } catch (err) {
+        ctx.ui.notify(
+          `pi-dingtalk: 初始化失败 — ${err instanceof Error ? err.message : String(err)}`,
+          'warning',
+        );
+      }
+    } else {
+      ctx.ui.setStatus?.('pi-dingtalk', 'installing dws...');
+      ensureDws()
+        .then((installed) => {
+          if (installed) {
+            initDws(config);
+            skillsDir = resolveSkillsDir();
+            ctx.ui.setStatus?.('pi-dingtalk', 'dws: ready');
+          }
+        })
+        .catch((err) => {
+          ctx.ui.notify(
+            `pi-dingtalk: 安装失败 — ${err instanceof Error ? err.message : String(err)}`,
+            'warning',
+          );
+        });
+    }
+  });
+
+  pi.on('resources_discover', () => {
+    if (skillsDir) {
+      return { skillPaths: [skillsDir] };
+    }
+    return {};
+  });
+
+  pi.on('session_shutdown', async () => {
+    skillsDir = undefined;
+  });
+}

--- a/packages/pi-dingtalk/tsconfig.json
+++ b/packages/pi-dingtalk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    { "path": "../shared" }
+  ],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/pi-lark/README.md
+++ b/packages/pi-lark/README.md
@@ -1,0 +1,51 @@
+# pi-lark
+
+Pi extension for [Lark/Feishu](https://www.feishu.cn/) workspace — calendar, docs, drive, sheets, tasks, mail and more via [lark-cli](https://github.com/larksuite/cli).
+
+## Features
+
+- Auto-installs `lark-cli` if not present
+- Initializes credentials from pi settings (non-interactive)
+- Injects lark-cli skills into the agent session (calendar, IM, docs, drive, sheets, tasks, mail, wiki, etc.)
+
+## Configuration
+
+Add to your `.pi/settings.json`:
+
+```json
+{
+  "pi-lark": {
+    "appId": "cli_xxx",
+    "appSecret": "your_app_secret",
+    "domain": "feishu"
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `appId` | Yes | App ID from [Feishu Open Platform](https://open.feishu.cn/) |
+| `appSecret` | Yes | App Secret |
+| `domain` | No | `"feishu"` (default) or `"lark"` (international) |
+
+## Skills Provided
+
+27 skills from lark-cli covering:
+
+- `lark-calendar` — Events, agenda, free/busy, room booking
+- `lark-im` — Messages, group chats, search
+- `lark-doc` — Create, read, update documents
+- `lark-drive` — Upload, download, manage files
+- `lark-sheets` — Spreadsheet CRUD
+- `lark-base` — Tables, records, views, dashboards
+- `lark-task` — Tasks, subtasks, reminders
+- `lark-mail` — Email send, read, search
+- `lark-wiki` — Knowledge spaces and nodes
+- `lark-contact` — User search, profiles
+- And more...
+
+## CLI Reference
+
+- Repository: https://github.com/larksuite/cli
+- Install: `npm install -g @larksuite/cli`
+- Docs: https://github.com/larksuite/cli#readme

--- a/packages/pi-lark/package.json
+++ b/packages/pi-lark/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@amaster.ai/pi-lark",
+  "version": "0.1.0",
+  "description": "Pi extension for Lark/Feishu workspace — calendar, docs, drive, sheets, tasks, mail and more via lark-cli.",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "lark",
+    "feishu"
+  ],
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TGYD-helige/pi.git",
+    "directory": "packages/pi-lark"
+  },
+  "scripts": {
+    "fetch-skills": "node scripts/fetch-skills.mjs",
+    "prebuild": "node scripts/fetch-skills.mjs",
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false",
+    "test": "vitest run src"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.74.0",
+    "typebox": "*",
+    "vitest": "^4.0.0"
+  },
+  "dependencies": {
+    "@amaster.ai/pi-shared": "workspace:*"
+  }
+}

--- a/packages/pi-lark/scripts/fetch-skills.mjs
+++ b/packages/pi-lark/scripts/fetch-skills.mjs
@@ -1,0 +1,50 @@
+/**
+ * Fetches the latest lark-cli skills from GitHub and writes them to the skills/ directory.
+ * Run via: node scripts/fetch-skills.mjs
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = join(__dirname, '..', 'skills');
+const REPO = 'larksuite/cli';
+const BRANCH = 'main';
+const REMOTE_PATH = 'skills';
+
+async function fetchSkills() {
+  console.log('[pi-lark] Fetching skills from github.com/%s ...', REPO);
+
+  if (existsSync(SKILLS_DIR)) {
+    rmSync(SKILLS_DIR, { recursive: true, force: true });
+  }
+  mkdirSync(SKILLS_DIR, { recursive: true });
+
+  const tmpDir = join(__dirname, '..', '.tmp-skills-fetch');
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  mkdirSync(tmpDir, { recursive: true });
+
+  try {
+    execSync(
+      `git clone --depth 1 --filter=blob:none --sparse https://github.com/${REPO}.git .`,
+      { cwd: tmpDir, stdio: 'pipe' },
+    );
+    execSync(`git sparse-checkout set ${REMOTE_PATH}`, { cwd: tmpDir, stdio: 'pipe' });
+
+    const srcSkills = join(tmpDir, REMOTE_PATH);
+    if (!existsSync(srcSkills)) {
+      throw new Error(`Skills directory not found at ${srcSkills}`);
+    }
+
+    execSync(`cp -r "${srcSkills}/"* "${SKILLS_DIR}/"`, { stdio: 'pipe' });
+    console.log('[pi-lark] Skills fetched successfully.');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+fetchSkills().catch((err) => {
+  console.warn('[pi-lark] Failed to fetch skills (using existing if available):', err.message);
+  process.exit(0);
+});

--- a/packages/pi-lark/src/__tests__/cli.test.ts
+++ b/packages/pi-lark/src/__tests__/cli.test.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { initLarkCli } from '../cli.js';
+
+describe('initLarkCli', () => {
+  let configDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    configDir = join(
+      tmpdir(),
+      `lark-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    originalEnv = { ...process.env };
+    process.env.LARKSUITE_CLI_CONFIG_DIR = configDir;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test('writes config.json with correct content', async () => {
+    await initLarkCli({ appId: 'cli_abc', appSecret: 'secret123', domain: 'feishu' });
+
+    const configFile = join(configDir, 'config.json');
+    expect(existsSync(configFile)).toBe(true);
+
+    const content = JSON.parse(readFileSync(configFile, 'utf-8'));
+    expect(content.apps).toHaveLength(1);
+    expect(content.apps[0].appId).toBe('cli_abc');
+    expect(content.apps[0].appSecret).toBe('secret123');
+    expect(content.apps[0].brand).toBe('feishu');
+  });
+
+  test('uses lark brand when domain is lark', async () => {
+    await initLarkCli({ appId: 'cli_abc', appSecret: 'secret123', domain: 'lark' });
+
+    const configFile = join(configDir, 'config.json');
+    const content = JSON.parse(readFileSync(configFile, 'utf-8'));
+    expect(content.apps[0].brand).toBe('lark');
+  });
+
+  test('defaults to feishu brand when domain is unset', async () => {
+    await initLarkCli({ appId: 'cli_abc', appSecret: 'secret123' });
+
+    const configFile = join(configDir, 'config.json');
+    const content = JSON.parse(readFileSync(configFile, 'utf-8'));
+    expect(content.apps[0].brand).toBe('feishu');
+  });
+
+  test('rejects when appId is missing', async () => {
+    await expect(initLarkCli({ appSecret: 'secret123' })).rejects.toThrow(
+      'appId and appSecret are required',
+    );
+  });
+
+  test('rejects when appSecret is missing', async () => {
+    await expect(initLarkCli({ appId: 'cli_abc' })).rejects.toThrow(
+      'appId and appSecret are required',
+    );
+  });
+
+  test('creates config directory if it does not exist', async () => {
+    const nested = join(configDir, 'sub', 'dir');
+    process.env.LARKSUITE_CLI_CONFIG_DIR = nested;
+
+    await initLarkCli({ appId: 'cli_abc', appSecret: 'secret123' });
+
+    expect(existsSync(join(nested, 'config.json'))).toBe(true);
+  });
+});

--- a/packages/pi-lark/src/__tests__/config.test.ts
+++ b/packages/pi-lark/src/__tests__/config.test.ts
@@ -1,0 +1,65 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { loadLarkConfig } from '../config.js';
+
+describe('loadLarkConfig', () => {
+  let base: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    base = join(tmpdir(), `pi-lark-config-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    originalEnv = { ...process.env };
+    process.env.PI_CODING_AGENT_DIR = join(base, 'agent');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('returns undefined when no config exists', () => {
+    mkdirSync(join(base, 'project'), { recursive: true });
+    const config = loadLarkConfig(join(base, 'project'));
+    expect(config).toBeUndefined();
+  });
+
+  test('loads config from .pi/settings.json', () => {
+    const project = join(base, 'project');
+    mkdirSync(join(project, '.pi'), { recursive: true });
+    writeFileSync(
+      join(project, '.pi', 'settings.json'),
+      JSON.stringify({
+        'pi-lark': {
+          appId: 'cli_test123',
+          appSecret: 'secret456',
+          domain: 'feishu',
+        },
+      }),
+    );
+
+    const config = loadLarkConfig(project);
+
+    expect(config).toEqual({
+      appId: 'cli_test123',
+      appSecret: 'secret456',
+      domain: 'feishu',
+    });
+  });
+
+  test('returns undefined when appId and appSecret are both empty', () => {
+    const project = join(base, 'project');
+    mkdirSync(join(project, '.pi'), { recursive: true });
+    writeFileSync(
+      join(project, '.pi', 'settings.json'),
+      JSON.stringify({
+        'pi-lark': { domain: 'feishu' },
+      }),
+    );
+
+    const config = loadLarkConfig(project);
+    expect(config).toBeUndefined();
+  });
+});

--- a/packages/pi-lark/src/__tests__/extension.test.ts
+++ b/packages/pi-lark/src/__tests__/extension.test.ts
@@ -1,0 +1,73 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+type Handler = (...args: any[]) => any;
+
+describe('piLarkExtension', () => {
+  let base: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    base = join(tmpdir(), `pi-lark-ext-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(base, { recursive: true });
+    originalEnv = { ...process.env };
+    process.env.PI_CODING_AGENT_DIR = join(base, 'agent');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    vi.resetModules();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('does not inject skills when config is missing', async () => {
+    const handlers: Record<string, Handler> = {};
+    const mockPi = {
+      on: (event: string, handler: Handler) => {
+        handlers[event] = handler;
+      },
+    };
+
+    const { default: piLarkExtension } = await import('../index.js');
+    piLarkExtension(mockPi as any);
+
+    const project = join(base, 'project');
+    mkdirSync(project, { recursive: true });
+
+    await handlers.session_start!(
+      { type: 'session_start', reason: 'startup' },
+      { cwd: project, ui: { notify: vi.fn(), setStatus: vi.fn() } },
+    );
+
+    const result = handlers.resources_discover!({
+      type: 'resources_discover',
+      cwd: project,
+      reason: 'startup',
+    });
+    expect(result).toEqual({});
+  });
+
+  test('session_shutdown clears skillsDir', async () => {
+    const handlers: Record<string, Handler> = {};
+    const mockPi = {
+      on: (event: string, handler: Handler) => {
+        handlers[event] = handler;
+      },
+    };
+
+    const { default: piLarkExtension } = await import('../index.js');
+    piLarkExtension(mockPi as any);
+
+    await handlers.session_shutdown!({ type: 'session_shutdown' }, {} as any);
+
+    const result = handlers.resources_discover!({
+      type: 'resources_discover',
+      cwd: base,
+      reason: 'startup',
+    });
+    expect(result).toEqual({});
+  });
+});

--- a/packages/pi-lark/src/cli.ts
+++ b/packages/pi-lark/src/cli.ts
@@ -1,0 +1,107 @@
+import { exec, execSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { LarkConfig } from './config.js';
+
+const NPM_PACKAGE = '@larksuite/cli';
+
+export function isLarkCliInstalled(): boolean {
+  try {
+    execSync('lark-cli --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function installLarkCli(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    exec(`npm install -g ${NPM_PACKAGE}@latest`, (error) => {
+      if (error) reject(new Error(`Failed to install ${NPM_PACKAGE}: ${error.message}`));
+      else resolve();
+    });
+  });
+}
+
+export async function ensureLarkCli(): Promise<boolean> {
+  if (isLarkCliInstalled()) return true;
+  await installLarkCli();
+  return isLarkCliInstalled();
+}
+
+export function initLarkCli(config: LarkConfig): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const { appId, appSecret, domain } = config;
+    if (!appId || !appSecret) {
+      reject(new Error('appId and appSecret are required'));
+      return;
+    }
+
+    const configDir = process.env.LARKSUITE_CLI_CONFIG_DIR || join(homedir(), '.lark-cli');
+    const configFile = join(configDir, 'config.json');
+
+    const brand = domain === 'lark' ? 'lark' : 'feishu';
+
+    if (!existsSync(configDir)) {
+      mkdirSync(configDir, { mode: 0o700, recursive: true });
+    }
+
+    const configContent = JSON.stringify(
+      {
+        apps: [
+          {
+            appId,
+            appSecret,
+            brand,
+            users: [],
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
+    writeFileSync(configFile, `${configContent}\n`, { mode: 0o600 });
+    resolve();
+  });
+}
+
+export function getLarkCliSkillsDir(): string | undefined {
+  try {
+    const output = execSync('lark-cli skills path', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    if (output && existsSync(output)) return output;
+  } catch {
+    // fallback: try to find skills in the npm global package
+  }
+
+  try {
+    const npmRoot = execSync('npm root -g', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    const skillsPath = join(npmRoot, '@larksuite', 'cli', 'skills');
+    if (existsSync(skillsPath)) return skillsPath;
+  } catch {
+    // ignore
+  }
+
+  return undefined;
+}
+
+export function checkLarkCliAuth(): { ok: boolean; error?: string } {
+  try {
+    const output = execSync('lark-cli auth status --json', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    const status = JSON.parse(output);
+    if (status?.loggedIn || status?.authenticated) return { ok: true };
+    return { ok: false, error: 'not authenticated' };
+  } catch {
+    return { ok: false, error: 'lark-cli auth status failed' };
+  }
+}

--- a/packages/pi-lark/src/config.ts
+++ b/packages/pi-lark/src/config.ts
@@ -1,0 +1,15 @@
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+
+export type LarkConfig = {
+  appId?: string;
+  appSecret?: string;
+  domain?: 'feishu' | 'lark' | string;
+};
+
+const SETTINGS_KEY = 'pi-lark';
+
+export function loadLarkConfig(cwd: string): LarkConfig | undefined {
+  const config = loadPiSettings<LarkConfig>(SETTINGS_KEY, { cwd });
+  if (!config || (!config.appId && !config.appSecret)) return undefined;
+  return config;
+}

--- a/packages/pi-lark/src/index.ts
+++ b/packages/pi-lark/src/index.ts
@@ -1,0 +1,70 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { ensureLarkCli, getLarkCliSkillsDir, initLarkCli, isLarkCliInstalled } from './cli.js';
+import { loadLarkConfig } from './config.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUNDLED_SKILLS_DIR = join(__dirname, '..', 'skills');
+
+function resolveSkillsDir(): string | undefined {
+  const cliSkills = getLarkCliSkillsDir();
+  if (cliSkills) return cliSkills;
+  if (existsSync(BUNDLED_SKILLS_DIR)) return BUNDLED_SKILLS_DIR;
+  return undefined;
+}
+
+export default function piLarkExtension(pi: ExtensionAPI): void {
+  let skillsDir: string | undefined;
+
+  pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
+    const config = loadLarkConfig(ctx.cwd);
+    if (!config?.appId || !config?.appSecret) return;
+
+    // Use bundled skills immediately so they're available while CLI installs
+    if (existsSync(BUNDLED_SKILLS_DIR)) {
+      skillsDir = BUNDLED_SKILLS_DIR;
+    }
+
+    if (isLarkCliInstalled()) {
+      try {
+        await initLarkCli(config);
+        skillsDir = resolveSkillsDir();
+        ctx.ui.setStatus?.('pi-lark', 'lark-cli: ready');
+      } catch (err) {
+        ctx.ui.notify(
+          `pi-lark: 初始化失败 — ${err instanceof Error ? err.message : String(err)}`,
+          'warning',
+        );
+      }
+    } else {
+      ctx.ui.setStatus?.('pi-lark', 'installing lark-cli...');
+      ensureLarkCli()
+        .then(async (installed) => {
+          if (installed) {
+            await initLarkCli(config);
+            skillsDir = resolveSkillsDir();
+            ctx.ui.setStatus?.('pi-lark', 'lark-cli: ready');
+          }
+        })
+        .catch((err) => {
+          ctx.ui.notify(
+            `pi-lark: 安装失败 — ${err instanceof Error ? err.message : String(err)}`,
+            'warning',
+          );
+        });
+    }
+  });
+
+  pi.on('resources_discover', () => {
+    if (skillsDir) {
+      return { skillPaths: [skillsDir] };
+    }
+    return {};
+  });
+
+  pi.on('session_shutdown', async () => {
+    skillsDir = undefined;
+  });
+}

--- a/packages/pi-lark/tsconfig.json
+++ b/packages/pi-lark/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    { "path": "../shared" }
+  ],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/pi-teamwork/README.md
+++ b/packages/pi-teamwork/README.md
@@ -21,7 +21,7 @@ Set `autoInstall: false` to disable this behavior.
 
 ### Mode 1 — Self-hosted server
 
-For teams running their own Multica server. The extension runs `multica setup self-host` with the provided URL, then authenticates with the token:
+For teams running their own Multica server. The extension runs `multica setup self-host` with the provided URLs, then authenticates with the token:
 
 ```json
 {
@@ -30,6 +30,7 @@ For teams running their own Multica server. The extension runs `multica setup se
     "provider": "multica",
     "multica": {
       "serverUrl": "https://api.your-server.com",
+      "appUrl": "https://your-server.com",
       "token": "<token-from-multica-server>"
     }
   }
@@ -78,6 +79,7 @@ For CI or non-interactive environments where you can't run `multica setup`. The 
 | `multica.workspace` | Workspace ID override; leave empty to use multica's default |
 | `multica.token` | Headless-login token. Omit when multica is already logged in on the machine |
 | `multica.serverUrl` | Self-hosted server API URL. Triggers `multica setup self-host --server-url` on start |
+| `multica.appUrl` | Self-hosted server frontend URL. Required when `serverUrl` is a remote address |
 | `multica.autoInstall` | Auto-install multica CLI if missing (default: `true`) |
 
 ## Tools

--- a/packages/pi-teamwork/README.md
+++ b/packages/pi-teamwork/README.md
@@ -10,11 +10,35 @@ Pi extension for team collaboration and project management. Provides LLM-callabl
 
 ## Configuration
 
-This extension does **not** manage multica's setup or credentials — those live with the multica CLI itself. Pick one of two modes:
+### Auto-Install
 
-### Mode 1 — Pre-configured environment (recommended)
+When the extension starts and `multica` is not found on `$PATH`, it will automatically install the CLI:
 
-Run `multica setup` once on the machine and finish login through multica's normal flow. The extension will reuse that state, and you can leave the auth fields empty:
+- **macOS / Linux**: Homebrew (`brew install multica-ai/tap/multica`) with a fallback to the install script (`curl -fsSL ... | bash`)
+- **Windows**: PowerShell install script (`irm ... | iex`)
+
+Set `autoInstall: false` to disable this behavior.
+
+### Mode 1 — Self-hosted server
+
+For teams running their own Multica server. The extension runs `multica setup self-host` with the provided URL, then authenticates with the token:
+
+```json
+{
+  "pi-teamwork": {
+    "enabled": true,
+    "provider": "multica",
+    "multica": {
+      "serverUrl": "https://api.your-server.com",
+      "token": "<token-from-multica-server>"
+    }
+  }
+}
+```
+
+### Mode 2 — Pre-configured environment
+
+Run `multica setup` once on the machine and finish login through multica's normal flow. The extension will reuse that state:
 
 ```json
 {
@@ -28,9 +52,9 @@ Run `multica setup` once on the machine and finish login through multica's norma
 }
 ```
 
-### Mode 2 — Headless token
+### Mode 3 — Headless token (Multica Cloud)
 
-For CI or non-interactive environments where you can't run `multica setup`. Issue a long-lived token from your multica server, and the extension will run `multica login --token <token>` on every `session_start`:
+For CI or non-interactive environments where you can't run `multica setup`. The extension will run `multica login --token <token>` on every `session_start`:
 
 ```json
 {
@@ -52,7 +76,9 @@ For CI or non-interactive environments where you can't run `multica setup`. Issu
 | `provider` | Provider name (currently only `multica`) |
 | `multica.binary` | Path to multica binary (default: `multica`) |
 | `multica.workspace` | Workspace ID override; leave empty to use multica's default |
-| `multica.token` | Headless-login token. Only set in mode 2; omit when multica is already logged in on the machine |
+| `multica.token` | Headless-login token. Omit when multica is already logged in on the machine |
+| `multica.serverUrl` | Self-hosted server API URL. Triggers `multica setup self-host --server-url` on start |
+| `multica.autoInstall` | Auto-install multica CLI if missing (default: `true`) |
 
 ## Tools
 
@@ -77,7 +103,8 @@ src/
 ├── index.ts              # Generic tool layer (provider-agnostic)
 ├── types.ts              # TeamworkProvider interface + shared types
 └── adapters/
-    └── multica.ts        # Multica CLI adapter + initialization
+    ├── multica.ts        # Multica CLI adapter + initialization
+    └── multica-installer.ts  # Auto-detect & install multica CLI
 ```
 
 The extension uses a provider pattern — `index.ts` registers tools that delegate to a `TeamworkProvider` interface. Adding a new provider (Linear, Jira, etc.) only requires implementing the interface and adding a factory branch in `session_start`.

--- a/packages/pi-teamwork/src/adapters/multica-installer.ts
+++ b/packages/pi-teamwork/src/adapters/multica-installer.ts
@@ -1,0 +1,95 @@
+import type { ExecFn } from '../types.js';
+
+export type InstallResult = {
+  installed: boolean;
+  alreadyPresent: boolean;
+  error?: string;
+};
+
+const BREW_TAP = 'multica-ai/tap/multica';
+const INSTALL_SCRIPT_URL =
+  'https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.sh';
+const INSTALL_PS1_URL =
+  'https://raw.githubusercontent.com/multica-ai/multica/main/scripts/install.ps1';
+
+export async function ensureMulticaBinary(binary: string, exec: ExecFn): Promise<InstallResult> {
+  if (await isAvailable(binary, exec)) {
+    return { installed: true, alreadyPresent: true };
+  }
+
+  const platform = process.platform;
+  let installError: string | undefined;
+
+  if (platform === 'win32') {
+    installError = await installWindows(exec);
+  } else {
+    installError = await installUnix(exec);
+  }
+
+  if (installError) {
+    return { installed: false, alreadyPresent: false, error: installError };
+  }
+
+  if (await isAvailable(binary, exec)) {
+    return { installed: true, alreadyPresent: false };
+  }
+
+  return {
+    installed: false,
+    alreadyPresent: false,
+    error: 'multica binary not found on PATH after installation',
+  };
+}
+
+async function isAvailable(binary: string, exec: ExecFn): Promise<boolean> {
+  try {
+    const { code } = await exec(binary, ['--version']);
+    return code === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function installUnix(exec: ExecFn): Promise<string | undefined> {
+  const hasBrew = await checkBrew(exec);
+
+  if (hasBrew) {
+    try {
+      const { code } = await exec('brew', ['install', BREW_TAP]);
+      if (code === 0) return undefined;
+    } catch {
+      // brew threw, fall through to curl
+    }
+  }
+
+  return installViaCurl(exec);
+}
+
+async function checkBrew(exec: ExecFn): Promise<boolean> {
+  try {
+    const { code } = await exec('which', ['brew']);
+    return code === 0;
+  } catch {
+    return false;
+  }
+}
+
+async function installViaCurl(exec: ExecFn): Promise<string | undefined> {
+  try {
+    const { code, stderr } = await exec('bash', ['-c', `curl -fsSL ${INSTALL_SCRIPT_URL} | bash`]);
+    if (code === 0) return undefined;
+    return stderr.trim() || `install script exited with code ${code}`;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}
+
+async function installWindows(exec: ExecFn): Promise<string | undefined> {
+  try {
+    const { code, stderr } = await exec('powershell', ['-Command', `irm ${INSTALL_PS1_URL} | iex`]);
+    if (code === 0) return undefined;
+    return stderr.trim() || `install script exited with code ${code}`;
+  } catch (e) {
+    return e instanceof Error ? e.message : String(e);
+  }
+}

--- a/packages/pi-teamwork/src/adapters/multica.ts
+++ b/packages/pi-teamwork/src/adapters/multica.ts
@@ -8,6 +8,7 @@ import type {
   MulticaAdapterConfig,
   Project,
   TeamworkProvider,
+  Workspace,
 } from '../types.js';
 import { ensureMulticaBinary, type InstallResult } from './multica-installer.js';
 
@@ -33,12 +34,24 @@ export async function initMulticaProvider(
   }
 
   if (config.serverUrl) {
-    const setupArgs = ['setup', 'self-host', '--server-url', config.serverUrl];
     try {
-      await exec(binary, setupArgs);
+      await exec(binary, ['config', 'set', 'server_url', config.serverUrl]);
     } catch {
-      // Setup may already be done
+      // Config may already be set
     }
+    if (config.appUrl) {
+      try {
+        await exec(binary, ['config', 'set', 'app_url', config.appUrl]);
+      } catch {
+        // Config may already be set
+      }
+    }
+  }
+
+  try {
+    await exec(binary, ['daemon', 'start']);
+  } catch {
+    // Daemon may already be running
   }
 
   if (config.token) {
@@ -49,32 +62,41 @@ export async function initMulticaProvider(
     }
   }
 
-  try {
-    await exec(binary, ['daemon', 'start']);
-  } catch {
-    // Daemon may already be running
-  }
-
   return { adapter: new MulticaAdapter(config, exec), installResult };
 }
 
 export class MulticaAdapter implements TeamworkProvider {
   readonly name = 'multica';
   private readonly binary: string;
-  private readonly workspaceArgs: string[];
+  private readonly defaultWorkspaceArgs: string[];
 
   constructor(
     config: MulticaAdapterConfig,
     private readonly exec: ExecFn,
   ) {
     this.binary = config.binary?.trim() || 'multica';
-    this.workspaceArgs = config.workspace?.trim()
+    this.defaultWorkspaceArgs = config.workspace?.trim()
       ? ['--workspace-id', config.workspace.trim()]
       : [];
   }
 
+  private wsArgs(workspaceId?: string): string[] {
+    return workspaceId ? ['--workspace-id', workspaceId] : this.defaultWorkspaceArgs;
+  }
+
+  async listWorkspaces(): Promise<Workspace[]> {
+    const result = await this.run(['workspace', 'list', '--output', 'json']);
+    const data = parseJson(result);
+    if (!Array.isArray(data)) return [];
+    return data.map((item) => ({
+      id: String(item.id ?? ''),
+      name: String(item.name ?? item.title ?? ''),
+    }));
+  }
+
   async listIssues(filter?: IssueListFilter): Promise<Issue[]> {
-    const args = ['issue', 'list', '--output', 'json', ...this.workspaceArgs];
+    const wsArgs = this.wsArgs(filter?.workspaceId);
+    const args = ['issue', 'list', '--output', 'json', ...wsArgs];
     if (filter?.status) args.push('--status', filter.status);
     if (filter?.assignee) args.push('--assignee', filter.assignee);
     if (filter?.project) args.push('--project', filter.project);
@@ -85,15 +107,23 @@ export class MulticaAdapter implements TeamworkProvider {
     return data.map(mapIssue);
   }
 
-  async getIssue(id: string): Promise<Issue | undefined> {
-    const result = await this.run(['issue', 'get', id, '--output', 'json', ...this.workspaceArgs]);
+  async getIssue(id: string, workspaceId?: string): Promise<Issue | undefined> {
+    const result = await this.run([
+      'issue',
+      'get',
+      id,
+      '--output',
+      'json',
+      ...this.wsArgs(workspaceId),
+    ]);
     const data = parseJson(result);
     if (!data || typeof data !== 'object') return undefined;
     return mapIssue(data);
   }
 
   async createIssue(input: IssueCreateInput): Promise<Issue> {
-    const args = ['issue', 'create', '--title', input.title, ...this.workspaceArgs];
+    const wsArgs = this.wsArgs(input.workspaceId);
+    const args = ['issue', 'create', '--title', input.title, ...wsArgs];
     if (input.description) args.push('--description', input.description);
     if (input.priority) args.push('--priority', input.priority);
     if (input.assignee) args.push('--assignee', input.assignee);
@@ -104,9 +134,14 @@ export class MulticaAdapter implements TeamworkProvider {
     return { id: 'unknown', title: input.title, status: 'todo' };
   }
 
-  async updateIssue(id: string, input: IssueUpdateInput): Promise<Issue | undefined> {
+  async updateIssue(
+    id: string,
+    input: IssueUpdateInput,
+    workspaceId?: string,
+  ): Promise<Issue | undefined> {
+    const wsArgs = this.wsArgs(workspaceId);
     if (input.status) {
-      await this.run(['issue', 'status', id, input.status, ...this.workspaceArgs]);
+      await this.run(['issue', 'status', id, input.status, ...wsArgs]);
     }
     const updateArgs: string[] = [];
     if (input.title) updateArgs.push('--title', input.title);
@@ -114,13 +149,19 @@ export class MulticaAdapter implements TeamworkProvider {
     if (input.priority) updateArgs.push('--priority', input.priority);
     if (input.assignee) updateArgs.push('--assignee', input.assignee);
     if (updateArgs.length > 0) {
-      await this.run(['issue', 'update', id, ...updateArgs, ...this.workspaceArgs]);
+      await this.run(['issue', 'update', id, ...updateArgs, ...wsArgs]);
     }
-    return this.getIssue(id);
+    return this.getIssue(id, workspaceId);
   }
 
-  async addComment(issueId: string, content: string, parentId?: string): Promise<Comment> {
-    const args = ['issue', 'comment', 'add', issueId, '--content', content, ...this.workspaceArgs];
+  async addComment(
+    issueId: string,
+    content: string,
+    parentId?: string,
+    workspaceId?: string,
+  ): Promise<Comment> {
+    const wsArgs = this.wsArgs(workspaceId);
+    const args = ['issue', 'comment', 'add', issueId, '--content', content, ...wsArgs];
     if (parentId) args.push('--parent', parentId);
     const result = await this.run(args);
     const data = parseJson(result);
@@ -137,7 +178,7 @@ export class MulticaAdapter implements TeamworkProvider {
     return { id: 'unknown', issueId, content };
   }
 
-  async listComments(issueId: string): Promise<Comment[]> {
+  async listComments(issueId: string, workspaceId?: string): Promise<Comment[]> {
     const result = await this.run([
       'issue',
       'comment',
@@ -145,7 +186,7 @@ export class MulticaAdapter implements TeamworkProvider {
       issueId,
       '--output',
       'json',
-      ...this.workspaceArgs,
+      ...this.wsArgs(workspaceId),
     ]);
     const data = parseJson(result);
     if (!Array.isArray(data)) return [];
@@ -159,8 +200,14 @@ export class MulticaAdapter implements TeamworkProvider {
     }));
   }
 
-  async listProjects(): Promise<Project[]> {
-    const result = await this.run(['project', 'list', '--output', 'json', ...this.workspaceArgs]);
+  async listProjects(workspaceId?: string): Promise<Project[]> {
+    const result = await this.run([
+      'project',
+      'list',
+      '--output',
+      'json',
+      ...this.wsArgs(workspaceId),
+    ]);
     const data = parseJson(result);
     if (!Array.isArray(data)) return [];
     return data.map((item) => ({

--- a/packages/pi-teamwork/src/adapters/multica.ts
+++ b/packages/pi-teamwork/src/adapters/multica.ts
@@ -9,12 +9,37 @@ import type {
   Project,
   TeamworkProvider,
 } from '../types.js';
+import { ensureMulticaBinary, type InstallResult } from './multica-installer.js';
+
+export type InitMulticaResult = {
+  adapter: MulticaAdapter;
+  installResult: InstallResult;
+};
 
 export async function initMulticaProvider(
   config: MulticaAdapterConfig,
   exec: ExecFn,
-): Promise<MulticaAdapter> {
+): Promise<InitMulticaResult> {
   const binary = config.binary?.trim() || 'multica';
+  const autoInstall = config.autoInstall !== false;
+
+  let installResult: InstallResult = { installed: true, alreadyPresent: true };
+
+  if (autoInstall) {
+    installResult = await ensureMulticaBinary(binary, exec);
+    if (!installResult.installed) {
+      return { adapter: new MulticaAdapter(config, exec), installResult };
+    }
+  }
+
+  if (config.serverUrl) {
+    const setupArgs = ['setup', 'self-host', '--server-url', config.serverUrl];
+    try {
+      await exec(binary, setupArgs);
+    } catch {
+      // Setup may already be done
+    }
+  }
 
   if (config.token) {
     try {
@@ -30,7 +55,7 @@ export async function initMulticaProvider(
     // Daemon may already be running
   }
 
-  return new MulticaAdapter(config, exec);
+  return { adapter: new MulticaAdapter(config, exec), installResult };
 }
 
 export class MulticaAdapter implements TeamworkProvider {

--- a/packages/pi-teamwork/src/index.test.ts
+++ b/packages/pi-teamwork/src/index.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { initMulticaProvider, MulticaAdapter } from './adapters/multica.js';
+import { ensureMulticaBinary } from './adapters/multica-installer.js';
 import type { ExecFn } from './types.js';
 
 function _mockExec(
@@ -244,8 +245,9 @@ describe('initMulticaProvider', () => {
       return { stdout: '', stderr: '', code: 0 };
     };
     await initMulticaProvider({ token: 'my-token' }, exec);
-    expect(calls[0]).toEqual(['login', '--token', 'my-token']);
-    expect(calls[1]).toEqual(['daemon', 'start']);
+    expect(calls[0]).toEqual(['--version']);
+    expect(calls[1]).toEqual(['login', '--token', 'my-token']);
+    expect(calls[2]).toEqual(['daemon', 'start']);
   });
 
   it('skips login when no token', async () => {
@@ -255,8 +257,9 @@ describe('initMulticaProvider', () => {
       return { stdout: '', stderr: '', code: 0 };
     };
     await initMulticaProvider({}, exec);
-    expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual(['daemon', 'start']);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual(['--version']);
+    expect(calls[1]).toEqual(['daemon', 'start']);
   });
 
   it('continues even if login fails', async () => {
@@ -266,8 +269,8 @@ describe('initMulticaProvider', () => {
       if (args.includes('start')) daemonStarted = true;
       return { stdout: '', stderr: '', code: 0 };
     };
-    const provider = await initMulticaProvider({ token: 'bad-token' }, exec);
-    expect(provider).toBeInstanceOf(MulticaAdapter);
+    const { adapter } = await initMulticaProvider({ token: 'bad-token' }, exec);
+    expect(adapter).toBeInstanceOf(MulticaAdapter);
     expect(daemonStarted).toBe(true);
   });
 
@@ -276,13 +279,385 @@ describe('initMulticaProvider', () => {
       if (args.includes('start')) throw new Error('already running');
       return { stdout: '', stderr: '', code: 0 };
     };
-    const provider = await initMulticaProvider({}, exec);
-    expect(provider).toBeInstanceOf(MulticaAdapter);
+    const { adapter } = await initMulticaProvider({}, exec);
+    expect(adapter).toBeInstanceOf(MulticaAdapter);
   });
 
   it('returns a MulticaAdapter instance', async () => {
-    const provider = await initMulticaProvider({}, successExec());
-    expect(provider).toBeInstanceOf(MulticaAdapter);
-    expect(provider.name).toBe('multica');
+    const { adapter } = await initMulticaProvider({}, successExec());
+    expect(adapter).toBeInstanceOf(MulticaAdapter);
+    expect(adapter.name).toBe('multica');
+  });
+
+  it('skips install when autoInstall is false', async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = async (_cmd, args) => {
+      calls.push(args);
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    await initMulticaProvider({ autoInstall: false }, exec);
+    expect(calls[0]).toEqual(['daemon', 'start']);
+  });
+
+  it('runs setup self-host when serverUrl is configured', async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = async (_cmd, args) => {
+      calls.push(args);
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    await initMulticaProvider({ serverUrl: 'https://api.example.com' }, exec);
+    expect(calls).toContainEqual(['setup', 'self-host', '--server-url', 'https://api.example.com']);
+  });
+
+  it('runs setup self-host before login when both serverUrl and token are configured', async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = async (_cmd, args) => {
+      calls.push(args);
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    await initMulticaProvider({ serverUrl: 'https://api.example.com', token: 'my-token' }, exec);
+    const setupIdx = calls.findIndex((a) => a[0] === 'setup');
+    const loginIdx = calls.findIndex((a) => a[0] === 'login');
+    expect(setupIdx).toBeGreaterThan(-1);
+    expect(loginIdx).toBeGreaterThan(-1);
+    expect(setupIdx).toBeLessThan(loginIdx);
+  });
+
+  it('continues even if setup self-host fails', async () => {
+    let daemonStarted = false;
+    const exec: ExecFn = async (_cmd, args) => {
+      if (args[0] === 'setup') throw new Error('setup failed');
+      if (args.includes('start')) daemonStarted = true;
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    const { adapter } = await initMulticaProvider(
+      { serverUrl: 'https://api.example.com', token: 'tk' },
+      exec,
+    );
+    expect(adapter).toBeInstanceOf(MulticaAdapter);
+    expect(daemonStarted).toBe(true);
+  });
+
+  it('returns adapter even when install fails', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    const exec: ExecFn = async (cmd, args) => {
+      if (args[0] === '--version') return { stdout: '', stderr: '', code: 127 };
+      if (cmd === 'which') return { stdout: '', stderr: '', code: 1 };
+      if (cmd === 'bash') return { stdout: '', stderr: 'fail', code: 1 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    const { adapter, installResult } = await initMulticaProvider({}, exec);
+    expect(adapter).toBeInstanceOf(MulticaAdapter);
+    expect(installResult.installed).toBe(false);
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('does not run setup or login when install fails', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    const calls: { cmd: string; args: string[] }[] = [];
+    const exec: ExecFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === '--version') return { stdout: '', stderr: '', code: 127 };
+      if (cmd === 'which') return { stdout: '', stderr: '', code: 1 };
+      if (cmd === 'bash') return { stdout: '', stderr: 'fail', code: 1 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    await initMulticaProvider({ serverUrl: 'https://api.example.com', token: 'tk' }, exec);
+    expect(calls.some((c) => c.args[0] === 'setup')).toBe(false);
+    expect(calls.some((c) => c.args[0] === 'login')).toBe(false);
+    expect(calls.some((c) => c.args.includes('start'))).toBe(false);
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('uses custom binary path for version check and all commands', async () => {
+    const cmds: string[] = [];
+    const exec: ExecFn = async (cmd, _args) => {
+      cmds.push(cmd);
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    await initMulticaProvider({ binary: '/opt/multica', token: 'tk', autoInstall: false }, exec);
+    expect(cmds.every((c) => c === '/opt/multica')).toBe(true);
+  });
+});
+
+describe('ensureMulticaBinary', () => {
+  it('returns alreadyPresent when binary exists', async () => {
+    const exec: ExecFn = async () => ({ stdout: 'multica 1.0.0', stderr: '', code: 0 });
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result).toEqual({ installed: true, alreadyPresent: true });
+  });
+
+  it('attempts brew install on macOS/Linux when brew is available', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    const calls: { cmd: string; args: string[] }[] = [];
+    let versionCallCount = 0;
+    const exec: ExecFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === '--version') {
+        versionCallCount++;
+        if (versionCallCount === 1) return { stdout: '', stderr: '', code: 127 };
+        return { stdout: 'multica 1.0.0', stderr: '', code: 0 };
+      }
+      if (cmd === 'which' && args[0] === 'brew')
+        return { stdout: '/opt/homebrew/bin/brew', stderr: '', code: 0 };
+      if (cmd === 'brew') return { stdout: '', stderr: '', code: 0 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result).toEqual({ installed: true, alreadyPresent: false });
+    expect(calls.some((c) => c.cmd === 'brew' && c.args.includes('multica-ai/tap/multica'))).toBe(
+      true,
+    );
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to curl when brew is not available', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+
+    const calls: { cmd: string; args: string[] }[] = [];
+    let versionCallCount = 0;
+    const exec: ExecFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === '--version') {
+        versionCallCount++;
+        if (versionCallCount === 1) return { stdout: '', stderr: '', code: 127 };
+        return { stdout: 'multica 1.0.0', stderr: '', code: 0 };
+      }
+      if (cmd === 'which' && args[0] === 'brew') return { stdout: '', stderr: '', code: 1 };
+      if (cmd === 'bash') return { stdout: '', stderr: '', code: 0 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result).toEqual({ installed: true, alreadyPresent: false });
+    expect(calls.some((c) => c.cmd === 'bash' && c.args[0] === '-c')).toBe(true);
+    expect(calls.some((c) => c.cmd === 'brew')).toBe(false);
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to curl when brew install fails', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    const calls: { cmd: string; args: string[] }[] = [];
+    let versionCallCount = 0;
+    const exec: ExecFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === '--version') {
+        versionCallCount++;
+        if (versionCallCount === 1) return { stdout: '', stderr: '', code: 127 };
+        return { stdout: 'multica 1.0.0', stderr: '', code: 0 };
+      }
+      if (cmd === 'which' && args[0] === 'brew')
+        return { stdout: '/opt/homebrew/bin/brew', stderr: '', code: 0 };
+      if (cmd === 'brew') return { stdout: '', stderr: 'brew error', code: 1 };
+      if (cmd === 'bash') return { stdout: '', stderr: '', code: 0 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result).toEqual({ installed: true, alreadyPresent: false });
+    expect(calls.some((c) => c.cmd === 'bash' && c.args[0] === '-c')).toBe(true);
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('uses powershell on Windows', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    const calls: { cmd: string; args: string[] }[] = [];
+    let versionCallCount = 0;
+    const exec: ExecFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === '--version') {
+        versionCallCount++;
+        if (versionCallCount === 1) return { stdout: '', stderr: '', code: 127 };
+        return { stdout: 'multica 1.0.0', stderr: '', code: 0 };
+      }
+      if (cmd === 'powershell') return { stdout: '', stderr: '', code: 0 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result).toEqual({ installed: true, alreadyPresent: false });
+    expect(calls.some((c) => c.cmd === 'powershell' && c.args[0] === '-Command')).toBe(true);
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('returns error when install fails and binary still not found', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    const exec: ExecFn = async (cmd, args) => {
+      if (args[0] === '--version') return { stdout: '', stderr: '', code: 127 };
+      if (cmd === 'which' && args[0] === 'brew') return { stdout: '', stderr: '', code: 1 };
+      if (cmd === 'bash') return { stdout: '', stderr: 'network error', code: 1 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result.installed).toBe(false);
+    expect(result.alreadyPresent).toBe(false);
+    expect(result.error).toBeDefined();
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('returns error when binary not on PATH after successful install', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+
+    const exec: ExecFn = async (cmd, args) => {
+      if (args[0] === '--version') return { stdout: '', stderr: '', code: 127 };
+      if (cmd === 'which' && args[0] === 'brew')
+        return { stdout: '/usr/bin/brew', stderr: '', code: 0 };
+      if (cmd === 'brew') return { stdout: '', stderr: '', code: 0 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result.installed).toBe(false);
+    expect(result.error).toBe('multica binary not found on PATH after installation');
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('handles exec throwing an exception', async () => {
+    let callCount = 0;
+    const exec: ExecFn = async () => {
+      callCount++;
+      if (callCount === 1) throw new Error('command not found');
+      throw new Error('still not found');
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result.installed).toBe(false);
+    expect(result.alreadyPresent).toBe(false);
+  });
+
+  it('uses custom binary name for version check', async () => {
+    const cmds: string[] = [];
+    const exec: ExecFn = async (cmd) => {
+      cmds.push(cmd);
+      return { stdout: 'multica 2.0', stderr: '', code: 0 };
+    };
+    await ensureMulticaBinary('/custom/path/multica', exec);
+    expect(cmds[0]).toBe('/custom/path/multica');
+  });
+
+  it('does not attempt install when binary already exists', async () => {
+    const calls: { cmd: string; args: string[] }[] = [];
+    const exec: ExecFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      return { stdout: 'multica 1.0.0', stderr: '', code: 0 };
+    };
+    await ensureMulticaBinary('multica', exec);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).toEqual(['--version']);
+  });
+
+  it('handles brew exec throwing exception and falls back to curl', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    const calls: { cmd: string; args: string[] }[] = [];
+    let versionCallCount = 0;
+    const exec: ExecFn = async (cmd, args) => {
+      calls.push({ cmd, args });
+      if (args[0] === '--version') {
+        versionCallCount++;
+        if (versionCallCount === 1) return { stdout: '', stderr: '', code: 127 };
+        return { stdout: 'multica 1.0.0', stderr: '', code: 0 };
+      }
+      if (cmd === 'which' && args[0] === 'brew')
+        return { stdout: '/opt/homebrew/bin/brew', stderr: '', code: 0 };
+      if (cmd === 'brew') throw new Error('brew crashed');
+      if (cmd === 'bash') return { stdout: '', stderr: '', code: 0 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result).toEqual({ installed: true, alreadyPresent: false });
+    expect(calls.some((c) => c.cmd === 'bash' && c.args[0] === '-c')).toBe(true);
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('returns error when curl fallback exec throws', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+
+    const exec: ExecFn = async (cmd, args) => {
+      if (args[0] === '--version') return { stdout: '', stderr: '', code: 127 };
+      if (cmd === 'which' && args[0] === 'brew') return { stdout: '', stderr: '', code: 1 };
+      if (cmd === 'bash') throw new Error('network timeout');
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result.installed).toBe(false);
+    expect(result.error).toContain('network timeout');
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('returns error when Windows powershell install fails', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    const exec: ExecFn = async (cmd, args) => {
+      if (args[0] === '--version') return { stdout: '', stderr: '', code: 127 };
+      if (cmd === 'powershell') return { stdout: '', stderr: 'access denied', code: 1 };
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result.installed).toBe(false);
+    expect(result.error).toBe('access denied');
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
+  });
+
+  it('returns error when Windows powershell exec throws', async () => {
+    const originalPlatform = process.platform;
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    const exec: ExecFn = async (cmd, args) => {
+      if (args[0] === '--version') return { stdout: '', stderr: '', code: 127 };
+      if (cmd === 'powershell') throw new Error('powershell not found');
+      return { stdout: '', stderr: '', code: 0 };
+    };
+
+    const result = await ensureMulticaBinary('multica', exec);
+    expect(result.installed).toBe(false);
+    expect(result.error).toContain('powershell not found');
+
+    vi.stubGlobal('process', { ...process, platform: originalPlatform });
+    vi.unstubAllGlobals();
   });
 });

--- a/packages/pi-teamwork/src/index.test.ts
+++ b/packages/pi-teamwork/src/index.test.ts
@@ -49,7 +49,13 @@ describe('MulticaAdapter', () => {
         return { stdout: '[]', stderr: '', code: 0 };
       };
       const adapter = new MulticaAdapter({}, exec);
-      await adapter.listIssues({ status: 'todo', assignee: 'alice', project: 'P1', limit: 5 });
+      await adapter.listIssues({
+        workspaceId: 'ws-1',
+        status: 'todo',
+        assignee: 'alice',
+        project: 'P1',
+        limit: 5,
+      });
       expect(calls[0]).toContain('--status');
       expect(calls[0]).toContain('todo');
       expect(calls[0]).toContain('--assignee');
@@ -107,7 +113,12 @@ describe('MulticaAdapter', () => {
         };
       };
       const adapter = new MulticaAdapter({}, exec);
-      const result = await adapter.createIssue({ title: 'New', priority: 'high', assignee: 'bob' });
+      const result = await adapter.createIssue({
+        workspaceId: 'ws-1',
+        title: 'New',
+        priority: 'high',
+        assignee: 'bob',
+      });
       expect(result).toMatchObject({ id: 'ISS-NEW', title: 'New' });
       expect(calls[0]).toContain('--title');
       expect(calls[0]).toContain('New');
@@ -119,7 +130,7 @@ describe('MulticaAdapter', () => {
 
     it('returns fallback issue on invalid JSON response', async () => {
       const adapter = new MulticaAdapter({}, successExec('ok'));
-      const result = await adapter.createIssue({ title: 'Fallback' });
+      const result = await adapter.createIssue({ workspaceId: 'ws-1', title: 'Fallback' });
       expect(result).toMatchObject({ id: 'unknown', title: 'Fallback', status: 'todo' });
     });
   });
@@ -246,8 +257,8 @@ describe('initMulticaProvider', () => {
     };
     await initMulticaProvider({ token: 'my-token' }, exec);
     expect(calls[0]).toEqual(['--version']);
-    expect(calls[1]).toEqual(['login', '--token', 'my-token']);
-    expect(calls[2]).toEqual(['daemon', 'start']);
+    expect(calls[1]).toEqual(['daemon', 'start']);
+    expect(calls[2]).toEqual(['login', '--token', 'my-token']);
   });
 
   it('skips login when no token', async () => {
@@ -299,28 +310,44 @@ describe('initMulticaProvider', () => {
     expect(calls[0]).toEqual(['daemon', 'start']);
   });
 
-  it('runs setup self-host when serverUrl is configured', async () => {
+  it('sets server_url and app_url via config when serverUrl and appUrl are configured', async () => {
+    const calls: string[][] = [];
+    const exec: ExecFn = async (_cmd, args) => {
+      calls.push(args);
+      return { stdout: '', stderr: '', code: 0 };
+    };
+    await initMulticaProvider(
+      { serverUrl: 'https://api.example.com', appUrl: 'https://example.com' },
+      exec,
+    );
+    expect(calls).toContainEqual(['config', 'set', 'server_url', 'https://api.example.com']);
+    expect(calls).toContainEqual(['config', 'set', 'app_url', 'https://example.com']);
+  });
+
+  it('sets only server_url when appUrl is not configured', async () => {
     const calls: string[][] = [];
     const exec: ExecFn = async (_cmd, args) => {
       calls.push(args);
       return { stdout: '', stderr: '', code: 0 };
     };
     await initMulticaProvider({ serverUrl: 'https://api.example.com' }, exec);
-    expect(calls).toContainEqual(['setup', 'self-host', '--server-url', 'https://api.example.com']);
+    expect(calls).toContainEqual(['config', 'set', 'server_url', 'https://api.example.com']);
+    expect(calls.some((a) => a.includes('app_url'))).toBe(false);
   });
 
-  it('runs setup self-host before login when both serverUrl and token are configured', async () => {
+  it('sets config before login when both serverUrl and token are configured', async () => {
     const calls: string[][] = [];
     const exec: ExecFn = async (_cmd, args) => {
       calls.push(args);
       return { stdout: '', stderr: '', code: 0 };
     };
     await initMulticaProvider({ serverUrl: 'https://api.example.com', token: 'my-token' }, exec);
-    const setupIdx = calls.findIndex((a) => a[0] === 'setup');
+    const configIdx = calls.findIndex((a) => a[0] === 'config');
+    const daemonIdx = calls.findIndex((a) => a.includes('start'));
     const loginIdx = calls.findIndex((a) => a[0] === 'login');
-    expect(setupIdx).toBeGreaterThan(-1);
-    expect(loginIdx).toBeGreaterThan(-1);
-    expect(setupIdx).toBeLessThan(loginIdx);
+    expect(configIdx).toBeGreaterThan(-1);
+    expect(daemonIdx).toBeGreaterThan(configIdx);
+    expect(loginIdx).toBeGreaterThan(daemonIdx);
   });
 
   it('continues even if setup self-host fails', async () => {

--- a/packages/pi-teamwork/src/index.test.ts
+++ b/packages/pi-teamwork/src/index.test.ts
@@ -575,7 +575,7 @@ describe('ensureMulticaBinary', () => {
     };
     await ensureMulticaBinary('multica', exec);
     expect(calls).toHaveLength(1);
-    expect(calls[0].args).toEqual(['--version']);
+    expect(calls[0]!.args).toEqual(['--version']);
   });
 
   it('handles brew exec throwing exception and falls back to curl', async () => {

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -25,12 +25,16 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   let provider: TeamworkProvider | undefined;
   let readyPromise: Promise<void> | undefined;
 
-  const exec: ExecFn = async (command, args) => {
-    const result = await pi.exec(command, args);
-    return { stdout: result.stdout, stderr: result.stderr, code: result.code };
-  };
+  async function ensureReady(): Promise<string | undefined> {
+    if (readyPromise) await readyPromise;
+    if (!provider) return 'Teamwork provider is not initialized.';
+    return undefined;
+  }
 
   pi.on('session_start', async (_event, ctx) => {
+    provider = undefined;
+    readyPromise = undefined;
+
     const config = loadConfig(ctx.cwd);
     if (config.enabled === false) {
       ctx.ui.setStatus(STATUS_KEY, 'teamwork: disabled');
@@ -38,36 +42,54 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     }
 
     const providerName = config.provider ?? 'multica';
-    if (providerName === 'multica') {
-      readyPromise = (async () => {
-        const { adapter, installResult } = await initMulticaProvider(config.multica ?? {}, exec);
-        provider = adapter;
-
-        if (!installResult.installed) {
-          ctx.ui.notify(
-            `multica CLI could not be installed: ${installResult.error ?? 'unknown error'}. Run "multica setup" manually.`,
-            'warning',
-          );
-          ctx.ui.setStatus(STATUS_KEY, 'teamwork: multica (not installed)');
-          return;
-        }
-
-        if (!installResult.alreadyPresent) {
-          ctx.ui.notify('multica CLI was auto-installed successfully.', 'info');
-        }
-
-        if (!config.multica?.token && !config.multica?.serverUrl) {
-          ctx.ui.notify(
-            'No multica token or serverUrl configured. Run "multica setup" to authenticate.',
-            'warning',
-          );
-        }
-
-        ctx.ui.setStatus(STATUS_KEY, 'teamwork: multica');
-      })();
-    } else {
+    if (providerName !== 'multica') {
       ctx.ui.setStatus(STATUS_KEY, `teamwork: unknown provider "${providerName}"`);
+      return;
     }
+
+    const exec: ExecFn = async (command, args) => {
+      const result = await pi.exec(command, args);
+      return { stdout: result.stdout, stderr: result.stderr, code: result.code };
+    };
+
+    readyPromise = (async () => {
+      const { adapter, installResult } = await initMulticaProvider(config.multica ?? {}, exec);
+      provider = adapter;
+
+      if (!installResult.installed) {
+        ctx.ui.notify(
+          `multica CLI could not be installed: ${installResult.error ?? 'unknown error'}. Run "multica setup" manually.`,
+          'warning',
+        );
+        ctx.ui.setStatus(STATUS_KEY, 'teamwork: multica (not installed)');
+        return;
+      }
+
+      if (!installResult.alreadyPresent) {
+        ctx.ui.notify('multica CLI was auto-installed successfully.', 'info');
+      }
+
+      if (!config.multica?.token && !config.multica?.serverUrl) {
+        ctx.ui.notify(
+          'No multica token or serverUrl configured. Run "multica setup" to authenticate.',
+          'warning',
+        );
+      }
+
+      if (config.multica?.serverUrl && !config.multica?.appUrl) {
+        ctx.ui.notify(
+          'multica serverUrl is set but appUrl is missing. Remote servers require both.',
+          'warning',
+        );
+      }
+
+      ctx.ui.setStatus(STATUS_KEY, 'teamwork: multica');
+    })().catch((err) => {
+      ctx.ui.setStatus(
+        STATUS_KEY,
+        `teamwork: multica (error: ${err instanceof Error ? err.message : String(err)})`,
+      );
+    });
   });
 
   pi.on('session_shutdown', async () => {
@@ -76,6 +98,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   });
 
   pi.on('before_agent_start', async (event) => {
+    if (readyPromise) await readyPromise;
     if (!provider) return;
     return {
       systemPrompt: event.systemPrompt
@@ -101,13 +124,27 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     },
   });
 
-  // --- LLM-callable tools ---
+  // --- LLM-callable tools (registered once, use latest provider via closure) ---
 
-  async function ensureReady(): Promise<string | undefined> {
-    if (readyPromise) await readyPromise;
-    if (!provider) return 'Teamwork provider is not initialized.';
-    return undefined;
-  }
+  pi.registerTool({
+    name: 'workspace_list',
+    label: 'Teamwork',
+    description:
+      'List all workspaces you belong to. Call this first to get a workspace ID before using other teamwork tools.',
+    promptSnippet: 'List workspaces in the shared project tracker.',
+    parameters: Type.Object({}),
+    async execute() {
+      const err = await ensureReady();
+      if (err) return textResult(err);
+      try {
+        const workspaces = await provider!.listWorkspaces();
+        if (workspaces.length === 0) return textResult('No workspaces found.');
+        return textResult(JSON.stringify(workspaces, null, 2));
+      } catch (error) {
+        return textResult(`Error: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  });
 
   pi.registerTool({
     name: 'issue_list',
@@ -116,6 +153,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       'List issues from a shared project tracker. Issues are work items that humans or other agents collaborate on. Supports filtering by status, assignee, and project.',
     promptSnippet: 'List issues from a shared project tracker where humans and agents collaborate.',
     parameters: Type.Object({
+      workspaceId: Type.String({ description: 'Workspace ID (get from workspace_list).' }),
       status: Type.Optional(
         Type.String({ description: 'Filter by status (e.g. todo, in_progress, done, blocked).' }),
       ),
@@ -142,13 +180,14 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     description:
       'Get detailed information about a specific issue (a work item in the shared project tracker).',
     parameters: Type.Object({
+      workspaceId: Type.String({ description: 'Workspace ID (get from workspace_list).' }),
       id: Type.String({ description: 'The issue ID.' }),
     }),
     async execute(_toolCallId, params) {
       const err = await ensureReady();
       if (err) return textResult(err);
       try {
-        const issue = await provider!.getIssue(params.id);
+        const issue = await provider!.getIssue(params.id, params.workspaceId);
         if (!issue) return textResult(`Issue not found: ${params.id}`);
         return textResult(JSON.stringify(issue, null, 2));
       } catch (error) {
@@ -165,6 +204,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     promptSnippet:
       'Create issues / tickets in a shared project tracker for humans or agents to collaborate on.',
     parameters: Type.Object({
+      workspaceId: Type.String({ description: 'Workspace ID (get from workspace_list).' }),
       title: Type.String({ description: 'Issue title.' }),
       description: Type.Optional(Type.String({ description: 'Issue description.' })),
       priority: Type.Optional(
@@ -191,6 +231,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     description:
       'Update an existing issue in the shared project tracker. Can change title, description, status, priority, or assignee.',
     parameters: Type.Object({
+      workspaceId: Type.String({ description: 'Workspace ID (get from workspace_list).' }),
       id: Type.String({ description: 'The issue ID to update.' }),
       title: Type.Optional(Type.String({ description: 'New title.' })),
       description: Type.Optional(Type.String({ description: 'New description.' })),
@@ -205,9 +246,9 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     async execute(_toolCallId, params) {
       const err = await ensureReady();
       if (err) return textResult(err);
-      const { id, ...input } = params;
+      const { id, workspaceId, ...input } = params;
       try {
-        const issue = await provider!.updateIssue(id, input);
+        const issue = await provider!.updateIssue(id, input, workspaceId);
         if (!issue) return textResult(`Issue not found: ${id}`);
         return textResult(JSON.stringify(issue, null, 2));
       } catch (error) {
@@ -222,6 +263,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     description:
       'Add a comment to an issue in the shared project tracker. Use for progress updates, questions, or blockers visible to other collaborators (humans or agents).',
     parameters: Type.Object({
+      workspaceId: Type.String({ description: 'Workspace ID (get from workspace_list).' }),
       issueId: Type.String({ description: 'The issue ID to comment on.' }),
       content: Type.String({ description: 'Comment content.' }),
       parentId: Type.Optional(
@@ -232,7 +274,12 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       const err = await ensureReady();
       if (err) return textResult(err);
       try {
-        const comment = await provider!.addComment(params.issueId, params.content, params.parentId);
+        const comment = await provider!.addComment(
+          params.issueId,
+          params.content,
+          params.parentId,
+          params.workspaceId,
+        );
         return textResult(JSON.stringify(comment, null, 2));
       } catch (error) {
         return textResult(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -243,13 +290,15 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   pi.registerTool({
     name: 'project_list',
     label: 'Teamwork',
-    description: 'List all projects in the shared collaboration workspace.',
-    parameters: Type.Object({}),
-    async execute() {
+    description: 'List all projects in a workspace.',
+    parameters: Type.Object({
+      workspaceId: Type.String({ description: 'Workspace ID (get from workspace_list).' }),
+    }),
+    async execute(_toolCallId, params) {
       const err = await ensureReady();
       if (err) return textResult(err);
       try {
-        const projects = await provider!.listProjects();
+        const projects = await provider!.listProjects(params.workspaceId);
         if (projects.length === 0) return textResult('No projects found.');
         return textResult(JSON.stringify(projects, null, 2));
       } catch (error) {

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -8,8 +8,7 @@ const SETTINGS_KEY = 'pi-teamwork';
 const STATUS_KEY = 'pi-teamwork';
 
 const TEAMWORK_GUIDANCE = [
-  '# Teamwork Guidance',
-  '',
+  '<teamwork-guidance>',
   'You are working in a shared project tracker (teamwork) where humans and other agents collaborate. Use the issue_* and project_* tools to keep that shared space in sync.',
   '',
   'Before starting non-trivial work, check whether a relevant issue already exists (issue_list / issue_get) — to avoid duplicating work another collaborator has picked up.',
@@ -19,10 +18,12 @@ const TEAMWORK_GUIDANCE = [
   'When you finish work that an issue describes, update its status (issue_update). An issue left in an outdated state misleads other collaborators.',
   '',
   'The tracker is for cross-collaborator coordination, not for tracking your own session-local TODOs. Do not file an issue just to remind yourself of something within the current conversation.',
+  '</teamwork-guidance>',
 ].join('\n');
 
 export default function piTeamworkExtension(pi: ExtensionAPI): void {
   let provider: TeamworkProvider | undefined;
+  let readyPromise: Promise<void> | undefined;
 
   const exec: ExecFn = async (command, args) => {
     const result = await pi.exec(command, args);
@@ -38,8 +39,32 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
 
     const providerName = config.provider ?? 'multica';
     if (providerName === 'multica') {
-      provider = await initMulticaProvider(config.multica ?? {}, exec);
-      ctx.ui.setStatus(STATUS_KEY, 'teamwork: multica');
+      readyPromise = (async () => {
+        const { adapter, installResult } = await initMulticaProvider(config.multica ?? {}, exec);
+        provider = adapter;
+
+        if (!installResult.installed) {
+          ctx.ui.notify(
+            `multica CLI could not be installed: ${installResult.error ?? 'unknown error'}. Run "multica setup" manually.`,
+            'warning',
+          );
+          ctx.ui.setStatus(STATUS_KEY, 'teamwork: multica (not installed)');
+          return;
+        }
+
+        if (!installResult.alreadyPresent) {
+          ctx.ui.notify('multica CLI was auto-installed successfully.', 'info');
+        }
+
+        if (!config.multica?.token && !config.multica?.serverUrl) {
+          ctx.ui.notify(
+            'No multica token or serverUrl configured. Run "multica setup" to authenticate.',
+            'warning',
+          );
+        }
+
+        ctx.ui.setStatus(STATUS_KEY, 'teamwork: multica');
+      })();
     } else {
       ctx.ui.setStatus(STATUS_KEY, `teamwork: unknown provider "${providerName}"`);
     }
@@ -47,6 +72,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
 
   pi.on('session_shutdown', async () => {
     provider = undefined;
+    readyPromise = undefined;
   });
 
   pi.on('before_agent_start', async (event) => {
@@ -61,6 +87,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   pi.registerCommand('teamwork-status', {
     description: 'Show teamwork provider status.',
     handler: async (_args, ctx) => {
+      if (readyPromise) await readyPromise;
       if (!provider) {
         ctx.ui.notify('Teamwork provider is not initialized.', 'warning');
         return;
@@ -75,6 +102,12 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
   });
 
   // --- LLM-callable tools ---
+
+  async function ensureReady(): Promise<string | undefined> {
+    if (readyPromise) await readyPromise;
+    if (!provider) return 'Teamwork provider is not initialized.';
+    return undefined;
+  }
 
   pi.registerTool({
     name: 'issue_list',
@@ -91,9 +124,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       limit: Type.Optional(Type.Number({ description: 'Max number of results.' })),
     }),
     async execute(_toolCallId, params) {
-      if (!provider) return textResult('Teamwork provider is not initialized.');
+      const err = await ensureReady();
+      if (err) return textResult(err);
       try {
-        const issues = await provider.listIssues(params);
+        const issues = await provider!.listIssues(params);
         if (issues.length === 0) return textResult('No issues found.');
         return textResult(JSON.stringify(issues, null, 2));
       } catch (error) {
@@ -111,9 +145,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       id: Type.String({ description: 'The issue ID.' }),
     }),
     async execute(_toolCallId, params) {
-      if (!provider) return textResult('Teamwork provider is not initialized.');
+      const err = await ensureReady();
+      if (err) return textResult(err);
       try {
-        const issue = await provider.getIssue(params.id);
+        const issue = await provider!.getIssue(params.id);
         if (!issue) return textResult(`Issue not found: ${params.id}`);
         return textResult(JSON.stringify(issue, null, 2));
       } catch (error) {
@@ -139,9 +174,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       project: Type.Optional(Type.String({ description: 'Project ID to associate with.' })),
     }),
     async execute(_toolCallId, params) {
-      if (!provider) return textResult('Teamwork provider is not initialized.');
+      const err = await ensureReady();
+      if (err) return textResult(err);
       try {
-        const issue = await provider.createIssue(params);
+        const issue = await provider!.createIssue(params);
         return textResult(JSON.stringify(issue, null, 2));
       } catch (error) {
         return textResult(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -167,10 +203,11 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       assignee: Type.Optional(Type.String({ description: 'New assignee name.' })),
     }),
     async execute(_toolCallId, params) {
-      if (!provider) return textResult('Teamwork provider is not initialized.');
+      const err = await ensureReady();
+      if (err) return textResult(err);
       const { id, ...input } = params;
       try {
-        const issue = await provider.updateIssue(id, input);
+        const issue = await provider!.updateIssue(id, input);
         if (!issue) return textResult(`Issue not found: ${id}`);
         return textResult(JSON.stringify(issue, null, 2));
       } catch (error) {
@@ -192,9 +229,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       ),
     }),
     async execute(_toolCallId, params) {
-      if (!provider) return textResult('Teamwork provider is not initialized.');
+      const err = await ensureReady();
+      if (err) return textResult(err);
       try {
-        const comment = await provider.addComment(params.issueId, params.content, params.parentId);
+        const comment = await provider!.addComment(params.issueId, params.content, params.parentId);
         return textResult(JSON.stringify(comment, null, 2));
       } catch (error) {
         return textResult(`Error: ${error instanceof Error ? error.message : String(error)}`);
@@ -208,9 +246,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     description: 'List all projects in the shared collaboration workspace.',
     parameters: Type.Object({}),
     async execute() {
-      if (!provider) return textResult('Teamwork provider is not initialized.');
+      const err = await ensureReady();
+      if (err) return textResult(err);
       try {
-        const projects = await provider.listProjects();
+        const projects = await provider!.listProjects();
         if (projects.length === 0) return textResult('No projects found.');
         return textResult(JSON.stringify(projects, null, 2));
       } catch (error) {
@@ -226,9 +265,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       'Check the status of the teamwork collaboration provider (daemon status, connected agents, etc.).',
     parameters: Type.Object({}),
     async execute() {
-      if (!provider) return textResult('Teamwork provider is not initialized.');
+      const err = await ensureReady();
+      if (err) return textResult(err);
       try {
-        const s = await provider.status();
+        const s = await provider!.status();
         return textResult(JSON.stringify(s, null, 2));
       } catch (error) {
         return textResult(`Error: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/pi-teamwork/src/types.ts
+++ b/packages/pi-teamwork/src/types.ts
@@ -72,6 +72,8 @@ export type MulticaAdapterConfig = {
   binary?: string;
   workspace?: string;
   token?: string;
+  autoInstall?: boolean;
+  serverUrl?: string;
 };
 
 export type TeamworkConfig = {

--- a/packages/pi-teamwork/src/types.ts
+++ b/packages/pi-teamwork/src/types.ts
@@ -12,6 +12,7 @@ export type Issue = {
 };
 
 export type IssueCreateInput = {
+  workspaceId: string;
   title: string;
   description?: string;
   priority?: string;
@@ -28,6 +29,7 @@ export type IssueUpdateInput = {
 };
 
 export type IssueListFilter = {
+  workspaceId: string;
   status?: string;
   assignee?: string;
   project?: string;
@@ -51,15 +53,30 @@ export type Project = {
   lead?: string;
 };
 
+export type Workspace = {
+  id: string;
+  name: string;
+};
+
 export interface TeamworkProvider {
   name: string;
+  listWorkspaces(): Promise<Workspace[]>;
   listIssues(filter?: IssueListFilter): Promise<Issue[]>;
-  getIssue(id: string): Promise<Issue | undefined>;
+  getIssue(id: string, workspaceId?: string): Promise<Issue | undefined>;
   createIssue(input: IssueCreateInput): Promise<Issue>;
-  updateIssue(id: string, input: IssueUpdateInput): Promise<Issue | undefined>;
-  addComment(issueId: string, content: string, parentId?: string): Promise<Comment>;
-  listComments(issueId: string): Promise<Comment[]>;
-  listProjects(): Promise<Project[]>;
+  updateIssue(
+    id: string,
+    input: IssueUpdateInput,
+    workspaceId?: string,
+  ): Promise<Issue | undefined>;
+  addComment(
+    issueId: string,
+    content: string,
+    parentId?: string,
+    workspaceId?: string,
+  ): Promise<Comment>;
+  listComments(issueId: string, workspaceId?: string): Promise<Comment[]>;
+  listProjects(workspaceId?: string): Promise<Project[]>;
   status(): Promise<Record<string, unknown>>;
 }
 
@@ -74,6 +91,7 @@ export type MulticaAdapterConfig = {
   token?: string;
   autoInstall?: boolean;
   serverUrl?: string;
+  appUrl?: string;
 };
 
 export type TeamworkConfig = {

--- a/packages/pi-wecom/README.md
+++ b/packages/pi-wecom/README.md
@@ -1,0 +1,47 @@
+# pi-wecom
+
+Pi extension for [WeCom (企业微信)](https://work.weixin.qq.com/) workspace — contacts, messages, meetings, schedules, docs and more via [wecom-cli](https://github.com/WecomTeam/wecom-cli).
+
+## Features
+
+- Auto-installs `wecom-cli` if not present
+- Injects wecom-cli skills into the agent session
+- Detects authentication status and prompts for QR code login if needed
+
+## Configuration
+
+Add to your `.pi/settings.json`:
+
+```json
+{
+  "pi-wecom": {
+    "botId": "your_bot_id",
+    "botSecret": "your_bot_secret"
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `botId` | Yes | Bot ID from [WeCom Admin Console](https://work.weixin.qq.com/) |
+| `botSecret` | Yes | Bot Secret |
+
+> **Note:** wecom-cli requires QR code scan for initial authentication. After the extension installs the CLI, run `wecom-cli init` to complete the interactive login.
+
+## Skills Provided
+
+7 skills from wecom-cli covering:
+
+- `wecomcli-msg` — Messages, conversations, media download
+- `wecomcli-contact` — Address book, user search
+- `wecomcli-meeting` — Create, cancel, manage meetings
+- `wecomcli-schedule` — Schedule CRUD, free/busy
+- `wecomcli-todo` — Task management
+- `wecomcli-doc` — Documents and smart sheets
+- `wecomcli-smartsheet` — Table, field, record CRUD
+
+## CLI Reference
+
+- Repository: https://github.com/WecomTeam/wecom-cli
+- Install: `npm install -g @wecom/cli`
+- Docs: https://github.com/WecomTeam/wecom-cli#readme

--- a/packages/pi-wecom/package.json
+++ b/packages/pi-wecom/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@amaster.ai/pi-wecom",
+  "version": "0.1.0",
+  "description": "Pi extension for WeCom (enterprise WeChat) workspace — contacts, messages, meetings, schedules, docs and more via wecom-cli.",
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "wecom",
+    "enterprise-wechat"
+  ],
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  },
+  "files": [
+    "dist",
+    "skills"
+  ],
+  "pi": {
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TGYD-helige/pi.git",
+    "directory": "packages/pi-wecom"
+  },
+  "scripts": {
+    "fetch-skills": "node scripts/fetch-skills.mjs",
+    "prebuild": "node scripts/fetch-skills.mjs",
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false",
+    "test": "vitest run src"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@earendil-works/pi-coding-agent": "0.74.0",
+    "typebox": "*",
+    "vitest": "^4.0.0"
+  },
+  "dependencies": {
+    "@amaster.ai/pi-shared": "workspace:*"
+  }
+}

--- a/packages/pi-wecom/scripts/fetch-skills.mjs
+++ b/packages/pi-wecom/scripts/fetch-skills.mjs
@@ -1,0 +1,48 @@
+/**
+ * Fetches the latest wecom-cli skills from GitHub and writes them to the skills/ directory.
+ */
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILLS_DIR = join(__dirname, '..', 'skills');
+const REPO = 'WecomTeam/wecom-cli';
+const REMOTE_PATH = 'skills';
+
+async function fetchSkills() {
+  console.log('[pi-wecom] Fetching skills from github.com/%s ...', REPO);
+
+  if (existsSync(SKILLS_DIR)) {
+    rmSync(SKILLS_DIR, { recursive: true, force: true });
+  }
+  mkdirSync(SKILLS_DIR, { recursive: true });
+
+  const tmpDir = join(__dirname, '..', '.tmp-skills-fetch');
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  mkdirSync(tmpDir, { recursive: true });
+
+  try {
+    execSync(
+      `git clone --depth 1 --filter=blob:none --sparse https://github.com/${REPO}.git .`,
+      { cwd: tmpDir, stdio: 'pipe' },
+    );
+    execSync(`git sparse-checkout set ${REMOTE_PATH}`, { cwd: tmpDir, stdio: 'pipe' });
+
+    const srcSkills = join(tmpDir, REMOTE_PATH);
+    if (!existsSync(srcSkills)) {
+      throw new Error(`Skills directory not found at ${srcSkills}`);
+    }
+
+    execSync(`cp -r "${srcSkills}/"* "${SKILLS_DIR}/"`, { stdio: 'pipe' });
+    console.log('[pi-wecom] Skills fetched successfully.');
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+fetchSkills().catch((err) => {
+  console.warn('[pi-wecom] Failed to fetch skills (using existing if available):', err.message);
+  process.exit(0);
+});

--- a/packages/pi-wecom/src/__tests__/config.test.ts
+++ b/packages/pi-wecom/src/__tests__/config.test.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { loadWeComConfig } from '../config.js';
+
+describe('loadWeComConfig', () => {
+  let base: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    base = join(tmpdir(), `pi-wecom-config-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    originalEnv = { ...process.env };
+    process.env.PI_CODING_AGENT_DIR = join(base, 'agent');
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  test('returns undefined when no config exists', () => {
+    mkdirSync(join(base, 'project'), { recursive: true });
+    const config = loadWeComConfig(join(base, 'project'));
+    expect(config).toBeUndefined();
+  });
+
+  test('loads config from .pi/settings.json', () => {
+    const project = join(base, 'project');
+    mkdirSync(join(project, '.pi'), { recursive: true });
+    writeFileSync(
+      join(project, '.pi', 'settings.json'),
+      JSON.stringify({
+        'pi-wecom': {
+          botId: 'bot_abc123',
+          botSecret: 'secret456',
+        },
+      }),
+    );
+
+    const config = loadWeComConfig(project);
+
+    expect(config).toEqual({
+      botId: 'bot_abc123',
+      botSecret: 'secret456',
+    });
+  });
+
+  test('returns undefined when botId and botSecret are both empty', () => {
+    const project = join(base, 'project');
+    mkdirSync(join(project, '.pi'), { recursive: true });
+    writeFileSync(
+      join(project, '.pi', 'settings.json'),
+      JSON.stringify({
+        'pi-wecom': {},
+      }),
+    );
+
+    const config = loadWeComConfig(project);
+    expect(config).toBeUndefined();
+  });
+});

--- a/packages/pi-wecom/src/cli.ts
+++ b/packages/pi-wecom/src/cli.ts
@@ -1,0 +1,55 @@
+import { exec, execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const NPM_PACKAGE = '@wecom/cli';
+
+export function isWeComCliInstalled(): boolean {
+  try {
+    execSync('wecom-cli --version', { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function installWeComCli(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    exec(`npm install -g ${NPM_PACKAGE}@latest`, (error) => {
+      if (error) reject(new Error(`Failed to install ${NPM_PACKAGE}: ${error.message}`));
+      else resolve();
+    });
+  });
+}
+
+export async function ensureWeComCli(): Promise<boolean> {
+  if (isWeComCliInstalled()) return true;
+  await installWeComCli();
+  return isWeComCliInstalled();
+}
+
+export function isWeComCliAuthenticated(): boolean {
+  try {
+    const output = execSync('wecom-cli auth status', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    return !output.includes('not authenticated') && !output.includes('未认证');
+  } catch {
+    return false;
+  }
+}
+
+export function getWeComCliSkillsDir(): string | undefined {
+  try {
+    const npmRoot = execSync('npm root -g', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+    const skillsPath = join(npmRoot, '@wecom', 'cli', 'skills');
+    if (existsSync(skillsPath)) return skillsPath;
+  } catch {
+    // ignore
+  }
+  return undefined;
+}

--- a/packages/pi-wecom/src/config.ts
+++ b/packages/pi-wecom/src/config.ts
@@ -1,0 +1,14 @@
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+
+export type WeComConfig = {
+  botId?: string;
+  botSecret?: string;
+};
+
+const SETTINGS_KEY = 'pi-wecom';
+
+export function loadWeComConfig(cwd: string): WeComConfig | undefined {
+  const config = loadPiSettings<WeComConfig>(SETTINGS_KEY, { cwd });
+  if (!config || (!config.botId && !config.botSecret)) return undefined;
+  return config;
+}

--- a/packages/pi-wecom/src/index.ts
+++ b/packages/pi-wecom/src/index.ts
@@ -1,0 +1,74 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import {
+  ensureWeComCli,
+  getWeComCliSkillsDir,
+  isWeComCliAuthenticated,
+  isWeComCliInstalled,
+} from './cli.js';
+import { loadWeComConfig } from './config.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BUNDLED_SKILLS_DIR = join(__dirname, '..', 'skills');
+
+function resolveSkillsDir(): string | undefined {
+  const cliSkills = getWeComCliSkillsDir();
+  if (cliSkills) return cliSkills;
+  if (existsSync(BUNDLED_SKILLS_DIR)) return BUNDLED_SKILLS_DIR;
+  return undefined;
+}
+
+export default function piWeComExtension(pi: ExtensionAPI): void {
+  let skillsDir: string | undefined;
+
+  pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
+    const config = loadWeComConfig(ctx.cwd);
+    if (!config?.botId || !config?.botSecret) return;
+
+    if (existsSync(BUNDLED_SKILLS_DIR)) {
+      skillsDir = BUNDLED_SKILLS_DIR;
+    }
+
+    if (isWeComCliInstalled()) {
+      if (!isWeComCliAuthenticated()) {
+        ctx.ui.notify('pi-wecom: wecom-cli 未认证，请运行 wecom-cli init 完成扫码认证', 'warning');
+      }
+      skillsDir = resolveSkillsDir();
+      ctx.ui.setStatus?.('pi-wecom', 'wecom-cli: ready');
+    } else {
+      ctx.ui.setStatus?.('pi-wecom', 'installing wecom-cli...');
+      ensureWeComCli()
+        .then((installed) => {
+          if (installed) {
+            skillsDir = resolveSkillsDir();
+            ctx.ui.setStatus?.('pi-wecom', 'wecom-cli: ready');
+            if (!isWeComCliAuthenticated()) {
+              ctx.ui.notify(
+                'pi-wecom: wecom-cli 未认证，请运行 wecom-cli init 完成扫码认证',
+                'warning',
+              );
+            }
+          }
+        })
+        .catch((err) => {
+          ctx.ui.notify(
+            `pi-wecom: 安装失败 — ${err instanceof Error ? err.message : String(err)}`,
+            'warning',
+          );
+        });
+    }
+  });
+
+  pi.on('resources_discover', () => {
+    if (skillsDir) {
+      return { skillPaths: [skillsDir] };
+    }
+    return {};
+  });
+
+  pi.on('session_shutdown', async () => {
+    skillsDir = undefined;
+  });
+}

--- a/packages/pi-wecom/tsconfig.json
+++ b/packages/pi-wecom/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    { "path": "../shared" }
+  ],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,7 +115,39 @@ importers:
         specifier: ^4.0.0
         version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
 
+  packages/pi-dingtalk:
+    dependencies:
+      '@amaster.ai/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.74.0
+        version: 0.74.0
+      typebox:
+        specifier: '*'
+        version: 1.1.38
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+
   packages/pi-image-gen:
+    dependencies:
+      '@amaster.ai/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.74.0
+        version: 0.74.0
+      typebox:
+        specifier: '*'
+        version: 1.1.38
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+
+  packages/pi-lark:
     dependencies:
       '@amaster.ai/pi-shared':
         specifier: workspace:*
@@ -166,7 +198,7 @@ importers:
         version: link:../shared
       mem0ai:
         specifier: ^3.0.6
-        version: 3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@mistralai/mistralai@2.2.1)(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(socks@2.8.9))(ollama@0.5.18)(pg@8.11.3)(redis@4.7.1)(ws@8.20.1)
+        version: 3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@mistralai/mistralai@2.2.1)(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(socks@2.8.9))(ollama@0.5.18)(pg@8.21.0)(redis@5.12.1)(ws@8.20.1)
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.74.0
@@ -260,6 +292,22 @@ importers:
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6
+      typebox:
+        specifier: '*'
+        version: 1.1.38
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+
+  packages/pi-wecom:
+    dependencies:
+      '@amaster.ai/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.74.0
+        version: 0.74.0
       typebox:
         specifier: '*'
         version: 1.1.38
@@ -934,20 +982,11 @@ packages:
     resolution: {integrity: sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA==}
     engines: {node: '>=18.0.0', pnpm: '>=8'}
 
-  '@redis/bloom@1.2.0':
-    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
     engines: {node: '>= 18.19.0'}
     peerDependencies:
       '@redis/client': ^5.12.1
-
-  '@redis/client@1.6.1':
-    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
-    engines: {node: '>=14'}
 
   '@redis/client@5.12.1':
     resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
@@ -961,37 +1000,17 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@redis/json@5.12.1':
     resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
     engines: {node: '>= 18.19.0'}
     peerDependencies:
       '@redis/client': ^5.12.1
 
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@redis/search@5.12.1':
     resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
     engines: {node: '>= 18.19.0'}
     peerDependencies:
       '@redis/client': ^5.12.1
-
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
 
   '@redis/time-series@5.12.1':
     resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
@@ -1537,10 +1556,6 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
-  buffer-writer@2.0.0:
-    resolution: {integrity: sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==}
-    engines: {node: '>=4'}
-
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -2028,10 +2043,6 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
-
-  generic-pool@3.9.0:
-    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
-    engines: {node: '>= 4'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -2705,9 +2716,6 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
-  packet-reader@1.0.0:
-    resolution: {integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==}
-
   parse5-htmlparser2-tree-adapter@6.0.1:
     resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
 
@@ -2777,15 +2785,6 @@ packages:
   pg-types@4.1.0:
     resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
     engines: {node: '>=10'}
-
-  pg@8.11.3:
-    resolution: {integrity: sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      pg-native: '>=3.0.1'
-    peerDependenciesMeta:
-      pg-native:
-        optional: true
 
   pg@8.21.0:
     resolution: {integrity: sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==}
@@ -2970,9 +2969,6 @@ packages:
   redis-parser@3.0.0:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
-
-  redis@4.7.1:
-    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
   redis@5.12.1:
     resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
@@ -3486,9 +3482,6 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -4464,47 +4457,21 @@ snapshots:
 
   '@qdrant/openapi-typescript-fetch@1.2.6': {}
 
-  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
   '@redis/bloom@5.12.1(@redis/client@5.12.1)':
     dependencies:
       '@redis/client': 5.12.1
-
-  '@redis/client@1.6.1':
-    dependencies:
-      cluster-key-slot: 1.1.2
-      generic-pool: 3.9.0
-      yallist: 4.0.0
 
   '@redis/client@5.12.1':
     dependencies:
       cluster-key-slot: 1.1.2
 
-  '@redis/graph@1.1.1(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/json@1.0.7(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
   '@redis/json@5.12.1(@redis/client@5.12.1)':
     dependencies:
       '@redis/client': 5.12.1
 
-  '@redis/search@1.2.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
   '@redis/search@5.12.1(@redis/client@5.12.1)':
     dependencies:
       '@redis/client': 5.12.1
-
-  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
 
   '@redis/time-series@5.12.1(@redis/client@5.12.1)':
     dependencies:
@@ -5005,8 +4972,6 @@ snapshots:
   buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
-
-  buffer-writer@2.0.0: {}
 
   buffer@5.7.1:
     dependencies:
@@ -5516,8 +5481,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  generic-pool@3.9.0: {}
-
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
@@ -5916,7 +5879,7 @@ snapshots:
 
   media-typer@1.1.0: {}
 
-  mem0ai@3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@mistralai/mistralai@2.2.1)(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(socks@2.8.9))(ollama@0.5.18)(pg@8.11.3)(redis@4.7.1)(ws@8.20.1):
+  mem0ai@3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@mistralai/mistralai@2.2.1)(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(socks@2.8.9))(ollama@0.5.18)(pg@8.21.0)(redis@5.12.1)(ws@8.20.1):
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@azure/identity': 4.13.1
@@ -5937,8 +5900,8 @@ snapshots:
       natural: 8.1.1(socks@2.8.9)
       ollama: 0.5.18
       openai: 4.104.0(ws@8.20.1)(zod@3.25.76)
-      pg: 8.11.3
-      redis: 4.7.1
+      pg: 8.21.0
+      redis: 5.12.1
       uuid: 9.0.1
       zod: 3.25.76
     transitivePeerDependencies:
@@ -6181,8 +6144,6 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.1.1
 
-  packet-reader@1.0.0: {}
-
   parse5-htmlparser2-tree-adapter@6.0.1:
     dependencies:
       parse5: 6.0.1
@@ -6221,10 +6182,6 @@ snapshots:
 
   pg-numeric@1.0.2: {}
 
-  pg-pool@3.14.0(pg@8.11.3):
-    dependencies:
-      pg: 8.11.3
-
   pg-pool@3.14.0(pg@8.21.0):
     dependencies:
       pg: 8.21.0
@@ -6248,18 +6205,6 @@ snapshots:
       postgres-date: 2.1.0
       postgres-interval: 3.0.0
       postgres-range: 1.1.4
-
-  pg@8.11.3:
-    dependencies:
-      buffer-writer: 2.0.0
-      packet-reader: 1.0.0
-      pg-connection-string: 2.13.0
-      pg-pool: 3.14.0(pg@8.11.3)
-      pg-protocol: 1.14.0
-      pg-types: 2.2.0
-      pgpass: 1.0.5
-    optionalDependencies:
-      pg-cloudflare: 1.4.0
 
   pg@8.21.0:
     dependencies:
@@ -6455,15 +6400,6 @@ snapshots:
   redis-parser@3.0.0:
     dependencies:
       redis-errors: 1.2.0
-
-  redis@4.7.1:
-    dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
-      '@redis/client': 1.6.1
-      '@redis/graph': 1.1.1(@redis/client@1.6.1)
-      '@redis/json': 1.0.7(@redis/client@1.6.1)
-      '@redis/search': 1.2.0(@redis/client@1.6.1)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
 
   redis@5.12.1:
     dependencies:
@@ -6946,8 +6882,6 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
-
-  yallist@4.0.0: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## Summary

- Add three new pi extension packages that integrate workspace CLI tools as connectors
- **pi-lark**: Feishu/Lark via [lark-cli](https://github.com/larksuite/cli) — calendar, docs, drive, sheets, tasks, mail (27 skills)
- **pi-dingtalk**: DingTalk via [dws](https://github.com/DingTalk-Real-AI/dingtalk-workspace-cli) — chat, calendar, docs, todo, sheets, mail (19 skills)
- **pi-wecom**: WeCom via [wecom-cli](https://github.com/WecomTeam/wecom-cli) — contacts, messages, meetings, schedules, docs (7 skills)
- Each extension auto-installs the CLI asynchronously, initializes credentials non-interactively, and injects skills via `resources_discover`
- Also includes a fix for pre-existing TS2532 in pi-teamwork test

## Test plan

- [x] `pnpm lint` — 0 errors on new packages
- [x] `pnpm typecheck` — passes (all packages)
- [x] `pnpm test` — 811 tests pass (19 new tests across the 3 packages)
- [x] `pnpm build` — succeeds