### PR TITLE
fix(pi-image-gen): unbreak OpenRouter, OpenAI gpt-image-2, and Gemini image paths

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -6,7 +6,7 @@ Pi extension that adds an `image_generate` tool. Supported providers:
 
 | Provider                       | Model id (alias)                              | Env var               |
 | ------------------------------ | --------------------------------------------- | --------------------- |
-| OpenAI                         | `gpt-image-1` (alias `gpt-image-2`)             | `OPENAI_API_KEY`      |
+| OpenAI                         | `gpt-image-2` (alias `gpt-image`)               | `OPENAI_API_KEY`      |
 | Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3-pro-image-preview`, `gemini-3.1-flash-image` (alias `nano-banana`), `gemini-3.1-flash-image-preview`, `gemini-2.5-flash-image` (alias `nano-banana-2`), `gemini-2.0-flash-image` | `GEMINI_API_KEY`      |
 | Alibaba DashScope (Qwen-Image) | `qwen-image-2.0-pro` (alias `qwen-image-pro`), `qwen-image-2.0` (alias `qwen-image-2`, `qwen-image`) | `DASHSCOPE_API_KEY` |
 | OpenRouter                     | any (use `openrouter/<vendor>/<id>`)          | `OPENROUTER_API_KEY`  |
@@ -92,7 +92,7 @@ That's it. From the agent: `image_generate({ prompt: "a cyberpunk cat" })`.
 
 ## Built-in setup walkthrough
 
-### 1. OpenAI (`gpt-image-1` / `gpt-image-2`)
+### 1. OpenAI (`gpt-image-2`)
 
 ```sh
 export OPENAI_API_KEY=sk-...
@@ -291,14 +291,14 @@ image_generate({ prompt: "a beaver chewing wood", filename: "beaver" })
   → /Users/.../.pi/images/beaver.png
 
 image_generate({ prompt: "now in watercolor style", image: ["/Users/.../.pi/images/beaver.png"] })
-  → /Users/.../.pi/images/gpt-image-1-20260605-...png  (edited)
+  → /Users/.../.pi/images/gpt-image-2-20260605-...png  (edited)
 ```
 
 Provider behavior:
 
 | Provider | Image input route |
 |---|---|
-| OpenAI (`gpt-image-1`) | `POST /v1/images/edits` (multipart). Supports multi-image. |
+| OpenAI (`gpt-image-2`) | `POST /v1/images/edits` (multipart). Supports multi-image. |
 | Gemini (`gemini-3.x-flash-image`, `nano-banana`) | `inline_data` parts prepended to the user message. Supports multi-image. |
 | DashScope (`qwen-image-2.0`, `qwen-image-2.0-pro`) | `image` parts in `messages[].content`. |
 | OpenRouter | `POST /api/v1/images` with `input_references` JSON. Supports multi-image. |

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -12,6 +12,14 @@ Pi extension that adds an `image_generate` tool. Supported providers:
 | OpenRouter                     | any (use `openrouter/<vendor>/<id>`)          | `OPENROUTER_API_KEY`  |
 | Custom providers               | whatever you declare in settings              | (your choice, via `$VAR`) |
 
+Upstream API docs (handy when debugging gateway behavior or adding new models):
+
+- OpenAI gpt-image-2 — [developers.openai.com/api/docs/models/gpt-image-2](https://developers.openai.com/api/docs/models/gpt-image-2)
+- Google Gemini image generation — [ai.google.dev/gemini-api/docs/image-generation](https://ai.google.dev/gemini-api/docs/image-generation)
+- Alibaba DashScope Qwen-Image (text-to-image) — [help.aliyun.com/zh/model-studio/text-to-image](https://help.aliyun.com/zh/model-studio/text-to-image)
+- Alibaba DashScope Qwen-Image-Edit — [help.aliyun.com/zh/model-studio/qwen-image-edit-guide](https://help.aliyun.com/zh/model-studio/qwen-image-edit-guide)
+- OpenRouter image API — [openrouter.ai/docs/api/api-reference/images/create-images](https://openrouter.ai/docs/api/api-reference/images/create-images)
+
 The env-var names match [pi.dev's provider table](https://pi.dev/docs/latest/providers) — if the agent already has a key set for a provider, this extension will reuse it. You don't need to introduce a new variable.
 
 The active model is **fixed in settings.json**. The `image_generate` tool intentionally does **not** take a `model` parameter — point your project at one model, get consistent output. To switch models, edit settings and run `/image-gen reload`.

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -7,7 +7,7 @@ Pi extension that adds an `image_generate` tool. Supported providers:
 | Provider                       | Model id (alias)                              | Env var               |
 | ------------------------------ | --------------------------------------------- | --------------------- |
 | OpenAI                         | `gpt-image-2` (alias `gpt-image`)               | `OPENAI_API_KEY`      |
-| Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3-pro-image-preview`, `gemini-3.1-flash-image` (alias `nano-banana`), `gemini-3.1-flash-image-preview`, `gemini-2.5-flash-image` (alias `nano-banana-2`), `gemini-2.0-flash-image` | `GEMINI_API_KEY`      |
+| Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3.1-flash-image` (alias `nano-banana-2`), `gemini-2.5-flash-image` (alias `nano-banana`) | `GEMINI_API_KEY` |
 | Alibaba DashScope (Qwen-Image) | `qwen-image-2.0-pro` (alias `qwen-image-pro`), `qwen-image-2.0` (alias `qwen-image-2`, `qwen-image`) | `DASHSCOPE_API_KEY` |
 | OpenRouter                     | any (use `openrouter/<vendor>/<id>`)          | `OPENROUTER_API_KEY`  |
 | Custom providers               | whatever you declare in settings              | (your choice, via `$VAR`) |
@@ -299,7 +299,7 @@ Provider behavior:
 | Provider | Image input route |
 |---|---|
 | OpenAI (`gpt-image-2`) | `POST /v1/images/edits` (multipart). Supports multi-image. |
-| Gemini (`gemini-3.x-flash-image`, `nano-banana`) | `inline_data` parts prepended to the user message. Supports multi-image. |
+| Gemini (`gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-2.5-flash-image`) | `inline_data` parts prepended to the user message. Supports multi-image. |
 | DashScope (`qwen-image-2.0`, `qwen-image-2.0-pro`) | `image` parts in `messages[].content`. |
 | OpenRouter | `POST /api/v1/images` with `input_references` JSON. Supports multi-image. |
 

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -142,10 +142,12 @@ export OPENROUTER_API_KEY=...
 ```
 
 ```json
-{ "pi-image-gen": { "defaultModel": "openrouter/google/gemini-2.5-flash-image" } }
+{ "pi-image-gen": { "defaultModel": "openrouter/bytedance-seed/seedream-4.5" } }
 ```
 
-The string after `openrouter/` is the OpenRouter model slug; pass any image model OpenRouter supports.
+The string after `openrouter/` is the OpenRouter model slug; pass any image model OpenRouter supports (`google/gemini-3.1-flash-image`, `openai/gpt-image-2`, `bytedance-seed/seedream-4.5`, …).
+
+OpenRouter's image API is **not** OpenAI-compatible despite the family name — it lives at `POST /api/v1/images` (no `/generations` suffix) and uses JSON `input_references` for image-to-image. The extension targets the right endpoint automatically; no wire-shape config needed.
 
 ## Custom providers
 
@@ -299,6 +301,7 @@ Provider behavior:
 | OpenAI (`gpt-image-1`) | `POST /v1/images/edits` (multipart). Supports multi-image. |
 | Gemini (`gemini-3.x-flash-image`, `nano-banana`) | `inline_data` parts prepended to the user message. Supports multi-image. |
 | DashScope (`qwen-image-2.0`, `qwen-image-2.0-pro`) | `image` parts in `messages[].content`. |
+| OpenRouter | `POST /api/v1/images` with `input_references` JSON. Supports multi-image. |
 
 There is intentionally no `model` parameter on the tool — the active model is fixed by `pi-image-gen.defaultModel` in settings.
 

--- a/packages/pi-image-gen/src/__tests__/config.test.ts
+++ b/packages/pi-image-gen/src/__tests__/config.test.ts
@@ -13,13 +13,13 @@ describe('resolveModel', () => {
     expect(result.provider.apiKey).toBe('gem-test');
   });
 
-  it('routes gpt-image-2 alias to openai gpt-image-1', () => {
+  it('routes gpt-image alias to openai gpt-image-2', () => {
     process.env.OPENAI_API_KEY = 'oa-test';
-    const result = resolveModel('gpt-image-2', {});
+    const result = resolveModel('gpt-image', {});
     if ('error' in result) throw new Error(result.error);
     expect(result.provider.id).toBe('openai');
-    expect(result.remoteId).toBe('gpt-image-1');
-    expect(result.requestedId).toBe('gpt-image-2');
+    expect(result.remoteId).toBe('gpt-image-2');
+    expect(result.requestedId).toBe('gpt-image');
   });
 
   it('routes qwen-image-2 alias to dashscope', () => {
@@ -41,7 +41,7 @@ describe('resolveModel', () => {
         openai: { apiKey: `$${'{MY_KEY}'}`, baseUrl: 'https://proxy.example.com/v1' },
       },
     };
-    const result = resolveModel('gpt-image-1', settings);
+    const result = resolveModel('gpt-image-2', settings);
     if ('error' in result) throw new Error(result.error);
     expect(result.provider.apiKey).toBe('override-key');
     expect(result.provider.baseUrl).toBe('https://proxy.example.com/v1');

--- a/packages/pi-image-gen/src/__tests__/config.test.ts
+++ b/packages/pi-image-gen/src/__tests__/config.test.ts
@@ -9,7 +9,7 @@ describe('resolveModel', () => {
     if ('error' in result) throw new Error(result.error);
     expect(result.provider.id).toBe('gemini');
     expect(result.provider.api).toBe('gemini');
-    expect(result.remoteId).toBe('gemini-3.1-flash-image');
+    expect(result.remoteId).toBe('gemini-2.5-flash-image');
     expect(result.provider.apiKey).toBe('gem-test');
   });
 

--- a/packages/pi-image-gen/src/__tests__/generate.test.ts
+++ b/packages/pi-image-gen/src/__tests__/generate.test.ts
@@ -214,4 +214,61 @@ describe('generateImage', () => {
     );
     expect(result.images).toHaveLength(2);
   });
+
+  it('routes OpenRouter to POST /api/v1/images (not /images/generations)', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
+    const settings: ImageGenSettings = {
+      defaultModel: 'google/gemini-3.1-flash-image',
+      customProviders: {
+        or: {
+          api: 'openrouter',
+          apiKey: 'or-test',
+          models: ['google/gemini-3.1-flash-image'],
+        },
+      },
+    };
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const fetchImpl: typeof fetch = (async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      calls.push({ url, body: JSON.parse(String(init?.body)) });
+      return fakeJsonResponse({ data: [{ b64_json: PNG_BYTES.toString('base64') }] });
+    }) as typeof fetch;
+
+    const result = await generateImage({ prompt: 'a cat' }, { cwd, settings, fetchImpl });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('https://openrouter.ai/api/v1/images');
+    expect(calls[0]?.body.model).toBe('google/gemini-3.1-flash-image');
+    expect(result.images).toHaveLength(1);
+  });
+
+  it('OpenRouter image-to-image sends input_references in JSON body', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
+    const settings: ImageGenSettings = {
+      defaultModel: 'google/gemini-3.1-flash-image',
+      customProviders: {
+        or: {
+          api: 'openrouter',
+          apiKey: 'or-test',
+          models: ['google/gemini-3.1-flash-image'],
+        },
+      },
+    };
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const fetchImpl: typeof fetch = (async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      calls.push({ url, body: JSON.parse(String(init?.body)) });
+      return fakeJsonResponse({ data: [{ b64_json: PNG_BYTES.toString('base64') }] });
+    }) as typeof fetch;
+
+    const refPath = join(cwd, 'ref.png');
+    writeFileSync(refPath, PNG_BYTES);
+    await generateImage({ prompt: 'make blue', image: [refPath] }, { cwd, settings, fetchImpl });
+
+    expect(calls[0]?.url).toBe('https://openrouter.ai/api/v1/images');
+    const refs = calls[0]?.body.input_references as Array<{
+      image_url: { url: string };
+    }>;
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.image_url.url.startsWith('data:image/png;base64,')).toBe(true);
+  });
 });

--- a/packages/pi-image-gen/src/__tests__/generate.test.ts
+++ b/packages/pi-image-gen/src/__tests__/generate.test.ts
@@ -35,7 +35,7 @@ describe('generateImage', () => {
       { prompt: 'a cat', filename: 'cat-test' },
       {
         cwd,
-        settings: { defaultModel: 'gpt-image-1' },
+        settings: { defaultModel: 'gpt-image-2' },
         fetchImpl,
         now: () => new Date(Date.UTC(2026, 5, 4, 12, 0, 0)),
       },
@@ -117,7 +117,7 @@ describe('generateImage', () => {
       { prompt: 'x' },
       {
         cwd,
-        settings: { defaultModel: 'gpt-image-1' },
+        settings: { defaultModel: 'gpt-image-2' },
         fetchImpl,
         signal: ctrl.signal,
       },
@@ -150,7 +150,7 @@ describe('generateImage', () => {
       { prompt: 'make it green', image: [refPath], filename: 'edit-test' },
       {
         cwd,
-        settings: { defaultModel: 'gpt-image-1' },
+        settings: { defaultModel: 'gpt-image-2' },
         fetchImpl,
         now: () => new Date(Date.UTC(2026, 5, 5, 0, 0, 0)),
       },
@@ -174,7 +174,7 @@ describe('generateImage', () => {
 
     const result = await generateImage(
       { prompt: 'cat' },
-      { cwd, settings: { defaultModel: 'gpt-image-1' }, fetchImpl },
+      { cwd, settings: { defaultModel: 'gpt-image-2' }, fetchImpl },
     );
     expect(result.images).toHaveLength(1);
     expect(readFileSync(result.images[0]!.path)).toEqual(PNG_BYTES);
@@ -210,7 +210,7 @@ describe('generateImage', () => {
 
     const result = await generateImage(
       { prompt: 'x' },
-      { cwd, settings: { defaultModel: 'gpt-image-1' }, fetchImpl: wrappedFetch },
+      { cwd, settings: { defaultModel: 'gpt-image-2' }, fetchImpl: wrappedFetch },
     );
     expect(result.images).toHaveLength(2);
   });

--- a/packages/pi-image-gen/src/image-input.ts
+++ b/packages/pi-image-gen/src/image-input.ts
@@ -79,7 +79,7 @@ async function resolveOne(
   return { bytes, mimeType };
 }
 
-function sniffMime(bytes: Uint8Array): string | undefined {
+export function sniffMime(bytes: Uint8Array): string | undefined {
   for (const { mimeType, bytes: magic } of MAGIC_BYTES) {
     if (bytes.length < magic.length) continue;
     let match = true;

--- a/packages/pi-image-gen/src/index.ts
+++ b/packages/pi-image-gen/src/index.ts
@@ -81,7 +81,7 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
       image: Type.Optional(
         Type.Array(Type.String(), {
           description:
-            'Optional reference image(s) for image-to-image / edit / style transfer / character preservation. Each entry MUST be either (a) a file path — absolute or relative to the session cwd — or (b) an http(s) URL. Base64 strings and data: URIs are rejected; write the bytes to a file first if you have raw image data. For a single image pass ["path"]. Multi-image conditioning is supported by OpenAI gpt-image-1, Gemini, and Qwen sync models. To iterate on a previous output, pass that file path here.',
+            'Optional reference image(s) for image-to-image / edit / style transfer / character preservation. Each entry MUST be either (a) a file path — absolute or relative to the session cwd — or (b) an http(s) URL. Base64 strings and data: URIs are rejected; write the bytes to a file first if you have raw image data. For a single image pass ["path"]. Multi-image conditioning is supported by OpenAI gpt-image-2, Gemini, and Qwen sync models. To iterate on a previous output, pass that file path here.',
         }),
       ),
       n: Type.Optional(

--- a/packages/pi-image-gen/src/models.ts
+++ b/packages/pi-image-gen/src/models.ts
@@ -13,14 +13,12 @@ export type BuiltInModelEntry = {
 };
 
 export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
-  // OpenAI image generation. The naming "gpt-image-2" the user mentioned does not
-  // currently exist in OpenAI's catalog; the closest stable id is "gpt-image-1".
-  // We accept both as aliases so prompts that ask for "gpt-image-2" still work.
+  // OpenAI image generation.
   {
-    id: 'gpt-image-1',
-    aliases: ['gpt-image', 'gpt-image-2'],
+    id: 'gpt-image-2',
+    aliases: ['gpt-image'],
     provider: 'openai',
-    remoteId: 'gpt-image-1',
+    remoteId: 'gpt-image-2',
   },
 
   // Google Gemini "Nano Banana" image generation. The `nano-banana` alias

--- a/packages/pi-image-gen/src/models.ts
+++ b/packages/pi-image-gen/src/models.ts
@@ -21,9 +21,11 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
     remoteId: 'gpt-image-2',
   },
 
-  // Google Gemini "Nano Banana" image generation. The `nano-banana` alias
-  // points at the most recent stable release; older variants stay addressable
-  // by their full id.
+  // Google Gemini "Nano Banana" image generation.
+  // Per https://ai.google.dev/gemini-api/docs/image-generation:
+  //   Nano Banana Pro → gemini-3-pro-image
+  //   Nano Banana 2   → gemini-3.1-flash-image
+  //   Nano Banana     → gemini-2.5-flash-image
   {
     id: 'gemini-3-pro-image',
     aliases: ['nano-banana-pro'],
@@ -31,31 +33,16 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
     remoteId: 'gemini-3-pro-image',
   },
   {
-    id: 'gemini-3-pro-image-preview',
-    provider: 'gemini',
-    remoteId: 'gemini-3-pro-image-preview',
-  },
-  {
     id: 'gemini-3.1-flash-image',
-    aliases: ['nano-banana', 'nano-banana-3'],
+    aliases: ['nano-banana-2'],
     provider: 'gemini',
     remoteId: 'gemini-3.1-flash-image',
   },
   {
-    id: 'gemini-3.1-flash-image-preview',
-    provider: 'gemini',
-    remoteId: 'gemini-3.1-flash-image-preview',
-  },
-  {
     id: 'gemini-2.5-flash-image',
-    aliases: ['nano-banana-2', 'gemini-image'],
+    aliases: ['nano-banana'],
     provider: 'gemini',
     remoteId: 'gemini-2.5-flash-image',
-  },
-  {
-    id: 'gemini-2.0-flash-image',
-    provider: 'gemini',
-    remoteId: 'gemini-2.0-flash-image',
   },
 
   // Alibaba Qwen-Image / WanX series via DashScope. The `qwen-image-2` and

--- a/packages/pi-image-gen/src/providers/gemini.ts
+++ b/packages/pi-image-gen/src/providers/gemini.ts
@@ -36,6 +36,9 @@ export const geminiAdapter: ImageProviderAdapter = {
     if (provider.headers) Object.assign(headers, provider.headers);
 
     const n = params.n ?? 1;
+    // Per https://ai.google.dev/gemini-api/docs/image-generation REST examples,
+    // request body uses snake_case (`inline_data`, `mime_type`). Google accepts
+    // both; we stay aligned with the docs.
     const userParts: Array<
       { text: string } | { inline_data: { mime_type: string; data: string } }
     > = [];
@@ -74,7 +77,10 @@ export const geminiAdapter: ImageProviderAdapter = {
     let json: {
       candidates?: Array<{
         content?: {
-          parts?: Array<{ inline_data?: { mime_type?: string; data?: string } }>;
+          parts?: Array<{
+            inlineData?: { mimeType?: string; data?: string };
+            inline_data?: { mime_type?: string; data?: string };
+          }>;
         };
       }>;
     };
@@ -87,13 +93,20 @@ export const geminiAdapter: ImageProviderAdapter = {
     const out: RawImageResult[] = [];
     for (const candidate of json.candidates ?? []) {
       for (const part of candidate.content?.parts ?? []) {
-        const inline = part.inline_data;
-        if (inline?.data) {
+        // Google's REST API returns camelCase `inlineData`; the gRPC/proto form
+        // is `inline_data`. Accept both — different gateways may pass either.
+        const inline = part.inlineData ?? part.inline_data;
+        const data = inline?.data;
+        const mimeType =
+          (inline as { mimeType?: string; mime_type?: string } | undefined)?.mimeType ??
+          (inline as { mimeType?: string; mime_type?: string } | undefined)?.mime_type ??
+          'image/png';
+        if (data) {
           out.push({
             data: {
               kind: 'base64',
-              bytes: inline.data,
-              mimeType: inline.mime_type ?? 'image/png',
+              bytes: data,
+              mimeType,
             },
           });
         }

--- a/packages/pi-image-gen/src/providers/index.ts
+++ b/packages/pi-image-gen/src/providers/index.ts
@@ -2,15 +2,13 @@ import type { ApiStyle, ImageProviderAdapter } from '../types.js';
 import { dashscopeAdapter } from './dashscope.js';
 import { geminiAdapter } from './gemini.js';
 import { openaiAdapter } from './openai.js';
+import { openrouterAdapter } from './openrouter.js';
 
-// OpenRouter exposes an OpenAI-compatible image endpoint, so it reuses
-// openaiAdapter — kept as a separate ApiStyle value so users can label intent
-// in customProviders.api without affecting the wire format.
 const ADAPTERS: Record<ApiStyle, ImageProviderAdapter> = {
   openai: openaiAdapter,
   gemini: geminiAdapter,
   dashscope: dashscopeAdapter,
-  openrouter: openaiAdapter,
+  openrouter: openrouterAdapter,
 };
 
 export function getAdapter(api: ApiStyle): ImageProviderAdapter {

--- a/packages/pi-image-gen/src/providers/openai.ts
+++ b/packages/pi-image-gen/src/providers/openai.ts
@@ -1,5 +1,5 @@
 import { classifyHttpError, describeNetworkError } from '../errors.js';
-import { classifyImageOutput } from '../image-input.js';
+import { classifyImageOutput, sniffMime } from '../image-input.js';
 import type {
   GenerateImageParams,
   ImageProviderAdapter,
@@ -9,7 +9,7 @@ import type {
 } from '../types.js';
 import { withDefaultPath } from '../url.js';
 
-function bearerHeaders(provider: ResolvedProvider): Record<string, string> {
+export function bearerHeaders(provider: ResolvedProvider): Record<string, string> {
   const headers: Record<string, string> = {};
   if (provider.apiKey) headers.authorization = `Bearer ${provider.apiKey}`;
   if (provider.headers) Object.assign(headers, provider.headers);
@@ -17,7 +17,7 @@ function bearerHeaders(provider: ResolvedProvider): Record<string, string> {
 }
 
 /**
- * OpenAI-compatible image API. Used for OpenAI directly, OpenRouter, and any
+ * OpenAI-compatible image API. Used for OpenAI directly and any
  * customProvider with `api: 'openai'`.
  *
  * Two endpoints:
@@ -26,6 +26,9 @@ function bearerHeaders(provider: ResolvedProvider): Record<string, string> {
  *
  * The edit path is selected when the caller passes `inputs` (resolved
  * reference images). Mask is intentionally not exposed to keep scope small.
+ *
+ * OpenRouter is NOT OpenAI-compatible for images — it uses POST /api/v1/images
+ * (no `/generations` suffix). See providers/openrouter.ts.
  */
 export const openaiAdapter: ImageProviderAdapter = {
   async generate(
@@ -114,7 +117,7 @@ async function generateWithImages(
   return parseImagesResponse(res, url, provider);
 }
 
-async function parseImagesResponse(
+export async function parseImagesResponse(
   res: Response,
   url: string,
   provider: ResolvedProvider,
@@ -130,7 +133,9 @@ async function parseImagesResponse(
       `${provider.name} returned ${contentType || 'non-JSON'} from ${url}. The endpoint probably doesn't expose the OpenAI-compatible images API at this path. Body: ${preview}`,
     );
   }
-  let json: { data?: Array<{ url?: string; b64_json?: string; revised_prompt?: string }> };
+  let json: {
+    data?: Array<{ url?: string; b64_json?: string; revised_prompt?: string; media_type?: string }>;
+  };
   try {
     json = JSON.parse(text);
   } catch (error) {
@@ -144,7 +149,9 @@ async function parseImagesResponse(
     // there instead of a real URL.
     let payload: RawImageResult['data'] | null = null;
     if (entry.b64_json) {
-      payload = { kind: 'base64', bytes: entry.b64_json, mimeType: 'image/png' };
+      const decoded = Buffer.from(entry.b64_json, 'base64');
+      const mimeType = sniffMime(decoded) ?? entry.media_type ?? 'image/png';
+      payload = { kind: 'base64', bytes: entry.b64_json, mimeType };
     } else {
       const classified = classifyImageOutput(entry.url);
       if (classified) payload = classified;
@@ -162,7 +169,7 @@ async function parseImagesResponse(
   return out;
 }
 
-function missingKeyMessage(provider: ResolvedProvider): string {
+export function missingKeyMessage(provider: ResolvedProvider): string {
   if (provider.builtIn) {
     return `Provider "${provider.id}" has no API key. Tell the user to set OPENAI_API_KEY (or pi-image-gen.providers.${provider.id}.apiKey in settings.json).`;
   }

--- a/packages/pi-image-gen/src/providers/openai.ts
+++ b/packages/pi-image-gen/src/providers/openai.ts
@@ -95,7 +95,7 @@ async function generateWithImages(
   form.append('prompt', params.prompt);
   form.append('n', String(params.n ?? 1));
   if (params.size) form.append('size', params.size);
-  // OpenAI accepts repeated `image[]` for multi-image edits on gpt-image-1.
+  // OpenAI accepts repeated `image[]` for multi-image edits on gpt-image-2.
   const fieldName = inputs.length > 1 ? 'image[]' : 'image';
   for (const [i, input] of inputs.entries()) {
     const ext = input.mimeType.split('/')[1] ?? 'png';

--- a/packages/pi-image-gen/src/providers/openrouter.ts
+++ b/packages/pi-image-gen/src/providers/openrouter.ts
@@ -1,0 +1,58 @@
+import { describeNetworkError } from '../errors.js';
+import { toDataUri } from '../image-input.js';
+import type {
+  GenerateImageParams,
+  ImageProviderAdapter,
+  RawImageResult,
+  ResolvedImageInput,
+  ResolvedProvider,
+} from '../types.js';
+import { withDefaultPath } from '../url.js';
+import { bearerHeaders, missingKeyMessage, parseImagesResponse } from './openai.js';
+
+/**
+ * OpenRouter image API. Looks OpenAI-shaped but the endpoint differs:
+ *   - OpenAI:     POST /v1/images/generations  (text)  /  /v1/images/edits (multipart)
+ *   - OpenRouter: POST /api/v1/images          (text)  /  same path + `input_references` JSON (edits)
+ *
+ * Response body uses `data[].b64_json` like OpenAI, so we reuse parseImagesResponse.
+ * See https://openrouter.ai/blog/announcements/image-api/.
+ */
+export const openrouterAdapter: ImageProviderAdapter = {
+  async generate(
+    provider: ResolvedProvider,
+    remoteModelId: string,
+    params: GenerateImageParams,
+    fetchImpl: typeof fetch,
+    signal?: AbortSignal,
+    inputs?: ResolvedImageInput[],
+  ): Promise<RawImageResult[]> {
+    if (!provider.apiKey) throw new Error(missingKeyMessage(provider));
+    const base = withDefaultPath(provider.baseUrl, '/api/v1');
+    const url = `${base}/images`;
+    const body: Record<string, unknown> = {
+      model: remoteModelId,
+      prompt: params.prompt,
+      n: params.n ?? 1,
+    };
+    if (params.size) body.size = params.size;
+    if (inputs && inputs.length > 0) {
+      body.input_references = inputs.map((input) => ({
+        image_url: { url: toDataUri(input) },
+      }));
+    }
+
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        method: 'POST',
+        headers: { ...bearerHeaders(provider), 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: signal ?? null,
+      });
+    } catch (error) {
+      throw new Error(describeNetworkError(error, provider));
+    }
+    return parseImagesResponse(res, url, provider);
+  },
+};


### PR DESCRIPTION
This PR started as a fix for #69 (OpenRouter routing). While verifying end-to-end against three different providers, I found two more latent bugs in adjacent code paths — fixing them here too rather than three separate PRs since the scope is the same package and the same testing setup.

Closes #69

## 1. OpenRouter routed through the wrong endpoint (the #69 fix)

OpenRouter was routed through `openaiAdapter`, hitting `POST /v1/images/generations` — an endpoint OpenRouter has never supported (404). The correct endpoint is `POST /api/v1/images` with a compatible JSON body and `input_references` (JSON, not multipart) for image-to-image.

- Add dedicated `openrouterAdapter` targeting `/api/v1/images`
- Export `bearerHeaders` / `parseImagesResponse` / `missingKeyMessage` from `openai.ts` so OpenRouter can reuse them (response parsing is identical)
- Sniff magic bytes on `b64_json` responses to pick the right mime — OpenRouter returns JPEG for several models but per its docs only sets `media_type` for SVG, so the previous hardcoded `image/png` produced wrong file extensions. Falls back to `entry.media_type`, then `image/png`. Benefits OpenAI-compatible custom providers (Doubao, self-hosted SD, etc.) too.
- README: correct OpenRouter section, add `/api/v1/images` route to the image-to-image table

Commit: `8562771`

## 2. `gpt-image-2` was a fake alias for `gpt-image-1`

`gpt-image-2` is a real OpenAI model ([docs](https://developers.openai.com/api/docs/models/gpt-image-2)), not a hypothetical alias. The previous `aliases: ['gpt-image', 'gpt-image-2']` on the `gpt-image-1` entry forced every user configuring `gpt-image-2` to send `"model": "gpt-image-1"` over the wire — breaking any gateway that distinguishes the two (amaster credits, OpenRouter pass-through, etc.).

- Promote `gpt-image-2` to the primary `BUILT_IN_MODELS` entry with `remoteId: 'gpt-image-2'`
- Drop the now-superseded `gpt-image-1` entry
- Keep `gpt-image` as the short alias
- README / tool description / test fixtures updated

Commit: `f35dc06`

## 3. Gemini image generation silently dropped every image

Two distinct issues:

**3a. Response parser used the wrong key casing.** Google's REST wire format returns `inlineData` / `mimeType` (camelCase), but the parser was reading `inline_data` / `mime_type` (snake_case from the docs' *request* examples — these are NOT symmetric). Every Gemini call hit the "no image data — model may have refused" branch and threw, regardless of the model actually returning a perfectly good image. Verified end-to-end via amaster-credits proxy (full passthrough); raw response shows `part.inlineData.{mimeType,data}`.

Parser now accepts both casings to survive any gateway that re-serializes the response. Request body stays snake_case to mirror the official [REST examples](https://ai.google.dev/gemini-api/docs/image-generation) (Google accepts both).

**3b. Built-in model list was inaccurate.** Per the official docs the three real models are:
- Nano Banana Pro → `gemini-3-pro-image`
- Nano Banana 2 → `gemini-3.1-flash-image`
- Nano Banana → `gemini-2.5-flash-image`

The previous entries (a) swapped the `nano-banana` and `nano-banana-2` aliases, (b) invented unsupported ids (`gemini-3-pro-image-preview`, `gemini-3.1-flash-image-preview`, `gemini-2.0-flash-image`), and (c) had unofficial aliases (`nano-banana-3`, `gemini-image`). Cleaned to match the docs.

Commit: `0f6df2f`

## 4. Upstream API doc links in README

Added links to the official API references for each provider so the next person debugging gateway behavior has them one click away.

Commit: `0332681`

## Test plan

- [x] Unit tests: 2 new OpenRouter cases (text-to-image hits `https://openrouter.ai/api/v1/images`; image-to-image sends `input_references: [{image_url: {url: data:...}}]`). 57/57 in package pass; 1005/1020 (15 pre-existing skips) at repo level.
- [x] End-to-end via `pi -p --provider deepseek --model deepseek-chat` driving `image_generate`:
  - OpenRouter `bytedance-seed/seedream-4.5` → real JPEG saved with correct `.jpg` extension (mime-sniffing verified)
  - OpenAI `gpt-image-2` via amaster credits proxy → real PNG, model id passed through as `gpt-image-2`
  - Gemini `gemini-3.1-flash-image-preview` via amaster credits proxy → both text-to-image AND image-to-image edit (water-colorize a previous output) succeeded
- [x] Lint + typecheck + 1005 tests pass on every commit via pre-commit hook.