### PR TITLE
fix: use local prefix install for workspace CLI extensions

### DIFF
--- a/packages/pi-dingtalk/src/__tests__/cli.test.ts
+++ b/packages/pi-dingtalk/src/__tests__/cli.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, test } from 'vitest';
 import { initDws } from '../cli.js';
 
 describe('initDws', () => {
-  test('throws when clientId is missing', () => {
-    expect(() => initDws({ clientSecret: 'secret' })).toThrow(
+  test('rejects when clientId is missing', async () => {
+    await expect(initDws({ clientSecret: 'secret' })).rejects.toThrow(
       'clientId and clientSecret are required',
     );
   });
 
-  test('throws when clientSecret is missing', () => {
-    expect(() => initDws({ clientId: 'dingabc' })).toThrow(
+  test('rejects when clientSecret is missing', async () => {
+    await expect(initDws({ clientId: 'dingabc' })).rejects.toThrow(
       'clientId and clientSecret are required',
     );
   });

--- a/packages/pi-dingtalk/src/cli.ts
+++ b/packages/pi-dingtalk/src/cli.ts
@@ -1,54 +1,84 @@
-import { exec, execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { exec } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { DingTalkConfig } from './config.js';
 
 const NPM_PACKAGE = 'dingtalk-workspace-cli';
+const INSTALL_DIR = join(homedir(), '.dws');
+const BIN_PATH = join(INSTALL_DIR, 'node_modules', '.bin', 'dws');
 
-export function isDwsInstalled(): boolean {
-  try {
-    execSync('dws --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
+let installAttempted = false;
+let cliAvailable: boolean | undefined;
 
-export function installDws(): Promise<void> {
+function execAsync(command: string): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    exec(`npm install -g ${NPM_PACKAGE}@latest`, (error) => {
-      if (error) reject(new Error(`Failed to install ${NPM_PACKAGE}: ${error.message}`));
-      else resolve();
+    exec(command, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout, stderr });
     });
   });
 }
 
+function dwsBin(): string {
+  if (existsSync(BIN_PATH)) return BIN_PATH;
+  return 'dws';
+}
+
+export async function isDwsInstalled(): Promise<boolean> {
+  if (cliAvailable !== undefined) return cliAvailable;
+  try {
+    await execAsync(`"${dwsBin()}" --version`);
+    cliAvailable = true;
+    return true;
+  } catch {
+    cliAvailable = false;
+    return false;
+  }
+}
+
+export async function installDws(): Promise<void> {
+  if (installAttempted) return;
+  installAttempted = true;
+  mkdirSync(INSTALL_DIR, { recursive: true });
+  await execAsync(`npm install --prefix "${INSTALL_DIR}" ${NPM_PACKAGE}@latest`);
+  cliAvailable = undefined;
+}
+
 export async function ensureDws(): Promise<boolean> {
-  if (isDwsInstalled()) return true;
+  if (await isDwsInstalled()) return true;
   await installDws();
   return isDwsInstalled();
 }
 
-export function initDws(config: DingTalkConfig): void {
+export async function initDws(config: DingTalkConfig): Promise<void> {
   const { clientId, clientSecret } = config;
   if (!clientId || !clientSecret) {
     throw new Error('clientId and clientSecret are required');
   }
-  execSync(`dws auth login --client-id "${clientId}" --client-secret "${clientSecret}" --yes`, {
-    stdio: 'pipe',
-  });
+  const bin = dwsBin();
+  await execAsync(
+    `"${bin}" auth login --client-id "${clientId}" --client-secret "${clientSecret}" --yes`,
+  );
 }
 
-export function getDwsSkillsDir(): string | undefined {
+export async function getDwsSkillsDir(): Promise<string | undefined> {
+  const localSkills = join(
+    INSTALL_DIR,
+    'node_modules',
+    'dingtalk-workspace-cli',
+    'skills',
+    'multi',
+  );
+  if (existsSync(localSkills)) return localSkills;
+
   try {
-    const npmRoot = execSync('npm root -g', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    }).trim();
-    const skillsPath = join(npmRoot, 'dingtalk-workspace-cli', 'skills', 'multi');
+    const { stdout } = await execAsync('npm root -g');
+    const skillsPath = join(stdout.trim(), 'dingtalk-workspace-cli', 'skills', 'multi');
     if (existsSync(skillsPath)) return skillsPath;
   } catch {
     // ignore
   }
+
   return undefined;
 }

--- a/packages/pi-dingtalk/src/index.ts
+++ b/packages/pi-dingtalk/src/index.ts
@@ -2,14 +2,14 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
-import { ensureDws, getDwsSkillsDir, initDws, isDwsInstalled } from './cli.js';
+import { ensureDws, getDwsSkillsDir, initDws } from './cli.js';
 import { loadDingTalkConfig } from './config.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLED_SKILLS_DIR = join(__dirname, '..', 'skills');
 
-function resolveSkillsDir(): string | undefined {
-  const cliSkills = getDwsSkillsDir();
+async function resolveSkillsDir(): Promise<string | undefined> {
+  const cliSkills = await getDwsSkillsDir();
   if (cliSkills) return cliSkills;
   if (existsSync(BUNDLED_SKILLS_DIR)) return BUNDLED_SKILLS_DIR;
   return undefined;
@@ -26,33 +26,18 @@ export default function piDingTalkExtension(pi: ExtensionAPI): void {
       skillsDir = BUNDLED_SKILLS_DIR;
     }
 
-    if (isDwsInstalled()) {
-      try {
-        initDws(config);
-        skillsDir = resolveSkillsDir();
+    try {
+      const installed = await ensureDws();
+      if (installed) {
+        await initDws(config);
+        skillsDir = await resolveSkillsDir();
         ctx.ui.setStatus?.('pi-dingtalk', 'dws: ready');
-      } catch (err) {
-        ctx.ui.notify(
-          `pi-dingtalk: 初始化失败 — ${err instanceof Error ? err.message : String(err)}`,
-          'warning',
-        );
       }
-    } else {
-      ctx.ui.setStatus?.('pi-dingtalk', 'installing dws...');
-      ensureDws()
-        .then((installed) => {
-          if (installed) {
-            initDws(config);
-            skillsDir = resolveSkillsDir();
-            ctx.ui.setStatus?.('pi-dingtalk', 'dws: ready');
-          }
-        })
-        .catch((err) => {
-          ctx.ui.notify(
-            `pi-dingtalk: 安装失败 — ${err instanceof Error ? err.message : String(err)}`,
-            'warning',
-          );
-        });
+    } catch (err) {
+      ctx.ui.notify(
+        `pi-dingtalk: 初始化失败 — ${err instanceof Error ? err.message : String(err)}`,
+        'warning',
+      );
     }
   });
 

--- a/packages/pi-lark/src/cli.ts
+++ b/packages/pi-lark/src/cli.ts
@@ -1,31 +1,52 @@
-import { exec, execSync } from 'node:child_process';
+import { exec } from 'node:child_process';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { LarkConfig } from './config.js';
 
 const NPM_PACKAGE = '@larksuite/cli';
+const INSTALL_DIR = join(homedir(), '.lark-cli');
+const BIN_PATH = join(INSTALL_DIR, 'node_modules', '.bin', 'lark-cli');
 
-export function isLarkCliInstalled(): boolean {
-  try {
-    execSync('lark-cli --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
+let installAttempted = false;
+let cliAvailable: boolean | undefined;
 
-export function installLarkCli(): Promise<void> {
+function execAsync(command: string): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    exec(`npm install -g ${NPM_PACKAGE}@latest`, (error) => {
-      if (error) reject(new Error(`Failed to install ${NPM_PACKAGE}: ${error.message}`));
-      else resolve();
+    exec(command, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout, stderr });
     });
   });
 }
 
+function larkCliBin(): string {
+  if (existsSync(BIN_PATH)) return BIN_PATH;
+  return 'lark-cli';
+}
+
+export async function isLarkCliInstalled(): Promise<boolean> {
+  if (cliAvailable !== undefined) return cliAvailable;
+  try {
+    await execAsync(`"${larkCliBin()}" --version`);
+    cliAvailable = true;
+    return true;
+  } catch {
+    cliAvailable = false;
+    return false;
+  }
+}
+
+export async function installLarkCli(): Promise<void> {
+  if (installAttempted) return;
+  installAttempted = true;
+  mkdirSync(INSTALL_DIR, { recursive: true });
+  await execAsync(`npm install --prefix "${INSTALL_DIR}" ${NPM_PACKAGE}@latest`);
+  cliAvailable = undefined;
+}
+
 export async function ensureLarkCli(): Promise<boolean> {
-  if (isLarkCliInstalled()) return true;
+  if (await isLarkCliInstalled()) return true;
   await installLarkCli();
   return isLarkCliInstalled();
 }
@@ -67,38 +88,26 @@ export function initLarkCli(config: LarkConfig): Promise<void> {
   });
 }
 
-export function getLarkCliSkillsDir(): string | undefined {
+export async function getLarkCliSkillsDir(): Promise<string | undefined> {
+  const bin = larkCliBin();
   try {
-    const output = execSync('lark-cli skills path', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    }).trim();
+    const { stdout } = await execAsync(`"${bin}" skills path`);
+    const output = stdout.trim();
     if (output && existsSync(output)) return output;
   } catch {
-    // fallback: try to find skills in the npm global package
+    // fallback
   }
 
-  try {
-    const npmRoot = execSync('npm root -g', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    }).trim();
-    const skillsPath = join(npmRoot, '@larksuite', 'cli', 'skills');
-    if (existsSync(skillsPath)) return skillsPath;
-  } catch {
-    // ignore
-  }
+  const localSkills = join(INSTALL_DIR, 'node_modules', '@larksuite', 'cli', 'skills');
+  if (existsSync(localSkills)) return localSkills;
 
   return undefined;
 }
 
-export function checkLarkCliAuth(): { ok: boolean; error?: string } {
+export async function checkLarkCliAuth(): Promise<{ ok: boolean; error?: string }> {
   try {
-    const output = execSync('lark-cli auth status --json', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    });
-    const status = JSON.parse(output);
+    const { stdout } = await execAsync(`"${larkCliBin()}" auth status --json`);
+    const status = JSON.parse(stdout);
     if (status?.loggedIn || status?.authenticated) return { ok: true };
     return { ok: false, error: 'not authenticated' };
   } catch {

--- a/packages/pi-lark/src/index.ts
+++ b/packages/pi-lark/src/index.ts
@@ -2,14 +2,14 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
-import { ensureLarkCli, getLarkCliSkillsDir, initLarkCli, isLarkCliInstalled } from './cli.js';
+import { ensureLarkCli, getLarkCliSkillsDir, initLarkCli } from './cli.js';
 import { loadLarkConfig } from './config.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLED_SKILLS_DIR = join(__dirname, '..', 'skills');
 
-function resolveSkillsDir(): string | undefined {
-  const cliSkills = getLarkCliSkillsDir();
+async function resolveSkillsDir(): Promise<string | undefined> {
+  const cliSkills = await getLarkCliSkillsDir();
   if (cliSkills) return cliSkills;
   if (existsSync(BUNDLED_SKILLS_DIR)) return BUNDLED_SKILLS_DIR;
   return undefined;
@@ -22,38 +22,22 @@ export default function piLarkExtension(pi: ExtensionAPI): void {
     const config = loadLarkConfig(ctx.cwd);
     if (!config?.appId || !config?.appSecret) return;
 
-    // Use bundled skills immediately so they're available while CLI installs
     if (existsSync(BUNDLED_SKILLS_DIR)) {
       skillsDir = BUNDLED_SKILLS_DIR;
     }
 
-    if (isLarkCliInstalled()) {
-      try {
+    try {
+      const installed = await ensureLarkCli();
+      if (installed) {
         await initLarkCli(config);
-        skillsDir = resolveSkillsDir();
+        skillsDir = await resolveSkillsDir();
         ctx.ui.setStatus?.('pi-lark', 'lark-cli: ready');
-      } catch (err) {
-        ctx.ui.notify(
-          `pi-lark: 初始化失败 — ${err instanceof Error ? err.message : String(err)}`,
-          'warning',
-        );
       }
-    } else {
-      ctx.ui.setStatus?.('pi-lark', 'installing lark-cli...');
-      ensureLarkCli()
-        .then(async (installed) => {
-          if (installed) {
-            await initLarkCli(config);
-            skillsDir = resolveSkillsDir();
-            ctx.ui.setStatus?.('pi-lark', 'lark-cli: ready');
-          }
-        })
-        .catch((err) => {
-          ctx.ui.notify(
-            `pi-lark: 安装失败 — ${err instanceof Error ? err.message : String(err)}`,
-            'warning',
-          );
-        });
+    } catch (err) {
+      ctx.ui.notify(
+        `pi-lark: 初始化失败 — ${err instanceof Error ? err.message : String(err)}`,
+        'warning',
+      );
     }
   });
 

--- a/packages/pi-wecom/src/cli.ts
+++ b/packages/pi-wecom/src/cli.ts
@@ -1,55 +1,75 @@
-import { exec, execSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { exec } from 'node:child_process';
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 const NPM_PACKAGE = '@wecom/cli';
+const INSTALL_DIR = join(homedir(), '.wecom-cli');
+const BIN_PATH = join(INSTALL_DIR, 'node_modules', '.bin', 'wecom-cli');
 
-export function isWeComCliInstalled(): boolean {
-  try {
-    execSync('wecom-cli --version', { stdio: 'ignore' });
-    return true;
-  } catch {
-    return false;
-  }
-}
+let installAttempted = false;
+let cliAvailable: boolean | undefined;
 
-export function installWeComCli(): Promise<void> {
+function execAsync(command: string): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    exec(`npm install -g ${NPM_PACKAGE}@latest`, (error) => {
-      if (error) reject(new Error(`Failed to install ${NPM_PACKAGE}: ${error.message}`));
-      else resolve();
+    exec(command, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout, stderr });
     });
   });
 }
 
+function wecomCliBin(): string {
+  if (existsSync(BIN_PATH)) return BIN_PATH;
+  return 'wecom-cli';
+}
+
+export async function isWeComCliInstalled(): Promise<boolean> {
+  if (cliAvailable !== undefined) return cliAvailable;
+  try {
+    await execAsync(`"${wecomCliBin()}" --version`);
+    cliAvailable = true;
+    return true;
+  } catch {
+    cliAvailable = false;
+    return false;
+  }
+}
+
+export async function installWeComCli(): Promise<void> {
+  if (installAttempted) return;
+  installAttempted = true;
+  mkdirSync(INSTALL_DIR, { recursive: true });
+  await execAsync(`npm install --prefix "${INSTALL_DIR}" ${NPM_PACKAGE}@latest`);
+  cliAvailable = undefined;
+}
+
 export async function ensureWeComCli(): Promise<boolean> {
-  if (isWeComCliInstalled()) return true;
+  if (await isWeComCliInstalled()) return true;
   await installWeComCli();
   return isWeComCliInstalled();
 }
 
-export function isWeComCliAuthenticated(): boolean {
+export async function isWeComCliAuthenticated(): Promise<boolean> {
   try {
-    const output = execSync('wecom-cli auth status', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    });
-    return !output.includes('not authenticated') && !output.includes('未认证');
+    const { stdout } = await execAsync(`"${wecomCliBin()}" auth status`);
+    return !stdout.includes('not authenticated') && !stdout.includes('未认证');
   } catch {
     return false;
   }
 }
 
-export function getWeComCliSkillsDir(): string | undefined {
+export async function getWeComCliSkillsDir(): Promise<string | undefined> {
+  const localSkills = join(INSTALL_DIR, 'node_modules', '@wecom', 'cli', 'skills');
+  if (existsSync(localSkills)) return localSkills;
+
   try {
-    const npmRoot = execSync('npm root -g', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'ignore'],
-    }).trim();
-    const skillsPath = join(npmRoot, '@wecom', 'cli', 'skills');
+    const { stdout } = await execAsync('npm root -g');
+    const skillsPath = join(stdout.trim(), '@wecom', 'cli', 'skills');
     if (existsSync(skillsPath)) return skillsPath;
   } catch {
     // ignore
   }
+
   return undefined;
 }

--- a/packages/pi-wecom/src/index.ts
+++ b/packages/pi-wecom/src/index.ts
@@ -2,19 +2,14 @@ import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
-import {
-  ensureWeComCli,
-  getWeComCliSkillsDir,
-  isWeComCliAuthenticated,
-  isWeComCliInstalled,
-} from './cli.js';
+import { ensureWeComCli, getWeComCliSkillsDir, isWeComCliAuthenticated } from './cli.js';
 import { loadWeComConfig } from './config.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BUNDLED_SKILLS_DIR = join(__dirname, '..', 'skills');
 
-function resolveSkillsDir(): string | undefined {
-  const cliSkills = getWeComCliSkillsDir();
+async function resolveSkillsDir(): Promise<string | undefined> {
+  const cliSkills = await getWeComCliSkillsDir();
   if (cliSkills) return cliSkills;
   if (existsSync(BUNDLED_SKILLS_DIR)) return BUNDLED_SKILLS_DIR;
   return undefined;
@@ -31,33 +26,23 @@ export default function piWeComExtension(pi: ExtensionAPI): void {
       skillsDir = BUNDLED_SKILLS_DIR;
     }
 
-    if (isWeComCliInstalled()) {
-      if (!isWeComCliAuthenticated()) {
-        ctx.ui.notify('pi-wecom: wecom-cli 未认证，请运行 wecom-cli init 完成扫码认证', 'warning');
-      }
-      skillsDir = resolveSkillsDir();
-      ctx.ui.setStatus?.('pi-wecom', 'wecom-cli: ready');
-    } else {
-      ctx.ui.setStatus?.('pi-wecom', 'installing wecom-cli...');
-      ensureWeComCli()
-        .then((installed) => {
-          if (installed) {
-            skillsDir = resolveSkillsDir();
-            ctx.ui.setStatus?.('pi-wecom', 'wecom-cli: ready');
-            if (!isWeComCliAuthenticated()) {
-              ctx.ui.notify(
-                'pi-wecom: wecom-cli 未认证，请运行 wecom-cli init 完成扫码认证',
-                'warning',
-              );
-            }
-          }
-        })
-        .catch((err) => {
+    try {
+      const installed = await ensureWeComCli();
+      if (installed) {
+        skillsDir = await resolveSkillsDir();
+        ctx.ui.setStatus?.('pi-wecom', 'wecom-cli: ready');
+        if (!(await isWeComCliAuthenticated())) {
           ctx.ui.notify(
-            `pi-wecom: 安装失败 — ${err instanceof Error ? err.message : String(err)}`,
+            'pi-wecom: wecom-cli 未认证，请运行 wecom-cli init 完成扫码认证',
             'warning',
           );
-        });
+        }
+      }
+    } catch (err) {
+      ctx.ui.notify(
+        `pi-wecom: 初始化失败 — ${err instanceof Error ? err.message : String(err)}`,
+        'warning',
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

- Install workspace CLIs to user-local directories (`~/.lark-cli`, `~/.dws`, `~/.wecom-cli`) via `npm install --prefix` instead of global install
- Avoids permission issues (`EACCES`) and PATH conflicts with pnpm environments
- All exec calls are now fully async (no `execSync` blocking session_start)
- Caches install attempts to avoid repeated downloads on failure
- Prefers local bin path (`~/.lark-cli/node_modules/.bin/lark-cli`), falls back to global PATH

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 812 tests pass
- [x] `pnpm build` succeeds