### PR TITLE
ci: add pi-image-gen and pi-browser-use to Stage C E2E matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -233,6 +233,14 @@ jobs:
             tools: web_fetch
             prompt: "Use web_fetch on https://www.baidu.com once. Tell me the page title in one sentence."
             assert_pattern: "(baidu|百度|bing|google|search|title)"
+          - extension: pi-image-gen
+            tools: image_generate
+            prompt: "Use image_generate to generate a test image with prompt 'a solid red square'. Report the generated file path."
+            assert_pattern: "(image|generated|.png|.jpg|.webp|pi-images)"
+          - extension: pi-browser-use
+            tools: browser_navigate_page,browser_take_snapshot
+            prompt: "Use browser_navigate_page to go to https://example.com then use browser_take_snapshot to get page content. Tell me the page title."
+            assert_pattern: "(Example Domain|example.com)"
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
       PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
@@ -340,6 +348,23 @@ jobs:
                   "config": { "model": "deepseek-v4-flash" }
                 }
               }
+            },
+            "pi-image-gen": {
+              "defaultModel": "qwen-image-2.0",
+              "outputDir": "${RUNNER_TEMP}/pi-images",
+              "customProviders": {
+                "ci-gateway": {
+                  "api": "openai",
+                  "baseUrl": "${PI_INTEGRATION_BASE_URL}",
+                  "apiKey": "\${PI_INTEGRATION_API_KEY}"
+                }
+              }
+            },
+            "pi-browser-use": {
+              "headless": true,
+              "sessionMode": "isolated",
+              "viewport": "1280x720",
+              "executablePath": "\${CHROMIUM_BIN}"
             }
           }
           EOF
@@ -385,6 +410,22 @@ jobs:
           multica login --token "$MULTICA_TOKEN"
           # Smoke-test the auth before handing off to pi-teamwork.
           multica workspace list --output json
+
+      - name: Install Chromium (pi-browser-use only)
+        if: matrix.extension == 'pi-browser-use'
+        run: |
+          set -euo pipefail
+          # Download Chrome for Testing (smaller, faster CDN than raw Chromium).
+          npx -y @puppeteer/browsers install chrome@stable \
+            --path "$RUNNER_TEMP/chrome-install"
+          CHROME_BIN=$(find "$RUNNER_TEMP/chrome-install" -name "chrome" -type f | head -1)
+          if [ -z "$CHROME_BIN" ]; then
+            echo "::error::Could not find chrome binary after install"
+            exit 1
+          fi
+          echo "Chrome: $CHROME_BIN"
+          "$CHROME_BIN" --version --no-sandbox || true
+          echo "CHROMIUM_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
 
       - name: Run extension prompt (Stage C)
         if: env.PI_INTEGRATION_BASE_URL != '' && env.PI_INTEGRATION_API_KEY != ''
@@ -507,6 +548,24 @@ jobs:
             exit 1
           fi
           echo "✓ mem0 OSS pipeline verified end-to-end."
+
+      - name: Verify image file generated (pi-image-gen only)
+        if: matrix.extension == 'pi-image-gen' && env.PI_INTEGRATION_BASE_URL != ''
+        run: |
+          set -euo pipefail
+          IMAGE_DIR="${RUNNER_TEMP}/pi-images"
+          if [ ! -d "$IMAGE_DIR" ]; then
+            echo "::error::pi-image-gen output dir $IMAGE_DIR not created"
+            exit 1
+          fi
+          FILE_COUNT=$(find "$IMAGE_DIR" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.webp" \) | wc -l)
+          echo "Image files found: $FILE_COUNT"
+          if [ "$FILE_COUNT" -lt 1 ]; then
+            echo "::error::No image files in $IMAGE_DIR"
+            exit 1
+          fi
+          find "$IMAGE_DIR" -type f -exec ls -la {} \;
+          echo "✓ pi-image-gen file verification passed."
 
       - name: Skipped (secrets unavailable)
         if: env.PI_INTEGRATION_BASE_URL == '' || env.PI_INTEGRATION_API_KEY == ''


### PR DESCRIPTION
## Summary

- Extend the integration workflow's `extension-tool-matrix` from 5 to 7 parallel jobs
- **pi-image-gen**: exercises `image_generate` tool via `ci-gateway` customProvider (OpenAI adapter → existing gateway, model `qwen-image-2.0`). Post-run verification asserts an image file was actually written to `$RUNNER_TEMP/pi-images/`
- **pi-browser-use**: installs Chromium headless on the runner, spawns `chrome-devtools-mcp` via npx, navigates `https://example.com`, takes an accessibility snapshot, and asserts "Example Domain" in the output

### Stage C coverage (7 extensions)

| Extension | Tool(s) | What it proves |
|---|---|---|
| pi-channels | `notify` (list-adapters) | Registry round-trip |
| pi-memory | `memory_add` → `memory_read` → `mem0_save` → `mem0_search` | Full memory pipeline + SQLite snapshot |
| pi-task-scheduler | `scheduler_list` | Real JsonScheduledTaskStore init |
| pi-teamwork | `workspace_list` | Live multica CLI → real workspace data |
| pi-web-access | `web_fetch` | Jina-reader fetch + deepseek summary |
| **pi-image-gen** (new) | `image_generate` | OpenAI-compat image generation API call, file written to disk |
| **pi-browser-use** (new) | `browser_navigate_page`, `browser_take_snapshot` | Headless Chromium spawn via chrome-devtools-mcp, real page navigation |

### New secrets required

None — reuses existing `PI_INTEGRATION_BASE_URL` + `PI_INTEGRATION_API_KEY`.

## Test plan

- [ ] `pnpm test` — 972 tests pass (no source changes, only workflow file)
- [ ] Integration workflow — all 7 Stage C matrix jobs green
- [ ] pi-image-gen post-run step confirms image file on disk
- [ ] pi-browser-use: Chromium installs, page navigated, "Example Domain" in output