### PR TITLE
feat(web-access): add Brave Search API provider

### DIFF
--- a/packages/pi-web-access/README.md
+++ b/packages/pi-web-access/README.md
@@ -45,6 +45,7 @@ Search X (Twitter) for posts and social media content. Only registered when xai 
 | Provider | Search | Fetch | X Search | Default Base URL | Env Var | Default Model |
 |----------|:------:|:-----:|:--------:|------------------|---------|---------------|
 | `tavily` | ✓ | ✓ | ✗ | `https://api.tavily.com` | `TAVILY_API_KEY` | - |
+| `brave` | ✓ | ✗ | ✗ | `https://api.search.brave.com` | `BRAVE_API_KEY` | - |
 | `kimi` | ✓ | ✗ | ✗ | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` | `kimi-k2.6` |
 | `mimo` | ✓ | ✗ | ✗ | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` | `mimo-v2.5-pro` |
 | `zai` | ✓ | ✓ | ✗ | `https://api.z.ai` | `ZAI_API_KEY` | - |

--- a/packages/pi-web-access/src/__tests__/providers.test.ts
+++ b/packages/pi-web-access/src/__tests__/providers.test.ts
@@ -216,6 +216,94 @@ describe('search - all providers', () => {
     expect(opts.headers['anthropic-version']).toBe('2023-06-01');
   });
 
+  it('brave: calls web search API with X-Subscription-Token', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'brave' },
+      providers: { brave: { apiKey: 'brave-key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        query: { original: 'test query' },
+        web: {
+          results: [
+            { title: 'Result 1', url: 'https://example.com', description: 'Example description' },
+            { title: 'Result 2', url: 'https://other.com', description: 'Other description' },
+          ],
+        },
+      }),
+    });
+
+    const result = await search({ query: 'test query' }, settings);
+
+    expect(result.provider).toBe('brave');
+    expect(result.query).toBe('test query');
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]!.title).toBe('Result 1');
+    expect(result.results[0]!.url).toBe('https://example.com');
+    expect(result.results[0]!.content).toBe('Example description');
+
+    const [url, opts] = mockFetch.mock.calls[0]!;
+    expect(url).toContain('https://api.search.brave.com/res/v1/web/search');
+    expect(url).toContain('q=test+query');
+    expect(opts.headers['X-Subscription-Token']).toBe('brave-key');
+  });
+
+  it('brave: passes freshness for timeRange', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'brave' },
+      providers: { brave: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ web: { results: [] } }),
+    });
+
+    await search({ query: 'test', timeRange: 'week' }, settings);
+
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toContain('freshness=pw');
+  });
+
+  it('brave: uses news results when topic is news', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'brave' },
+      providers: { brave: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        news: {
+          results: [{ title: 'News Item', url: 'https://news.com', description: 'Breaking news' }],
+        },
+      }),
+    });
+
+    const result = await search({ query: 'test', topic: 'news' }, settings);
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]!.title).toBe('News Item');
+
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toContain('result_filter=news');
+  });
+
+  it('brave: passes count parameter', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'brave' },
+      providers: { brave: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ web: { results: [] } }),
+    });
+
+    await search({ query: 'test', maxResults: 10 }, settings);
+
+    const [url] = mockFetch.mock.calls[0]!;
+    expect(url).toContain('count=10');
+  });
+
   it('openrouter: passes domain filters', async () => {
     const settings: WebToolSettings = {
       search: { provider: 'openrouter' },

--- a/packages/pi-web-access/src/config.ts
+++ b/packages/pi-web-access/src/config.ts
@@ -8,6 +8,7 @@ const SETTINGS_KEY = 'pi-web-access';
 
 const DEFAULT_BASE_URL: Record<BuiltInProviderId, string> = {
   tavily: 'https://api.tavily.com',
+  brave: 'https://api.search.brave.com',
   kimi: 'https://api.moonshot.cn/v1',
   mimo: 'https://api.xiaomimimo.com/v1',
   zai: 'https://api.z.ai',
@@ -21,6 +22,7 @@ const DEFAULT_BASE_URL: Record<BuiltInProviderId, string> = {
 
 const ENV_VARS: Record<BuiltInProviderId, string> = {
   tavily: 'TAVILY_API_KEY',
+  brave: 'BRAVE_API_KEY',
   kimi: 'MOONSHOT_API_KEY',
   mimo: 'MIMO_API_KEY',
   zai: 'ZAI_API_KEY',
@@ -109,6 +111,7 @@ export function resolveProvider(
 
 const ALL_SEARCH_PROVIDER_IDS: BuiltInProviderId[] = [
   'tavily',
+  'brave',
   'kimi',
   'mimo',
   'zai',

--- a/packages/pi-web-access/src/providers/brave.ts
+++ b/packages/pi-web-access/src/providers/brave.ts
@@ -1,0 +1,88 @@
+import type { ResolvedProvider, SearchParams, SearchResponse, SearchResult } from './base.js';
+import { BaseProvider } from './base.js';
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export class BraveProvider extends BaseProvider {
+  readonly id = 'brave' as const;
+
+  override async search(params: SearchParams, provider: ResolvedProvider): Promise<SearchResponse> {
+    if (!provider.apiKey) {
+      throw new Error(
+        'Brave Search API key not configured. Set BRAVE_API_KEY env var or configure in settings.json.',
+      );
+    }
+
+    const searchParams = new URLSearchParams();
+    searchParams.set('q', params.query);
+    searchParams.set('count', String(params.maxResults ?? 5));
+
+    if (params.topic === 'news') {
+      searchParams.set('result_filter', 'news');
+    }
+
+    if (params.timeRange) {
+      const freshnessMap: Record<string, string> = {
+        day: 'pd',
+        week: 'pw',
+        month: 'pm',
+        year: 'py',
+      };
+      searchParams.set('freshness', freshnessMap[params.timeRange]!);
+    }
+
+    const url = `${provider.baseUrl.replace(/\/$/, '')}/res/v1/web/search?${searchParams.toString()}`;
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Accept-Encoding': 'gzip',
+      'X-Subscription-Token': provider.apiKey,
+      ...provider.headers,
+    };
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+      signal: AbortSignal.timeout(provider.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Brave Search API error ${response.status}: ${text}`);
+    }
+
+    const data = (await response.json()) as {
+      query?: { original?: string };
+      web?: {
+        results?: Array<{
+          title: string;
+          url: string;
+          description: string;
+          age?: string;
+        }>;
+      };
+      news?: {
+        results?: Array<{
+          title: string;
+          url: string;
+          description: string;
+          age?: string;
+        }>;
+      };
+    };
+
+    const rawResults =
+      params.topic === 'news' ? (data.news?.results ?? []) : (data.web?.results ?? []);
+
+    const results: SearchResult[] = rawResults.map((r) => ({
+      title: r.title,
+      url: r.url,
+      content: r.description,
+    }));
+
+    return {
+      provider: provider.id,
+      query: data.query?.original ?? params.query,
+      results,
+    };
+  }
+}

--- a/packages/pi-web-access/src/providers/index.ts
+++ b/packages/pi-web-access/src/providers/index.ts
@@ -1,6 +1,7 @@
 import type { BuiltInProviderId } from '../types.js';
 import { AnthropicProvider } from './anthropic.js';
 import type { WebProvider } from './base.js';
+import { BraveProvider } from './brave.js';
 import { GeminiProvider } from './gemini.js';
 import { KimiProvider } from './kimi.js';
 import { MimoProvider } from './mimo.js';
@@ -25,6 +26,7 @@ export { BaseProvider, getEnvironmentContext, SEARCH_SYSTEM_PROMPT } from './bas
 
 const providers: WebProvider[] = [
   new TavilyProvider(),
+  new BraveProvider(),
   new KimiProvider(),
   new MimoProvider(),
   new ZaiProvider(),

--- a/packages/pi-web-access/src/types.ts
+++ b/packages/pi-web-access/src/types.ts
@@ -1,6 +1,7 @@
 /** Built-in provider identifiers. */
 export type BuiltInProviderId =
   | 'tavily'
+  | 'brave'
   | 'kimi'
   | 'mimo'
   | 'zai'


### PR DESCRIPTION
## Summary
- Add Brave Search as a new web search provider (`brave`) in `pi-web-access`
- Uses `GET /res/v1/web/search` with `X-Subscription-Token` authentication
- Supports `maxResults` (count), `timeRange` (freshness), and `topic: news` (result_filter) parameters
- Auto-discovered when `BRAVE_API_KEY` env var is set (priority after Tavily)

## Configuration
```json
{
  "pi-web-access": {
    "search": { "provider": "brave" },
    "providers": { "brave": { "apiKey": "${BRAVE_API_KEY}" } }
  }
}
```

Or simply set `BRAVE_API_KEY` environment variable for auto-discovery.

## Test plan
- [x] Unit tests for basic search, timeRange/freshness, news topic, and count parameter
- [x] Type-check passes
- [x] All 976 existing tests pass