### PR TITLE
feat(pi-image-gen): add Nano Banana 2 Lite; prune noisy aliases

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -6,9 +6,9 @@ Pi extension that adds an `image_generate` tool. Supported providers:
 
 | Provider                       | Model id (alias)                              | Env var               |
 | ------------------------------ | --------------------------------------------- | --------------------- |
-| OpenAI                         | `gpt-image-2` (alias `gpt-image`)               | `OPENAI_API_KEY`      |
-| Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3.1-flash-image` (alias `nano-banana-2`), `gemini-2.5-flash-image` (alias `nano-banana`) | `GEMINI_API_KEY` |
-| Alibaba DashScope (Qwen-Image) | `qwen-image-2.0-pro` (alias `qwen-image-pro`), `qwen-image-2.0` (alias `qwen-image-2`, `qwen-image`) | `DASHSCOPE_API_KEY` |
+| OpenAI                         | `gpt-image-2`                                 | `OPENAI_API_KEY`      |
+| Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3.1-flash-image` (alias `nano-banana-2`), `gemini-3.1-flash-lite-image` (alias `nano-banana-2-lite`), `gemini-2.5-flash-image` (alias `nano-banana`) | `GEMINI_API_KEY` |
+| Alibaba DashScope (Qwen-Image) | `qwen-image-2.0-pro`, `qwen-image-2.0`          | `DASHSCOPE_API_KEY`   |
 | Volcengine Ark (ByteDance Seedream) | `doubao-seedream-5-0-260128` (alias `seedream-5`, `seedream`), `doubao-seedream-5-0-lite-260128` (alias `seedream-5-lite`), `doubao-seedream-4-5-251128` (alias `seedream-4-5`), `doubao-seedream-4-0-250828` (alias `seedream-4`) | `ARK_API_KEY`         |
 | OpenRouter                     | any (use `openrouter/<vendor>/<id>`)          | `OPENROUTER_API_KEY`  |
 | Custom providers               | whatever you declare in settings              | (your choice, via `$VAR`) |
@@ -130,7 +130,7 @@ export DASHSCOPE_API_KEY=...
 ```
 
 ```json
-{ "pi-image-gen": { "defaultModel": "qwen-image-2" } }
+{ "pi-image-gen": { "defaultModel": "qwen-image-2.0" } }
 ```
 
 For the international DashScope endpoint, override the base URL:
@@ -138,7 +138,7 @@ For the international DashScope endpoint, override the base URL:
 ```json
 {
   "pi-image-gen": {
-    "defaultModel": "qwen-image-2",
+    "defaultModel": "qwen-image-2.0",
     "providers": {
       "dashscope": { "baseUrl": "https://dashscope-intl.aliyuncs.com/api/v1" }
     }
@@ -335,7 +335,7 @@ Provider behavior:
 | Provider | Image input route |
 |---|---|
 | OpenAI (`gpt-image-2`) | `POST /v1/images/edits` (multipart). Supports multi-image. |
-| Gemini (`gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-2.5-flash-image`) | `inline_data` parts prepended to the user message. Supports multi-image. |
+| Gemini (`gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, `gemini-2.5-flash-image`) | `inline_data` parts prepended to the user message. Supports multi-image. |
 | DashScope (`qwen-image-2.0`, `qwen-image-2.0-pro`) | `image` parts in `messages[].content`. |
 | OpenRouter | `POST /api/v1/images` with `input_references` JSON. Supports multi-image. |
 

--- a/packages/pi-image-gen/src/__tests__/config.test.ts
+++ b/packages/pi-image-gen/src/__tests__/config.test.ts
@@ -13,18 +13,18 @@ describe('resolveModel', () => {
     expect(result.provider.apiKey).toBe('gem-test');
   });
 
-  it('routes gpt-image alias to openai gpt-image-2', () => {
+  it('routes gpt-image-2 to openai', () => {
     process.env.OPENAI_API_KEY = 'oa-test';
-    const result = resolveModel('gpt-image', {});
+    const result = resolveModel('gpt-image-2', {});
     if ('error' in result) throw new Error(result.error);
     expect(result.provider.id).toBe('openai');
     expect(result.remoteId).toBe('gpt-image-2');
-    expect(result.requestedId).toBe('gpt-image');
+    expect(result.requestedId).toBe('gpt-image-2');
   });
 
-  it('routes qwen-image-2 alias to dashscope', () => {
+  it('routes qwen-image-2.0 to dashscope', () => {
     process.env.DASHSCOPE_API_KEY = 'ds-test';
-    const result = resolveModel('qwen-image-2', {});
+    const result = resolveModel('qwen-image-2.0', {});
     if ('error' in result) throw new Error(result.error);
     expect(result.provider.id).toBe('dashscope');
     expect(result.remoteId).toBe('qwen-image-2.0');

--- a/packages/pi-image-gen/src/models.ts
+++ b/packages/pi-image-gen/src/models.ts
@@ -16,16 +16,16 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
   // OpenAI image generation.
   {
     id: 'gpt-image-2',
-    aliases: ['gpt-image'],
     provider: 'openai',
     remoteId: 'gpt-image-2',
   },
 
   // Google Gemini "Nano Banana" image generation.
   // Per https://ai.google.dev/gemini-api/docs/image-generation:
-  //   Nano Banana Pro → gemini-3-pro-image
-  //   Nano Banana 2   → gemini-3.1-flash-image
-  //   Nano Banana     → gemini-2.5-flash-image
+  //   Nano Banana Pro      → gemini-3-pro-image
+  //   Nano Banana 2        → gemini-3.1-flash-image
+  //   Nano Banana 2 Lite   → gemini-3.1-flash-lite-image
+  //   Nano Banana          → gemini-2.5-flash-image
   {
     id: 'gemini-3-pro-image',
     aliases: ['nano-banana-pro'],
@@ -39,23 +39,26 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
     remoteId: 'gemini-3.1-flash-image',
   },
   {
+    id: 'gemini-3.1-flash-lite-image',
+    aliases: ['nano-banana-2-lite'],
+    provider: 'gemini',
+    remoteId: 'gemini-3.1-flash-lite-image',
+  },
+  {
     id: 'gemini-2.5-flash-image',
     aliases: ['nano-banana'],
     provider: 'gemini',
     remoteId: 'gemini-2.5-flash-image',
   },
 
-  // Alibaba Qwen-Image / WanX series via DashScope. The `qwen-image-2` and
-  // `qwen-image` aliases point at the most recent stable Qwen image release.
+  // Alibaba Qwen-Image / WanX series via DashScope.
   {
     id: 'qwen-image-2.0-pro',
-    aliases: ['qwen-image-pro'],
     provider: 'dashscope',
     remoteId: 'qwen-image-2.0-pro',
   },
   {
     id: 'qwen-image-2.0',
-    aliases: ['qwen-image-2', 'qwen-image'],
     provider: 'dashscope',
     remoteId: 'qwen-image-2.0',
   },


### PR DESCRIPTION
## Summary
- Register `gemini-3.1-flash-lite-image` (alias `nano-banana-2-lite`) — Google's just-announced fastest/cheapest Gemini image model. Same `geminiAdapter` handles it; only new model entry needed. [Ref](https://ai.google.dev/gemini-api/docs/image-generation)
- Prune aliases that added no real value:
  - `gpt-image` → `gpt-image-2` (only "-2" shorter; ambiguous once gpt-image-3 ships)
  - `qwen-image-pro` → `qwen-image-2.0-pro` (marginal)
  - `qwen-image-2`, `qwen-image` → `qwen-image-2.0` (silent "moving pointer" — points at whatever qwen release is current, users would think they'd locked a version)
- Keep `nano-banana*` and `seedream*`: they replace opaque official ids (dated suffixes like `-260128`, long marketing strings) with names users actually type.
- README + tests updated to match.

## Test plan
- [x] `pnpm build` in `packages/pi-image-gen` passes
- [x] `pnpm vitest run` — 62/62 pass
- [ ] Reviewer: sanity-check that `image_generate` with `"defaultModel": "nano-banana-2-lite"` actually resolves and hits the new endpoint (I don't have API access to verify live)