### PR TITLE
feat(pi-image-gen): add Volcengine Ark provider for ByteDance Seedream

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -156,7 +156,7 @@ export ARK_API_KEY=...
 { "pi-image-gen": { "defaultModel": "seedream" } }
 ```
 
-> Ark rejects `size` values below ~3.7 megapixels — `1024x1024` will fail with `InvalidParameter`. Use `2048x2048` (or any size ≥ 3,686,400 pixels) instead. Other built-in providers default to `1024x1024`, so this is the one knob you need to remember when switching to Seedream.
+> Supported `size` values are model-dependent. Seedream 5.0 / 5.0 lite / 4.5 require 2K or larger (e.g. `2048x2048`, `1728x2304`, `2848x1600`) — `1024x1024` will fail with `InvalidParameter`. Seedream 4.0 is the only one that accepts 1K sizes. Full sizing matrix in the [official docs](https://www.volcengine.com/docs/82379/1824121). Other built-in providers default to `1024x1024`, so this is the one knob to remember when switching to Seedream ≥ 4.5.
 
 The default base URL is `https://ark.cn-beijing.volces.com/api/v3`. To use a different region (e.g. `ap-southeast`), override it:
 

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -9,6 +9,7 @@ Pi extension that adds an `image_generate` tool. Supported providers:
 | OpenAI                         | `gpt-image-2` (alias `gpt-image`)               | `OPENAI_API_KEY`      |
 | Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3.1-flash-image` (alias `nano-banana-2`), `gemini-2.5-flash-image` (alias `nano-banana`) | `GEMINI_API_KEY` |
 | Alibaba DashScope (Qwen-Image) | `qwen-image-2.0-pro` (alias `qwen-image-pro`), `qwen-image-2.0` (alias `qwen-image-2`, `qwen-image`) | `DASHSCOPE_API_KEY` |
+| Volcengine Ark (ByteDance Seedream) | `doubao-seedream-5-0-260128` (alias `seedream-5`, `seedream`), `doubao-seedream-5-0-lite-260128` (alias `seedream-5-lite`), `doubao-seedream-4-5-251128` (alias `seedream-4-5`), `doubao-seedream-4-0-250828` (alias `seedream-4`) | `ARK_API_KEY`         |
 | OpenRouter                     | any (use `openrouter/<vendor>/<id>`)          | `OPENROUTER_API_KEY`  |
 | Custom providers               | whatever you declare in settings              | (your choice, via `$VAR`) |
 
@@ -18,6 +19,7 @@ Upstream API docs (handy when debugging gateway behavior or adding new models):
 - Google Gemini image generation — [ai.google.dev/gemini-api/docs/image-generation](https://ai.google.dev/gemini-api/docs/image-generation)
 - Alibaba DashScope Qwen-Image (text-to-image) — [help.aliyun.com/zh/model-studio/text-to-image](https://help.aliyun.com/zh/model-studio/text-to-image)
 - Alibaba DashScope Qwen-Image-Edit — [help.aliyun.com/zh/model-studio/qwen-image-edit-guide](https://help.aliyun.com/zh/model-studio/qwen-image-edit-guide)
+- Volcengine Ark Seedream — [volcengine.com/docs/82379/1824121](https://www.volcengine.com/docs/82379/1824121)
 - OpenRouter image API — [openrouter.ai/docs/api/api-reference/images/create-images](https://openrouter.ai/docs/api/api-reference/images/create-images)
 
 The env-var names match [pi.dev's provider table](https://pi.dev/docs/latest/providers) — if the agent already has a key set for a provider, this extension will reuse it. You don't need to introduce a new variable.
@@ -70,6 +72,7 @@ That's it. From the agent: `image_generate({ prompt: "a cyberpunk cat" })`.
       "openai":     { "baseUrl": "https://my-proxy.example.com/v1", "apiKey": "${MY_OPENAI_KEY}" },
       "gemini":     { "headers": { "x-goog-trace": "pi-prod" } },
       "dashscope":  { "baseUrl": "https://dashscope-intl.aliyuncs.com/api/v1" },
+      "ark":        { "apiKey": "$ARK_API_KEY" },
       "openrouter": { "apiKey": "$OPENROUTER_API_KEY" }
     },
 
@@ -143,7 +146,32 @@ For the international DashScope endpoint, override the base URL:
 }
 ```
 
-### 4. OpenRouter (one key, many models)
+### 4. Volcengine Ark (ByteDance Seedream)
+
+```sh
+export ARK_API_KEY=...
+```
+
+```json
+{ "pi-image-gen": { "defaultModel": "seedream" } }
+```
+
+> Ark rejects `size` values below ~3.7 megapixels — `1024x1024` will fail with `InvalidParameter`. Use `2048x2048` (or any size ≥ 3,686,400 pixels) instead. Other built-in providers default to `1024x1024`, so this is the one knob you need to remember when switching to Seedream.
+
+The default base URL is `https://ark.cn-beijing.volces.com/api/v3`. To use a different region (e.g. `ap-southeast`), override it:
+
+```json
+{
+  "pi-image-gen": {
+    "defaultModel": "seedream",
+    "providers": {
+      "ark": { "baseUrl": "https://ark.ap-southeast.bytepluses.com/api/v3" }
+    }
+  }
+}
+```
+
+### 5. OpenRouter (one key, many models)
 
 ```sh
 export OPENROUTER_API_KEY=...
@@ -165,14 +193,14 @@ Each custom provider declares:
 
 | Field      | Required | Notes                                                                                |
 | ---------- | -------- | ------------------------------------------------------------------------------------ |
-| `api` | yes      | One of `openai`, `gemini`, `dashscope`, `openrouter`. Picks the image-API wire shape. |
+| `api` | yes      | One of `openai`, `gemini`, `dashscope`, `openrouter`, `ark`. Picks the image-API wire shape. |
 | `baseUrl`  | yes      | API endpoint URL. `$VAR` syntax supported.                                           |
 | `apiKey`   | usually  | API key string. `$VAR` syntax supported.                                             |
 | `name`     | no       | Display name shown in `/image-gen list`.                                             |
 | `headers`  | no       | Extra headers merged into every request.                                             |
 | `models`   | no       | Optional model id/alias list. Omit to make this a **catch-all** — the provider will accept any unknown model id (passed through as the remote id). Provide a list only when you want aliases or want to route specific ids elsewhere. Each entry is a string or `{ id, alias?, name? }`. |
 
-> Note: pi.dev custom providers also have an `api` field, but its values (`openai-completions`, `anthropic-messages`, …) are LLM streaming formats that don't apply to image generation. The values here (`openai`, `gemini`, `dashscope`, `openrouter`) are image-API wire shapes — same field name, different namespace.
+> Note: pi.dev custom providers also have an `api` field, but its values (`openai-completions`, `anthropic-messages`, …) are LLM streaming formats that don't apply to image generation. The values here (`openai`, `gemini`, `dashscope`, `openrouter`, `ark`) are image-API wire shapes — same field name, different namespace.
 
 ### Example: self-hosted Stable Diffusion (OpenAI-compatible)
 

--- a/packages/pi-image-gen/src/__tests__/ark.test.ts
+++ b/packages/pi-image-gen/src/__tests__/ark.test.ts
@@ -1,0 +1,135 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveModel } from '../config.js';
+import { generateImage } from '../generate.js';
+
+const PNG_BYTES = Buffer.from(
+  '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c63000100000005000115c46f250000000049454e44ae426082',
+  'hex',
+);
+
+function fakeJsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('ark provider (Volcengine Seedream)', () => {
+  it('routes seedream alias to the latest 5.0 model', () => {
+    process.env.ARK_API_KEY = 'ark-test';
+    const result = resolveModel('seedream', {});
+    if ('error' in result) throw new Error(result.error);
+    expect(result.provider.id).toBe('ark');
+    expect(result.provider.api).toBe('ark');
+    expect(result.remoteId).toBe('doubao-seedream-5-0-260128');
+    expect(result.provider.baseUrl).toBe('https://ark.cn-beijing.volces.com/api/v3');
+    expect(result.provider.apiKey).toBe('ark-test');
+  });
+
+  it('routes seedream-4 alias to the 4.0 model', () => {
+    process.env.ARK_API_KEY = 'ark-test';
+    const result = resolveModel('seedream-4', {});
+    if ('error' in result) throw new Error(result.error);
+    expect(result.remoteId).toBe('doubao-seedream-4-0-250828');
+  });
+
+  it('text-to-image posts to /images/generations with prompt/n/size as JSON', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-ark-'));
+    process.env.ARK_API_KEY = 'ark-test';
+
+    const calls: Array<{ url: string; method: string; body: Record<string, unknown> }> = [];
+    const fetchImpl: typeof fetch = (async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      calls.push({
+        url,
+        method: (init as RequestInit | undefined)?.method ?? 'GET',
+        body: JSON.parse(String((init as RequestInit | undefined)?.body ?? '{}')),
+      });
+      return fakeJsonResponse({
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
+      });
+    }) as typeof fetch;
+
+    const result = await generateImage(
+      { prompt: '一只猫', size: '1024x1024', filename: 'cat' },
+      {
+        cwd,
+        settings: { defaultModel: 'seedream' },
+        fetchImpl,
+        now: () => new Date(Date.UTC(2026, 5, 4, 12, 0, 0)),
+      },
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('https://ark.cn-beijing.volces.com/api/v3/images/generations');
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.body).toMatchObject({
+      model: 'doubao-seedream-5-0-260128',
+      prompt: '一只猫',
+      n: 1,
+      size: '1024x1024',
+    });
+    expect(calls[0]?.body.image).toBeUndefined();
+    expect(result.provider).toBe('ark');
+    expect(result.images).toHaveLength(1);
+    expect(readFileSync(result.images[0]!.path)).toEqual(PNG_BYTES);
+  });
+
+  it('image-to-image inlines reference images as data URIs in the JSON body', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-ark-i2i-'));
+    process.env.ARK_API_KEY = 'ark-test';
+
+    const refPath = join(cwd, 'ref.png');
+    writeFileSync(refPath, PNG_BYTES);
+
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const fetchImpl: typeof fetch = (async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      calls.push({
+        url,
+        body: JSON.parse(String((init as RequestInit | undefined)?.body ?? '{}')),
+      });
+      return fakeJsonResponse({ data: [{ url: 'https://cdn.test/out.png' }] });
+    }) as typeof fetch;
+
+    // The url-style result triggers a second fetch for the bytes; that goes
+    // through the same fetchImpl, which would push an extra entry — wrap with
+    // a switch on the host so we don't conflate the two.
+    const wrapped: typeof fetch = (async (input, init) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/images/generations')) return fetchImpl(input, init);
+      return new Response(PNG_BYTES, {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      });
+    }) as typeof fetch;
+
+    const result = await generateImage(
+      { prompt: 'redraw it', image: [refPath] },
+      { cwd, settings: { defaultModel: 'seedream' }, fetchImpl: wrapped },
+    );
+
+    expect(calls).toHaveLength(1);
+    const sent = calls[0]?.body as { image?: unknown };
+    expect(Array.isArray(sent.image)).toBe(true);
+    const images = sent.image as string[];
+    expect(images).toHaveLength(1);
+    expect(images[0]).toMatch(/^data:image\/png;base64,/);
+    expect(result.images).toHaveLength(1);
+    expect(readFileSync(result.images[0]!.path)).toEqual(PNG_BYTES);
+  });
+
+  it('reports a helpful error when ARK_API_KEY is not set', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-ark-nokey-'));
+    delete process.env.ARK_API_KEY;
+    await expect(
+      generateImage(
+        { prompt: 'x' },
+        { cwd, settings: { defaultModel: 'seedream' }, fetchImpl: fetch },
+      ),
+    ).rejects.toThrow(/ARK_API_KEY|no API key|Unknown image model/i);
+  });
+});

--- a/packages/pi-image-gen/src/config.ts
+++ b/packages/pi-image-gen/src/config.ts
@@ -197,7 +197,7 @@ export type ConfiguredProvider = ResolvedProvider & {
 
 export function listConfiguredProviders(settings: ImageGenSettings): ConfiguredProvider[] {
   const out: ConfiguredProvider[] = [];
-  for (const id of ['openai', 'gemini', 'dashscope', 'openrouter'] as BuiltInProviderId[]) {
+  for (const id of ['openai', 'gemini', 'dashscope', 'openrouter', 'ark'] as BuiltInProviderId[]) {
     const provider = buildBuiltInProvider(id, settings);
     if (provider?.apiKey) out.push({ ...provider, catchAll: false, modelCount: 0 });
   }
@@ -213,6 +213,10 @@ export function listConfiguredProviders(settings: ImageGenSettings): ConfiguredP
 
 function isBuiltInProviderId(value: string): value is BuiltInProviderId {
   return (
-    value === 'openai' || value === 'gemini' || value === 'dashscope' || value === 'openrouter'
+    value === 'openai' ||
+    value === 'gemini' ||
+    value === 'dashscope' ||
+    value === 'openrouter' ||
+    value === 'ark'
   );
 }

--- a/packages/pi-image-gen/src/models.ts
+++ b/packages/pi-image-gen/src/models.ts
@@ -59,6 +59,34 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
     provider: 'dashscope',
     remoteId: 'qwen-image-2.0',
   },
+
+  // ByteDance Seedream via Volcengine Ark. The `seedream` alias points at the
+  // latest stable Seedream release.
+  // Docs: https://www.volcengine.com/docs/82379/1824121
+  {
+    id: 'doubao-seedream-5-0-260128',
+    aliases: ['seedream-5', 'seedream'],
+    provider: 'ark',
+    remoteId: 'doubao-seedream-5-0-260128',
+  },
+  {
+    id: 'doubao-seedream-5-0-lite-260128',
+    aliases: ['seedream-5-lite'],
+    provider: 'ark',
+    remoteId: 'doubao-seedream-5-0-lite-260128',
+  },
+  {
+    id: 'doubao-seedream-4-5-251128',
+    aliases: ['seedream-4-5'],
+    provider: 'ark',
+    remoteId: 'doubao-seedream-4-5-251128',
+  },
+  {
+    id: 'doubao-seedream-4-0-250828',
+    aliases: ['seedream-4'],
+    provider: 'ark',
+    remoteId: 'doubao-seedream-4-0-250828',
+  },
 ];
 
 export const DEFAULT_BASE_URL: Record<BuiltInProviderId, string> = {
@@ -66,6 +94,7 @@ export const DEFAULT_BASE_URL: Record<BuiltInProviderId, string> = {
   gemini: 'https://generativelanguage.googleapis.com/v1beta',
   dashscope: 'https://dashscope.aliyuncs.com/api/v1',
   openrouter: 'https://openrouter.ai/api/v1',
+  ark: 'https://ark.cn-beijing.volces.com/api/v3',
 };
 
 export const DEFAULT_API_STYLE: Record<BuiltInProviderId, ApiStyle> = {
@@ -73,6 +102,7 @@ export const DEFAULT_API_STYLE: Record<BuiltInProviderId, ApiStyle> = {
   gemini: 'gemini',
   dashscope: 'dashscope',
   openrouter: 'openrouter',
+  ark: 'ark',
 };
 
 export const ENV_VARS: Record<BuiltInProviderId, string> = {
@@ -80,6 +110,7 @@ export const ENV_VARS: Record<BuiltInProviderId, string> = {
   gemini: 'GEMINI_API_KEY',
   dashscope: 'DASHSCOPE_API_KEY',
   openrouter: 'OPENROUTER_API_KEY',
+  ark: 'ARK_API_KEY',
 };
 
 export const PROVIDER_DISPLAY_NAME: Record<BuiltInProviderId, string> = {
@@ -87,4 +118,5 @@ export const PROVIDER_DISPLAY_NAME: Record<BuiltInProviderId, string> = {
   gemini: 'Google Gemini',
   dashscope: 'Alibaba DashScope',
   openrouter: 'OpenRouter',
+  ark: 'Volcengine Ark',
 };

--- a/packages/pi-image-gen/src/providers/ark.ts
+++ b/packages/pi-image-gen/src/providers/ark.ts
@@ -1,0 +1,69 @@
+import { describeNetworkError } from '../errors.js';
+import { toDataUri } from '../image-input.js';
+import type {
+  GenerateImageParams,
+  ImageProviderAdapter,
+  RawImageResult,
+  ResolvedImageInput,
+  ResolvedProvider,
+} from '../types.js';
+import { withDefaultPath } from '../url.js';
+import { bearerHeaders, parseImagesResponse } from './openai.js';
+
+/**
+ * Volcengine Ark image generation (ByteDance Seedream series).
+ *
+ *   POST /api/v3/images/generations
+ *
+ * OpenAI-shaped request + response (model/prompt/n/size, data[].url|b64_json),
+ * with one twist: reference images for image-to-image / multi-image conditioning
+ * go into the same JSON body as `image: [<data-uri>, ...]` — NOT a multipart
+ * /images/edits call. So we reuse openai's parser but build our own body.
+ *
+ * Docs: https://www.volcengine.com/docs/82379/1824121
+ */
+export const arkAdapter: ImageProviderAdapter = {
+  async generate(
+    provider: ResolvedProvider,
+    remoteModelId: string,
+    params: GenerateImageParams,
+    fetchImpl: typeof fetch,
+    signal?: AbortSignal,
+    inputs?: ResolvedImageInput[],
+  ): Promise<RawImageResult[]> {
+    if (!provider.apiKey) {
+      throw new Error(missingKeyMessage(provider));
+    }
+    const base = withDefaultPath(provider.baseUrl, '/api/v3');
+    const url = `${base}/images/generations`;
+    const body: Record<string, unknown> = {
+      model: remoteModelId,
+      prompt: params.prompt,
+      n: params.n ?? 1,
+    };
+    if (params.size) body.size = params.size;
+    if (inputs && inputs.length > 0) {
+      body.image = inputs.map((input) => toDataUri(input));
+    }
+
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        method: 'POST',
+        headers: { ...bearerHeaders(provider), 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: signal ?? null,
+      });
+    } catch (error) {
+      throw new Error(describeNetworkError(error, provider));
+    }
+    return parseImagesResponse(res, url, provider);
+  },
+};
+
+function missingKeyMessage(provider: ResolvedProvider): string {
+  if (provider.builtIn) {
+    return `Provider "${provider.id}" has no API key. Tell the user to set ARK_API_KEY (or pi-image-gen.providers.${provider.id}.apiKey in settings.json).`;
+  }
+  return `Provider "${provider.id}" has no API key. Tell the user to set pi-image-gen.customProviders.${provider.id}.apiKey in settings.json.`;
+}

--- a/packages/pi-image-gen/src/providers/index.ts
+++ b/packages/pi-image-gen/src/providers/index.ts
@@ -1,4 +1,5 @@
 import type { ApiStyle, ImageProviderAdapter } from '../types.js';
+import { arkAdapter } from './ark.js';
 import { dashscopeAdapter } from './dashscope.js';
 import { geminiAdapter } from './gemini.js';
 import { openaiAdapter } from './openai.js';
@@ -9,6 +10,7 @@ const ADAPTERS: Record<ApiStyle, ImageProviderAdapter> = {
   gemini: geminiAdapter,
   dashscope: dashscopeAdapter,
   openrouter: openrouterAdapter,
+  ark: arkAdapter,
 };
 
 export function getAdapter(api: ApiStyle): ImageProviderAdapter {

--- a/packages/pi-image-gen/src/types.ts
+++ b/packages/pi-image-gen/src/types.ts
@@ -1,4 +1,4 @@
-export type ApiStyle = 'openai' | 'gemini' | 'dashscope' | 'openrouter';
+export type ApiStyle = 'openai' | 'gemini' | 'dashscope' | 'openrouter' | 'ark';
 
 /** Built-in provider id. Currently 1:1 with ApiStyle. */
 export type BuiltInProviderId = ApiStyle;


### PR DESCRIPTION
## Summary

- New built-in provider \`ark\` (Volcengine) routes the ByteDance Seedream family through the OpenAI-shaped \`/api/v3/images/generations\` endpoint
- Reference images for image-to-image are inlined as data URIs in the same JSON body — Seedream does **not** use OpenAI's multipart \`/images/edits\` route, so we reuse \`parseImagesResponse\` but build our own request body
- Built-in models: \`doubao-seedream-5-0-260128\` (alias \`seedream-5\`, \`seedream\`), \`doubao-seedream-5-0-lite-260128\` (alias \`seedream-5-lite\`), \`doubao-seedream-4-5-251128\` (alias \`seedream-4-5\`), \`doubao-seedream-4-0-250828\` (alias \`seedream-4\`)
- Env var: \`ARK_API_KEY\`. Default base URL \`https://ark.cn-beijing.volces.com/api/v3\` (overridable per provider)

## Why not just configure it as a customProvider?

Seedream's image API differs from OpenAI in exactly one place — reference images go into the JSON body as \`image: [data-uri, ...]\` instead of multipart form data. A custom provider with \`api: "openai"\` would correctly do text-to-image but break the moment a user passed \`image\` to \`image_generate\`. A built-in entry gives users a one-line config (\`defaultModel: "seedream"\` + \`ARK_API_KEY\`) and handles both paths correctly.

## README note

Added a callout that Ark rejects \`size\` below ~3.7 megapixels — \`1024x1024\` fails with \`InvalidParameter\`. Use \`2048x2048\`. Other built-in providers default to \`1024x1024\`, so this is the one knob users have to remember.

## Test plan

- [x] Unit: \`packages/pi-image-gen/src/__tests__/ark.test.ts\` covers alias routing (5.0 / 4.0), text-to-image body shape, image-to-image \`image: [data-uri]\` array, and the missing-key error path
- [x] \`pnpm pr-check\` (lint + typecheck + 1010 tests + build) green
- [x] E2E with a real \`ARK_API_KEY\`: text-to-image at 2048×2048 against \`doubao-seedream-5-0-260128\` round-trips through \`generateImage()\` and writes the resulting JPEG to disk