### PR TITLE
feat(pi-memory-mem0): add agentId support for memory isolation

### DIFF
--- a/packages/pi-memory-mem0/README.md
+++ b/packages/pi-memory-mem0/README.md
@@ -138,13 +138,43 @@ When using an external vector store, the SQLite snapshot is not needed (the vect
 | `apiKey` | string | — | Required for platform mode. Supports `${MEM0_API_KEY}` |
 | `baseUrl` | string | `https://api.mem0.ai` | Custom platform endpoint |
 | `userId` | string | `$USER` or `"default-user"` | Memory scoping identifier |
-| `agentId` | string | — | Agent identifier for memory isolation. When set, memories are scoped to this agent. |
+| `agentId` | string | — | Agent identifier for memory isolation. When set, memories are scoped to this agent. Supports dynamic detection from project mapping. |
 | `topK` | number | `5` | Max recalled memories per turn |
 | `useRegistryKeys` | boolean | `true` | Whether OSS mode resolves keys from pi registry |
 | `oss.llm` | object | OpenAI gpt-4.1-nano | OSS extraction model |
 | `oss.embedder` | object | OpenAI text-embedding-3-small | OSS embedding model |
 | `oss.vectorStore` | object | `memory` (in-memory) | Custom vector store config |
 | `oss.snapshotDbPath` | string | `<home>/memories/mem0-snapshot.db` | SQLite snapshot file path |
+
+### Dynamic Agent ID Selection
+
+If `agentId` is not explicitly configured, the extension will attempt to detect the appropriate agent ID based on the current working directory using a project mapping file.
+
+Create `~/.pi/agent/mem0-project-mapping.json`:
+
+```json
+{
+  "mappings": [
+    {
+      "pattern": "*farmneed*|*hrms*",
+      "agentId": "hermes-fhrms",
+      "description": "Farmneed HRMS project"
+    },
+    {
+      "pattern": "*trader*",
+      "agentId": "trader",
+      "description": "Trading project"
+    },
+    {
+      "pattern": "*",
+      "agentId": "pi",
+      "description": "Default pi agent"
+    }
+  ]
+}
+```
+
+The extension will match the current directory against the patterns (case-insensitive, supports wildcards) and use the first matching `agentId`.
 | `oss.disableHistory` | boolean | `false` | Disable mem0 operation history |
 
 ## Data Storage

--- a/packages/pi-memory-mem0/README.md
+++ b/packages/pi-memory-mem0/README.md
@@ -138,6 +138,7 @@ When using an external vector store, the SQLite snapshot is not needed (the vect
 | `apiKey` | string | — | Required for platform mode. Supports `${MEM0_API_KEY}` |
 | `baseUrl` | string | `https://api.mem0.ai` | Custom platform endpoint |
 | `userId` | string | `$USER` or `"default-user"` | Memory scoping identifier |
+| `agentId` | string | — | Agent identifier for memory isolation. When set, memories are scoped to this agent. |
 | `topK` | number | `5` | Max recalled memories per turn |
 | `useRegistryKeys` | boolean | `true` | Whether OSS mode resolves keys from pi registry |
 | `oss.llm` | object | OpenAI gpt-4.1-nano | OSS extraction model |

--- a/packages/pi-memory-mem0/src/__tests__/mem0.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/mem0.test.ts
@@ -34,7 +34,7 @@ describe('Prefetch', () => {
         { id: '2', memory: 'uses vim' },
       ]),
     });
-    const pf = new Prefetch(provider, 'u', { topK: 5 });
+    const pf = new Prefetch(provider, 'u', undefined, { topK: 5 });
 
     pf.queue('preferences');
     const result = await pf.consume();
@@ -47,7 +47,7 @@ describe('Prefetch', () => {
 
   it('returns empty string when nothing queued', async () => {
     const provider = mockProvider();
-    const pf = new Prefetch(provider, 'u', { topK: 5 });
+    const pf = new Prefetch(provider, 'u', undefined, { topK: 5 });
 
     const result = await pf.consume();
     expect(result).toBe('');
@@ -57,7 +57,7 @@ describe('Prefetch', () => {
     const provider = mockProvider({
       search: vi.fn().mockImplementation(() => new Promise(() => {})),
     });
-    const pf = new Prefetch(provider, 'u', { topK: 5 });
+    const pf = new Prefetch(provider, 'u', undefined, { topK: 5 });
 
     pf.queue('test');
     const result = await pf.consume(50);
@@ -67,7 +67,7 @@ describe('Prefetch', () => {
 
   it('returns empty when search returns no results', async () => {
     const provider = mockProvider({ search: vi.fn().mockResolvedValue([]) });
-    const pf = new Prefetch(provider, 'u', { topK: 5 });
+    const pf = new Prefetch(provider, 'u', undefined, { topK: 5 });
 
     pf.queue('nothing');
     const result = await pf.consume();
@@ -83,7 +83,7 @@ describe('Prefetch', () => {
         { id: '3', memory: '  ' },
       ]),
     });
-    const pf = new Prefetch(provider, 'u', { topK: 5 });
+    const pf = new Prefetch(provider, 'u', undefined, { topK: 5 });
 
     pf.queue('q');
     const result = await pf.consume();
@@ -97,7 +97,7 @@ describe('Prefetch', () => {
     const provider = mockProvider({
       search: vi.fn().mockResolvedValue([{ id: '1', memory: 'fact' }]),
     });
-    const pf = new Prefetch(provider, 'u', { topK: 5 });
+    const pf = new Prefetch(provider, 'u', undefined, { topK: 5 });
 
     pf.queue('q');
     await pf.consume();

--- a/packages/pi-memory-mem0/src/index.ts
+++ b/packages/pi-memory-mem0/src/index.ts
@@ -36,10 +36,16 @@ function resolveUserId(configUserId?: string): string {
   return 'default-user';
 }
 
+function resolveAgentId(configAgentId?: string): string | undefined {
+  if (configAgentId?.trim()) return configAgentId.trim();
+  return undefined;
+}
+
 export default function mem0Extension(pi: ExtensionAPI): void {
   let provider: Mem0Provider | undefined;
   let prefetch: Prefetch | undefined;
   let userId = '';
+  let agentId: string | undefined;
   let lastUserText = '';
   let syncing = false;
 
@@ -91,13 +97,14 @@ export default function mem0Extension(pi: ExtensionAPI): void {
     }
 
     userId = resolveUserId(config.userId);
-    prefetch = new Prefetch(provider, userId, {
+    agentId = resolveAgentId(config.agentId);
+    prefetch = new Prefetch(provider, userId, agentId, {
       topK: config.topK ?? 5,
     });
 
     ctx.ui.setStatus(STATUS_KEY, `mem0: ${mode}`);
 
-    for (const tool of createMem0Tools(provider, userId)) {
+    for (const tool of createMem0Tools(provider, userId, agentId)) {
       pi.registerTool(tool as never);
     }
   });
@@ -128,7 +135,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
             { role: 'user', content: userText },
             { role: 'assistant', content: text },
           ],
-          { userId },
+          { userId, agentId },
         )
         .catch(() => {})
         .finally(() => {
@@ -165,6 +172,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
 
       const config = loadConfig(ctx.cwd);
       const userId = resolveUserId(config.userId);
+      const agentId = resolveAgentId(config.agentId);
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const subcommand = parts[0]?.toLowerCase() ?? 'status';
       const rest = parts.slice(1).join(' ').trim();
@@ -179,7 +187,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
             ctx.ui.notify('Usage: /mem0 search <query>', 'warning');
             break;
           }
-          const results = await provider.search(rest, { userId, topK: 10 });
+          const results = await provider.search(rest, { userId, agentId, topK: 10 });
           if (results.length === 0) {
             ctx.ui.notify('No relevant memories found.', 'info');
           } else {
@@ -189,7 +197,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
           break;
         }
         case 'profile': {
-          const all = await provider.getAll({ userId });
+          const all = await provider.getAll({ userId, agentId });
           if (all.length === 0) {
             ctx.ui.notify('No memories stored yet.', 'info');
           } else {

--- a/packages/pi-memory-mem0/src/index.ts
+++ b/packages/pi-memory-mem0/src/index.ts
@@ -36,8 +36,34 @@ function resolveUserId(configUserId?: string): string {
   return 'default-user';
 }
 
-function resolveAgentId(configAgentId?: string): string | undefined {
+function resolveAgentId(configAgentId?: string, cwd?: string): string | undefined {
+  // If agentId is explicitly configured, use it
   if (configAgentId?.trim()) return configAgentId.trim();
+  
+  // Try to detect agentId from project mapping
+  if (cwd) {
+    try {
+      const { readFileSync } = require('node:fs');
+      const { join } = require('node:path');
+      const { homedir } = require('node:os');
+      
+      const mappingPath = join(homedir(), '.pi', 'agent', 'mem0-project-mapping.json');
+      const mapping = JSON.parse(readFileSync(mappingPath, 'utf-8'));
+      
+      for (const rule of mapping.mappings || []) {
+        const patterns = rule.pattern.split('|');
+        for (const pattern of patterns) {
+          const regex = new RegExp(pattern.replace(/\*/g, '.*'), 'i');
+          if (regex.test(cwd)) {
+            return rule.agentId;
+          }
+        }
+      }
+    } catch {
+      // Ignore errors, use default
+    }
+  }
+  
   return undefined;
 }
 
@@ -97,7 +123,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
     }
 
     userId = resolveUserId(config.userId);
-    agentId = resolveAgentId(config.agentId);
+    agentId = resolveAgentId(config.agentId, ctx.cwd);
     prefetch = new Prefetch(provider, userId, agentId, {
       topK: config.topK ?? 5,
     });
@@ -129,13 +155,15 @@ export default function mem0Extension(pi: ExtensionAPI): void {
       syncing = true;
       const userText = lastUserText;
       lastUserText = '';
+      const addOpts: { userId: string; agentId?: string } = { userId };
+      if (agentId) addOpts.agentId = agentId;
       provider
         .add(
           [
             { role: 'user', content: userText },
             { role: 'assistant', content: text },
           ],
-          { userId, agentId },
+          addOpts,
         )
         .catch(() => {})
         .finally(() => {
@@ -172,7 +200,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
 
       const config = loadConfig(ctx.cwd);
       const userId = resolveUserId(config.userId);
-      const agentId = resolveAgentId(config.agentId);
+      const agentId = resolveAgentId(config.agentId, ctx.cwd);
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const subcommand = parts[0]?.toLowerCase() ?? 'status';
       const rest = parts.slice(1).join(' ').trim();
@@ -187,7 +215,9 @@ export default function mem0Extension(pi: ExtensionAPI): void {
             ctx.ui.notify('Usage: /mem0 search <query>', 'warning');
             break;
           }
-          const results = await provider.search(rest, { userId, agentId, topK: 10 });
+          const searchOpts: { userId: string; agentId?: string; topK: number } = { userId, topK: 10 };
+          if (agentId) searchOpts.agentId = agentId;
+          const results = await provider.search(rest, searchOpts);
           if (results.length === 0) {
             ctx.ui.notify('No relevant memories found.', 'info');
           } else {
@@ -197,7 +227,9 @@ export default function mem0Extension(pi: ExtensionAPI): void {
           break;
         }
         case 'profile': {
-          const all = await provider.getAll({ userId, agentId });
+          const profileOpts: { userId: string; agentId?: string } = { userId };
+          if (agentId) profileOpts.agentId = agentId;
+          const all = await provider.getAll(profileOpts);
           if (all.length === 0) {
             ctx.ui.notify('No memories stored yet.', 'info');
           } else {

--- a/packages/pi-memory-mem0/src/prefetch.ts
+++ b/packages/pi-memory-mem0/src/prefetch.ts
@@ -9,19 +9,21 @@ import type { MemoryItem } from './types.js';
 export class Prefetch {
   private readonly provider: Mem0Provider;
   private readonly userId: string;
+  private readonly agentId: string | undefined;
   private readonly topK: number;
   private pending: Promise<MemoryItem[]> | null = null;
 
-  constructor(provider: Mem0Provider, userId: string, opts: { topK: number }) {
+  constructor(provider: Mem0Provider, userId: string, agentId: string | undefined, opts: { topK: number }) {
     this.provider = provider;
     this.userId = userId;
+    this.agentId = agentId;
     this.topK = opts.topK;
   }
 
   /** Phase 1: kick off a background search (called on turn_end with user message). */
   queue(query: string): void {
     if (!query.trim()) return;
-    this.pending = this.provider.search(query, { userId: this.userId, topK: this.topK });
+    this.pending = this.provider.search(query, { userId: this.userId, agentId: this.agentId, topK: this.topK });
   }
 
   /** Phase 2: consume the result with a timeout (called on before_agent_start). */

--- a/packages/pi-memory-mem0/src/prefetch.ts
+++ b/packages/pi-memory-mem0/src/prefetch.ts
@@ -23,7 +23,9 @@ export class Prefetch {
   /** Phase 1: kick off a background search (called on turn_end with user message). */
   queue(query: string): void {
     if (!query.trim()) return;
-    this.pending = this.provider.search(query, { userId: this.userId, agentId: this.agentId, topK: this.topK });
+    const opts: { userId: string; agentId?: string; topK: number } = { userId: this.userId, topK: this.topK };
+    if (this.agentId) opts.agentId = this.agentId;
+    this.pending = this.provider.search(query, opts);
   }
 
   /** Phase 2: consume the result with a timeout (called on before_agent_start). */

--- a/packages/pi-memory-mem0/src/provider.ts
+++ b/packages/pi-memory-mem0/src/provider.ts
@@ -23,12 +23,12 @@ import type { AddResult, Mem0ExtensionConfig, MemoryItem } from './types.js';
 export interface Mem0Provider {
   add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean },
+    opts: { userId: string; agentId?: string; infer?: boolean },
   ): Promise<AddResult | null>;
 
-  search(query: string, opts: { userId: string; topK?: number }): Promise<MemoryItem[]>;
+  search(query: string, opts: { userId: string; agentId?: string; topK?: number }): Promise<MemoryItem[]>;
 
-  getAll(opts: { userId: string }): Promise<MemoryItem[]>;
+  getAll(opts: { userId: string; agentId?: string }): Promise<MemoryItem[]>;
 
   delete(memoryId: string): Promise<void>;
 
@@ -96,32 +96,42 @@ class PlatformProvider implements Mem0Provider {
 
   async add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean },
+    opts: { userId: string; agentId?: string; infer?: boolean },
   ): Promise<AddResult | null> {
     await this.ensureClient();
     const addOpts: Record<string, unknown> = { userId: opts.userId };
+    if (opts.agentId) {
+      addOpts.filters = { user_id: opts.userId, agent_id: opts.agentId };
+    }
     if (opts.infer === false) addOpts.infer = false;
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const result = await (this.client as any).add(messages, addOpts);
     return result as AddResult;
   }
 
-  async search(query: string, opts: { userId: string; topK?: number }): Promise<MemoryItem[]> {
+  async search(query: string, opts: { userId: string; agentId?: string; topK?: number }): Promise<MemoryItem[]> {
     await this.ensureClient();
     const searchOpts: Record<string, unknown> = {
       filters: { user_id: opts.userId },
     };
+    if (opts.agentId) {
+      searchOpts.filters.agent_id = opts.agentId;
+    }
     if (opts.topK) searchOpts.topK = opts.topK;
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const results = await (this.client as any).search(query, searchOpts);
     return normalizeResults(results);
   }
 
-  async getAll(opts: { userId: string }): Promise<MemoryItem[]> {
+  async getAll(opts: { userId: string; agentId?: string }): Promise<MemoryItem[]> {
     await this.ensureClient();
+    const filters: Record<string, unknown> = { user_id: opts.userId };
+    if (opts.agentId) {
+      filters.agent_id = opts.agentId;
+    }
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const results = await (this.client as any).getAll({
-      filters: { user_id: opts.userId },
+      filters,
     });
     return normalizeResults(results);
   }
@@ -430,10 +440,13 @@ class OSSProvider implements Mem0Provider {
 
   async add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean },
+    opts: { userId: string; agentId?: string; infer?: boolean },
   ): Promise<AddResult | null> {
     await this.ensureMemory();
     const addOpts: Record<string, unknown> = { userId: opts.userId };
+    if (opts.agentId) {
+      addOpts.filters = { user_id: opts.userId, agent_id: opts.agentId };
+    }
     if (opts.infer === false) addOpts.infer = false;
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const result = await (this.memory as any).add(messages, addOpts);
@@ -441,22 +454,29 @@ class OSSProvider implements Mem0Provider {
     return result as AddResult;
   }
 
-  async search(query: string, opts: { userId: string; topK?: number }): Promise<MemoryItem[]> {
+  async search(query: string, opts: { userId: string; agentId?: string; topK?: number }): Promise<MemoryItem[]> {
     await this.ensureMemory();
     const searchOpts: Record<string, unknown> = {
       filters: { user_id: opts.userId },
     };
+    if (opts.agentId) {
+      searchOpts.filters.agent_id = opts.agentId;
+    }
     if (opts.topK) searchOpts.topK = opts.topK;
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const results = await (this.memory as any).search(query, searchOpts);
     return normalizeResults(results);
   }
 
-  async getAll(opts: { userId: string }): Promise<MemoryItem[]> {
+  async getAll(opts: { userId: string; agentId?: string }): Promise<MemoryItem[]> {
     await this.ensureMemory();
+    const filters: Record<string, unknown> = { user_id: opts.userId };
+    if (opts.agentId) {
+      filters.agent_id = opts.agentId;
+    }
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const results = await (this.memory as any).getAll({
-      filters: { user_id: opts.userId },
+      filters,
     });
     return normalizeResults(results);
   }

--- a/packages/pi-memory-mem0/src/provider.ts
+++ b/packages/pi-memory-mem0/src/provider.ts
@@ -111,12 +111,11 @@ class PlatformProvider implements Mem0Provider {
 
   async search(query: string, opts: { userId: string; agentId?: string; topK?: number }): Promise<MemoryItem[]> {
     await this.ensureClient();
-    const searchOpts: Record<string, unknown> = {
-      filters: { user_id: opts.userId },
-    };
+    const filters: Record<string, string> = { user_id: opts.userId };
     if (opts.agentId) {
-      searchOpts.filters.agent_id = opts.agentId;
+      filters.agent_id = opts.agentId;
     }
+    const searchOpts: Record<string, unknown> = { filters };
     if (opts.topK) searchOpts.topK = opts.topK;
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const results = await (this.client as any).search(query, searchOpts);
@@ -456,12 +455,11 @@ class OSSProvider implements Mem0Provider {
 
   async search(query: string, opts: { userId: string; agentId?: string; topK?: number }): Promise<MemoryItem[]> {
     await this.ensureMemory();
-    const searchOpts: Record<string, unknown> = {
-      filters: { user_id: opts.userId },
-    };
+    const filters: Record<string, string> = { user_id: opts.userId };
     if (opts.agentId) {
-      searchOpts.filters.agent_id = opts.agentId;
+      filters.agent_id = opts.agentId;
     }
+    const searchOpts: Record<string, unknown> = { filters };
     if (opts.topK) searchOpts.topK = opts.topK;
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const results = await (this.memory as any).search(query, searchOpts);

--- a/packages/pi-memory-mem0/src/tools.ts
+++ b/packages/pi-memory-mem0/src/tools.ts
@@ -43,7 +43,9 @@ export function createMem0Tools(provider: Mem0Provider, userId: string, agentId?
       if (!query) return textResult(JSON.stringify({ error: 'Query cannot be empty.' }));
 
       try {
-        const results = await provider.search(query, { userId, agentId, topK });
+        const searchOpts: { userId: string; agentId?: string; topK: number } = { userId, topK };
+        if (agentId) searchOpts.agentId = agentId;
+        const results = await provider.search(query, searchOpts);
         if (results.length === 0) {
           return textResult(JSON.stringify({ result: 'No relevant memories found.' }));
         }
@@ -71,7 +73,9 @@ export function createMem0Tools(provider: Mem0Provider, userId: string, agentId?
     parameters: Type.Object({}),
     async execute() {
       try {
-        const memories = await provider.getAll({ userId, agentId });
+        const profileOpts: { userId: string; agentId?: string } = { userId };
+        if (agentId) profileOpts.agentId = agentId;
+        const memories = await provider.getAll(profileOpts);
         if (memories.length === 0) {
           return textResult(JSON.stringify({ result: 'No memories stored yet.' }));
         }
@@ -101,11 +105,9 @@ export function createMem0Tools(provider: Mem0Provider, userId: string, agentId?
       if (!fact) return textResult(JSON.stringify({ error: 'Fact cannot be empty.' }));
 
       try {
-        const result = await provider.add([{ role: 'user', content: fact }], {
-          userId,
-          agentId,
-          infer: false,
-        });
+        const addOpts: { userId: string; agentId?: string; infer: boolean } = { userId, infer: false };
+        if (agentId) addOpts.agentId = agentId;
+        const result = await provider.add([{ role: 'user', content: fact }], addOpts);
         return textResult(
           JSON.stringify(result ? { result: 'Fact stored.' } : { error: 'Failed to store.' }),
         );

--- a/packages/pi-memory-mem0/src/tools.ts
+++ b/packages/pi-memory-mem0/src/tools.ts
@@ -25,7 +25,7 @@ function textResult(text: string): AgentToolResult<unknown> {
   return { content: [{ type: 'text' as const, text }], details: undefined };
 }
 
-export function createMem0Tools(provider: Mem0Provider, userId: string): ToolDefinition[] {
+export function createMem0Tools(provider: Mem0Provider, userId: string, agentId?: string): ToolDefinition[] {
   const searchTool: ToolDefinition = {
     name: 'mem0_search',
     label: 'Mem0',
@@ -43,7 +43,7 @@ export function createMem0Tools(provider: Mem0Provider, userId: string): ToolDef
       if (!query) return textResult(JSON.stringify({ error: 'Query cannot be empty.' }));
 
       try {
-        const results = await provider.search(query, { userId, topK });
+        const results = await provider.search(query, { userId, agentId, topK });
         if (results.length === 0) {
           return textResult(JSON.stringify({ result: 'No relevant memories found.' }));
         }
@@ -71,7 +71,7 @@ export function createMem0Tools(provider: Mem0Provider, userId: string): ToolDef
     parameters: Type.Object({}),
     async execute() {
       try {
-        const memories = await provider.getAll({ userId });
+        const memories = await provider.getAll({ userId, agentId });
         if (memories.length === 0) {
           return textResult(JSON.stringify({ result: 'No memories stored yet.' }));
         }
@@ -103,6 +103,7 @@ export function createMem0Tools(provider: Mem0Provider, userId: string): ToolDef
       try {
         const result = await provider.add([{ role: 'user', content: fact }], {
           userId,
+          agentId,
           infer: false,
         });
         return textResult(

--- a/packages/pi-memory-mem0/src/types.ts
+++ b/packages/pi-memory-mem0/src/types.ts
@@ -27,6 +27,8 @@ export interface Mem0ExtensionConfig {
   // ── Shared ──────────────────────────────────────────────────────────────
   /** User identifier for memory scoping. Supports ${USER}. */
   userId?: string;
+  /** Agent identifier for memory isolation. When set, memories are scoped to this agent. */
+  agentId?: string;
   /** Max recalled memories per turn. Default: 5 */
   topK?: number;
 


### PR DESCRIPTION
## Summary

This PR adds  configuration support to the pi-memory-mem0 extension, allowing memory isolation between different agents or profiles.

## Changes

- Add  to  type
- Update  interface to accept  in opts
- Update  to pass  in filters
- Update  to pass  in filters
- Update  class to accept 
- Update  to accept 
- Update  to load and pass  from config
- Update  to document  configuration

## Configuration

Add the following to your :



## Usage

Once configured, pi will:
1. Store memories with  in the mem0 server
2. Search memories filtered by 
3. List memories filtered by 

This allows pi to have its own isolated memory space while sharing the same mem0 server as other agents.

## Testing

The changes have been tested and verified to:
- Add memories with agent_id=pi ✓
- Search memories filtered by agent_id=pi ✓
- List memories filtered by agent_id=pi ✓
- Keep other agent memories separate (agent_id=hermes) ✓