### PR TITLE
fix(pi-teamwork): prefer AMaster agent-run auth

### DIFF
--- a/packages/pi-teamwork/src/__tests__/index.test.ts
+++ b/packages/pi-teamwork/src/__tests__/index.test.ts
@@ -626,6 +626,11 @@ describe('piTeamworkExtension AMaster provider', () => {
       hasApiKey: boolean;
       keyIsSession: boolean;
       keyIsConfigured: boolean;
+      hasPaperclipApiKey: boolean;
+      paperclipKeyIsAgentRun: boolean;
+      boardKeyIsEmpty: boolean;
+      paperclipApiBase: string | undefined;
+      paperclipCompanyId: string | undefined;
     }>;
   }> {
     const { chmod, mkdtemp, readFile, rm, writeFile } = await import('node:fs/promises');
@@ -645,6 +650,11 @@ describe('piTeamworkExtension AMaster provider', () => {
       '  hasApiKey: Boolean(process.env.AMASTER_BOARD_API_KEY),',
       "  keyIsSession: process.env.AMASTER_BOARD_API_KEY === 'session-key',",
       "  keyIsConfigured: process.env.AMASTER_BOARD_API_KEY === 'configured-key',",
+      '  hasPaperclipApiKey: Boolean(process.env.PAPERCLIP_API_KEY),',
+      "  paperclipKeyIsAgentRun: process.env.PAPERCLIP_API_KEY === 'agent-run-jwt',",
+      "  boardKeyIsEmpty: process.env.AMASTER_BOARD_API_KEY === '',",
+      '  paperclipApiBase: process.env.PAPERCLIP_API_URL,',
+      '  paperclipCompanyId: process.env.PAPERCLIP_COMPANY_ID,',
       "}) + '\\n');",
       "if (command === 'amaster-runtime') console.log('running');",
       "else if (args[0] === 'status') console.log(JSON.stringify({ ok: true }));",
@@ -674,6 +684,11 @@ describe('piTeamworkExtension AMaster provider', () => {
               hasApiKey: boolean;
               keyIsSession: boolean;
               keyIsConfigured: boolean;
+              hasPaperclipApiKey: boolean;
+              paperclipKeyIsAgentRun: boolean;
+              boardKeyIsEmpty: boolean;
+              paperclipApiBase: string | undefined;
+              paperclipCompanyId: string | undefined;
             },
         );
       return { result, calls };
@@ -865,14 +880,127 @@ describe('piTeamworkExtension AMaster provider', () => {
         keyIsConfigured: false,
       }),
     ]);
-    expect(JSON.stringify(calls)).not.toContain('session-key');
-    expect(JSON.stringify(calls)).not.toContain('configured-key');
+    expect(calls.some((call) => call.keyIsConfigured)).toBe(false);
 
     if (previousSettings === undefined) delete process.env.PI_SETTINGS_DIR;
     else process.env.PI_SETTINGS_DIR = previousSettings;
     await import('node:fs/promises').then(({ rm }) =>
       rm(settingsDir, { recursive: true, force: true }),
     );
+  });
+
+  it('prefers agent-run task-tools auth over board auth and config', async () => {
+    const previousSettings = process.env.PI_SETTINGS_DIR;
+    const previousPaperclipApiKey = process.env.PAPERCLIP_API_KEY;
+    const previousPaperclipApiUrl = process.env.PAPERCLIP_API_URL;
+    const previousPaperclipCompanyId = process.env.PAPERCLIP_COMPANY_ID;
+    const previousPaperclipRunId = process.env.PAPERCLIP_RUN_ID;
+    const settingsDir = await createSettingsDir({
+      'pi-teamwork': {
+        provider: 'amaster',
+        amaster: {
+          apiBase: 'http://configured-amaster.test',
+          apiKey: 'configured-key',
+          companyId: 'configured-company',
+        },
+      },
+    });
+    process.env.PI_SETTINGS_DIR = settingsDir;
+    process.env.PAPERCLIP_API_KEY = 'agent-run-jwt';
+    process.env.PAPERCLIP_API_URL = 'http://agent-run-amaster.test';
+    process.env.PAPERCLIP_COMPANY_ID = 'agent-run-company';
+    process.env.PAPERCLIP_RUN_ID = 'run-123';
+    try {
+      const tools = new Map<string, RegisteredTool>();
+      const pi = {
+        on: vi.fn(),
+        registerCommand: vi.fn(),
+        registerTool: vi.fn((tool: RegisteredTool) => tools.set(tool.name, tool)),
+        exec: vi.fn(async () => ({ stdout: '[]', stderr: '', code: 0 })),
+      };
+      piTeamworkExtension(pi as never);
+      const sessionStartHandler = pi.on.mock.calls.find((call) => call[0] === 'session_start')?.[1];
+
+      await sessionStartHandler(
+        {
+          amasterEmployee: {
+            apiKey: 'session-key',
+            apiBase: 'http://session.test',
+            companyId: 'session-company',
+          },
+        },
+        {
+          cwd: settingsDir,
+          ui: {
+            setStatus: vi.fn(),
+            notify: vi.fn(),
+          },
+        },
+      );
+
+      const { calls } = await withFakeAmasterCli(async () => {
+        await tools.get('teamwork_status')!.execute('tool-1' as never, {} as never);
+        await tools.get('issue_list')!.execute('tool-2' as never, {} as never);
+      });
+
+      expect(pi.exec).toHaveBeenCalledWith('amaster-runtime', ['daemon', 'status'], {
+        cwd: settingsDir,
+      });
+      const employeeCalls = calls.filter((call) => call.command === 'amaster-employee');
+      expect(employeeCalls).toEqual([
+        expect.objectContaining({
+          args: [
+            'status',
+            '--api-base',
+            'http://agent-run-amaster.test',
+            '-C',
+            'agent-run-company',
+            '--json',
+          ],
+          hasApiKey: false,
+          keyIsSession: false,
+          keyIsConfigured: false,
+          hasPaperclipApiKey: true,
+          paperclipKeyIsAgentRun: true,
+          boardKeyIsEmpty: true,
+          paperclipApiBase: 'http://agent-run-amaster.test',
+          paperclipCompanyId: 'agent-run-company',
+        }),
+        expect.objectContaining({
+          args: [
+            'issue',
+            'list',
+            '--api-base',
+            'http://agent-run-amaster.test',
+            '-C',
+            'agent-run-company',
+            '--json',
+          ],
+          hasApiKey: false,
+          keyIsSession: false,
+          keyIsConfigured: false,
+          hasPaperclipApiKey: true,
+          paperclipKeyIsAgentRun: true,
+          boardKeyIsEmpty: true,
+        }),
+      ]);
+      expect(JSON.stringify(calls)).not.toContain('agent-run-jwt');
+      expect(JSON.stringify(calls)).not.toContain('configured-key');
+    } finally {
+      if (previousSettings === undefined) delete process.env.PI_SETTINGS_DIR;
+      else process.env.PI_SETTINGS_DIR = previousSettings;
+      if (previousPaperclipApiKey === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previousPaperclipApiKey;
+      if (previousPaperclipApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
+      else process.env.PAPERCLIP_API_URL = previousPaperclipApiUrl;
+      if (previousPaperclipCompanyId === undefined) delete process.env.PAPERCLIP_COMPANY_ID;
+      else process.env.PAPERCLIP_COMPANY_ID = previousPaperclipCompanyId;
+      if (previousPaperclipRunId === undefined) delete process.env.PAPERCLIP_RUN_ID;
+      else process.env.PAPERCLIP_RUN_ID = previousPaperclipRunId;
+      await import('node:fs/promises').then(({ rm }) =>
+        rm(settingsDir, { recursive: true, force: true }),
+      );
+    }
   });
 
   it('uses pi.exec with the session cwd when no AMaster api key is configured', async () => {

--- a/packages/pi-teamwork/src/__tests__/index.test.ts
+++ b/packages/pi-teamwork/src/__tests__/index.test.ts
@@ -112,6 +112,43 @@ describe('AmasterAdapter', () => {
     await expect(issuePromise).resolves.toMatchObject({ id: 'ISS-1' });
   });
 
+  it('uses configured AMaster auth env instead of reading process env in the adapter', async () => {
+    const previousPaperclipApiKey = process.env.PAPERCLIP_API_KEY;
+    process.env.PAPERCLIP_API_KEY = 'agent-run-jwt';
+    try {
+      const calls: Array<{
+        env: Record<string, string> | undefined;
+      }> = [];
+      const adapter = new AmasterAdapter(
+        {
+          apiKey: 'session-key',
+          authMode: 'board',
+          authEnv: { AMASTER_BOARD_API_KEY: 'session-key', PAPERCLIP_API_KEY: '' },
+          companyId: 'company-1',
+        },
+        async (_cmd, _args, options) => {
+          calls.push({ env: options?.env });
+          return {
+            stdout: JSON.stringify({ issue: { id: 'ISS-1', title: 'Issue', status: 'todo' } }),
+            stderr: '',
+            code: 0,
+          };
+        },
+      );
+
+      await expect(adapter.getIssue('ISS-1')).resolves.toMatchObject({ id: 'ISS-1' });
+
+      expect(calls).toEqual([
+        {
+          env: { AMASTER_BOARD_API_KEY: 'session-key', PAPERCLIP_API_KEY: '' },
+        },
+      ]);
+    } finally {
+      if (previousPaperclipApiKey === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previousPaperclipApiKey;
+    }
+  });
+
   it('passes workspace IDs through to AMaster company-aware CLI commands', async () => {
     const calls: string[][] = [];
     const exec: ExecFn = async (_cmd, args) => {
@@ -880,7 +917,8 @@ describe('piTeamworkExtension AMaster provider', () => {
         keyIsConfigured: false,
       }),
     ]);
-    expect(calls.some((call) => call.keyIsConfigured)).toBe(false);
+    expect(JSON.stringify(calls)).not.toContain('session-key');
+    expect(JSON.stringify(calls)).not.toContain('configured-key');
 
     if (previousSettings === undefined) delete process.env.PI_SETTINGS_DIR;
     else process.env.PI_SETTINGS_DIR = previousSettings;
@@ -985,6 +1023,100 @@ describe('piTeamworkExtension AMaster provider', () => {
         }),
       ]);
       expect(JSON.stringify(calls)).not.toContain('agent-run-jwt');
+      expect(JSON.stringify(calls)).not.toContain('session-key');
+      expect(JSON.stringify(calls)).not.toContain('configured-key');
+    } finally {
+      if (previousSettings === undefined) delete process.env.PI_SETTINGS_DIR;
+      else process.env.PI_SETTINGS_DIR = previousSettings;
+      if (previousPaperclipApiKey === undefined) delete process.env.PAPERCLIP_API_KEY;
+      else process.env.PAPERCLIP_API_KEY = previousPaperclipApiKey;
+      if (previousPaperclipApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
+      else process.env.PAPERCLIP_API_URL = previousPaperclipApiUrl;
+      if (previousPaperclipCompanyId === undefined) delete process.env.PAPERCLIP_COMPANY_ID;
+      else process.env.PAPERCLIP_COMPANY_ID = previousPaperclipCompanyId;
+      if (previousPaperclipRunId === undefined) delete process.env.PAPERCLIP_RUN_ID;
+      else process.env.PAPERCLIP_RUN_ID = previousPaperclipRunId;
+      await import('node:fs/promises').then(({ rm }) =>
+        rm(settingsDir, { recursive: true, force: true }),
+      );
+    }
+  });
+
+  it('does not re-read PAPERCLIP auth env after AMaster provider initialization', async () => {
+    const previousSettings = process.env.PI_SETTINGS_DIR;
+    const previousPaperclipApiKey = process.env.PAPERCLIP_API_KEY;
+    const previousPaperclipApiUrl = process.env.PAPERCLIP_API_URL;
+    const previousPaperclipCompanyId = process.env.PAPERCLIP_COMPANY_ID;
+    const previousPaperclipRunId = process.env.PAPERCLIP_RUN_ID;
+    const settingsDir = await createSettingsDir({
+      'pi-teamwork': {
+        provider: 'amaster',
+        amaster: {
+          apiBase: 'http://configured-amaster.test',
+          apiKey: 'configured-key',
+          companyId: 'configured-company',
+        },
+      },
+    });
+    process.env.PI_SETTINGS_DIR = settingsDir;
+    delete process.env.PAPERCLIP_API_KEY;
+    delete process.env.PAPERCLIP_API_URL;
+    delete process.env.PAPERCLIP_COMPANY_ID;
+    delete process.env.PAPERCLIP_RUN_ID;
+    try {
+      const tools = new Map<string, RegisteredTool>();
+      const pi = {
+        on: vi.fn(),
+        registerCommand: vi.fn(),
+        registerTool: vi.fn((tool: RegisteredTool) => tools.set(tool.name, tool)),
+        exec: vi.fn(async () => ({ stdout: '[]', stderr: '', code: 0 })),
+      };
+      piTeamworkExtension(pi as never);
+      const sessionStartHandler = pi.on.mock.calls.find((call) => call[0] === 'session_start')?.[1];
+
+      await sessionStartHandler(
+        { amasterEmployee: { apiKey: 'session-key' } },
+        {
+          cwd: settingsDir,
+          ui: {
+            setStatus: vi.fn(),
+            notify: vi.fn(),
+          },
+        },
+      );
+
+      process.env.PAPERCLIP_API_KEY = 'agent-run-jwt';
+      process.env.PAPERCLIP_API_URL = 'http://agent-run-amaster.test';
+      process.env.PAPERCLIP_COMPANY_ID = 'agent-run-company';
+      process.env.PAPERCLIP_RUN_ID = 'run-123';
+
+      const { calls } = await withFakeAmasterCli(async () => {
+        await tools
+          .get('user_directory_list')!
+          .execute('tool-1' as never, { workspaceId: 'company-2' } as never);
+      });
+
+      expect(calls).toEqual([
+        expect.objectContaining({
+          command: 'amaster-employee',
+          args: [
+            'user-directory',
+            'list',
+            '--api-base',
+            'http://configured-amaster.test',
+            '-C',
+            'company-2',
+            '--json',
+          ],
+          hasApiKey: true,
+          keyIsSession: true,
+          keyIsConfigured: false,
+          hasPaperclipApiKey: false,
+          boardKeyIsEmpty: false,
+        }),
+      ]);
+      expect(JSON.stringify(calls)).not.toContain('agent-run-jwt');
+      expect(JSON.stringify(calls)).not.toContain('session-key');
       expect(JSON.stringify(calls)).not.toContain('configured-key');
     } finally {
       if (previousSettings === undefined) delete process.env.PI_SETTINGS_DIR;

--- a/packages/pi-teamwork/src/adapters/amaster.ts
+++ b/packages/pi-teamwork/src/adapters/amaster.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types.js';
 
 type ExecResult = Awaited<ReturnType<ExecFn>>;
+type AuthMode = NonNullable<AmasterAdapterConfig['authMode']>;
 
 export async function initAmasterProvider(
   config: AmasterAdapterConfig,
@@ -27,6 +28,8 @@ export class AmasterAdapter implements TeamworkProvider {
   private readonly binary = 'amaster-employee';
   private readonly runtimeBinary = 'amaster-runtime';
   private readonly apiKey?: string;
+  private readonly authMode: AuthMode;
+  private readonly authEnv: Record<string, string> | undefined;
   private readonly commonArgs: string[];
   private readonly defaultCompanyId?: string;
   private discoveredCompanyId: string | undefined;
@@ -38,6 +41,8 @@ export class AmasterAdapter implements TeamworkProvider {
   ) {
     const apiKey = config.apiKey?.trim();
     if (apiKey) this.apiKey = apiKey;
+    this.authMode = config.authMode ?? (this.apiKey ? 'board' : 'none');
+    this.authEnv = normalizeAuthEnv(config.authEnv);
     this.commonArgs = [];
     if (config.apiBase?.trim()) this.commonArgs.push('--api-base', config.apiBase.trim());
     if (config.context?.trim()) this.commonArgs.push('--context', config.context.trim());
@@ -207,11 +212,7 @@ export class AmasterAdapter implements TeamworkProvider {
       ok: teamwork.code === 0,
       runtimeOk: runtime.code === 0,
       authenticated: teamwork.code === 0,
-      authMode: execOptions?.env?.AMASTER_BOARD_API_KEY
-        ? 'board'
-        : execOptions?.env?.PAPERCLIP_API_KEY
-          ? 'agent_run'
-          : 'none',
+      authMode: this.authMode,
       localRuntimeAttached: runtime.code === 0 && /running|ready|attached/i.test(runtime.stdout),
       ...(teamwork.code !== 0 ? { error: classifyAmasterFailure('employee', teamwork) } : {}),
       ...(runtime.code !== 0 ? { runtimeError: classifyAmasterFailure('runtime', runtime) } : {}),
@@ -288,24 +289,7 @@ export class AmasterAdapter implements TeamworkProvider {
   }
 
   private amasterExecOptions(): ExecOptions | undefined {
-    const paperclipApiKey = process.env.PAPERCLIP_API_KEY?.trim();
-    if (paperclipApiKey) {
-      return {
-        env: {
-          PAPERCLIP_API_KEY: paperclipApiKey,
-          AMASTER_BOARD_API_KEY: '',
-          ...(process.env.PAPERCLIP_RUN_ID?.trim()
-            ? { PAPERCLIP_RUN_ID: process.env.PAPERCLIP_RUN_ID.trim() }
-            : {}),
-          ...(process.env.PAPERCLIP_API_URL?.trim()
-            ? { PAPERCLIP_API_URL: process.env.PAPERCLIP_API_URL.trim() }
-            : {}),
-          ...(process.env.PAPERCLIP_COMPANY_ID?.trim()
-            ? { PAPERCLIP_COMPANY_ID: process.env.PAPERCLIP_COMPANY_ID.trim() }
-            : {}),
-        },
-      };
-    }
+    if (this.authEnv && Object.keys(this.authEnv).length > 0) return { env: this.authEnv };
     if (this.apiKey) return { env: { AMASTER_BOARD_API_KEY: this.apiKey } };
     return undefined;
   }
@@ -321,6 +305,22 @@ export class AmasterAdapter implements TeamworkProvider {
     this.discoveredCompanyId = undefined;
     this.workspaceDiscoveryPromise = undefined;
   }
+}
+
+function normalizeAuthEnv(
+  env: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!env) return undefined;
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === '') {
+      normalized[key] = value;
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) normalized[key] = trimmed;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
 }
 
 function parseJson(text: string): unknown {

--- a/packages/pi-teamwork/src/adapters/amaster.ts
+++ b/packages/pi-teamwork/src/adapters/amaster.ts
@@ -2,6 +2,7 @@ import type {
   AmasterAdapterConfig,
   Comment,
   ExecFn,
+  ExecOptions,
   Issue,
   IssueCreateInput,
   IssueListFilter,
@@ -25,6 +26,7 @@ export class AmasterAdapter implements TeamworkProvider {
   readonly name = 'amaster';
   private readonly binary = 'amaster-employee';
   private readonly runtimeBinary = 'amaster-runtime';
+  private readonly apiKey?: string;
   private readonly commonArgs: string[];
   private readonly defaultCompanyId?: string;
   private discoveredCompanyId: string | undefined;
@@ -34,6 +36,8 @@ export class AmasterAdapter implements TeamworkProvider {
     config: AmasterAdapterConfig,
     private readonly exec: ExecFn,
   ) {
+    const apiKey = config.apiKey?.trim();
+    if (apiKey) this.apiKey = apiKey;
     this.commonArgs = [];
     if (config.apiBase?.trim()) this.commonArgs.push('--api-base', config.apiBase.trim());
     if (config.context?.trim()) this.commonArgs.push('--context', config.context.trim());
@@ -191,8 +195,9 @@ export class AmasterAdapter implements TeamworkProvider {
   }
 
   async status(): Promise<Record<string, unknown>> {
+    const execOptions = this.amasterExecOptions();
     const [teamwork, runtime] = await Promise.all([
-      this.runOptional(this.binary, withJson(this.buildArgsSync(['status']))),
+      this.runOptional(this.binary, withJson(this.buildArgsSync(['status'])), execOptions),
       this.runOptional(this.runtimeBinary, ['daemon', 'status']),
     ]);
     return {
@@ -202,6 +207,11 @@ export class AmasterAdapter implements TeamworkProvider {
       ok: teamwork.code === 0,
       runtimeOk: runtime.code === 0,
       authenticated: teamwork.code === 0,
+      authMode: execOptions?.env?.AMASTER_BOARD_API_KEY
+        ? 'board'
+        : execOptions?.env?.PAPERCLIP_API_KEY
+          ? 'agent_run'
+          : 'none',
       localRuntimeAttached: runtime.code === 0 && /running|ready|attached/i.test(runtime.stdout),
       ...(teamwork.code !== 0 ? { error: classifyAmasterFailure('employee', teamwork) } : {}),
       ...(runtime.code !== 0 ? { runtimeError: classifyAmasterFailure('runtime', runtime) } : {}),
@@ -209,16 +219,20 @@ export class AmasterAdapter implements TeamworkProvider {
   }
 
   private async runAmaster(args: string[]): Promise<string> {
-    const result = await this.exec(this.binary, args);
+    const result = await this.exec(this.binary, args, this.amasterExecOptions());
     if (result.code !== 0) {
       throw new Error(`amaster ${args[0]} failed: ${classifyAmasterFailure('employee', result)}`);
     }
     return result.stdout;
   }
 
-  private async runOptional(command: string, args: string[]): Promise<ExecResult> {
+  private async runOptional(
+    command: string,
+    args: string[],
+    options?: ExecOptions,
+  ): Promise<ExecResult> {
     try {
-      return await this.exec(command, args);
+      return await this.exec(command, args, options);
     } catch (error) {
       return {
         stdout: '',
@@ -271,6 +285,29 @@ export class AmasterAdapter implements TeamworkProvider {
     throw new Error(
       'Multiple AMaster workspaces are available; pass workspaceId from workspace_list.',
     );
+  }
+
+  private amasterExecOptions(): ExecOptions | undefined {
+    const paperclipApiKey = process.env.PAPERCLIP_API_KEY?.trim();
+    if (paperclipApiKey) {
+      return {
+        env: {
+          PAPERCLIP_API_KEY: paperclipApiKey,
+          AMASTER_BOARD_API_KEY: '',
+          ...(process.env.PAPERCLIP_RUN_ID?.trim()
+            ? { PAPERCLIP_RUN_ID: process.env.PAPERCLIP_RUN_ID.trim() }
+            : {}),
+          ...(process.env.PAPERCLIP_API_URL?.trim()
+            ? { PAPERCLIP_API_URL: process.env.PAPERCLIP_API_URL.trim() }
+            : {}),
+          ...(process.env.PAPERCLIP_COMPANY_ID?.trim()
+            ? { PAPERCLIP_COMPANY_ID: process.env.PAPERCLIP_COMPANY_ID.trim() }
+            : {}),
+        },
+      };
+    }
+    if (this.apiKey) return { env: { AMASTER_BOARD_API_KEY: this.apiKey } };
+    return undefined;
   }
 
   private primeDefaultCompanyCache(workspaces: Workspace[]): void {

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -83,7 +83,10 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
       return;
     }
 
-    const exec: ExecFn = async (command, args) => {
+    const exec: ExecFn = async (command, args, options) => {
+      if (options?.env && Object.keys(options.env).length > 0) {
+        return execWithEnv(command, args, options.env, ctx.cwd);
+      }
       const result = await pi.exec(command, args, { cwd: ctx.cwd });
       return { stdout: result.stdout, stderr: result.stderr, code: result.code };
     };
@@ -91,29 +94,8 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     const providerName = config.provider ?? 'multica';
     if (providerName === 'amaster') {
       const amasterConfig: AmasterAdapterConfig = { ...(config.amaster ?? {}) };
-      const eventRecord =
-        _event && typeof _event === 'object' && !Array.isArray(_event)
-          ? (_event as unknown as { amasterEmployee?: unknown })
-          : undefined;
-      const amasterEmployee = eventRecord?.amasterEmployee;
-      const sessionApiKey =
-        amasterEmployee && typeof amasterEmployee === 'object' && !Array.isArray(amasterEmployee)
-          ? (amasterEmployee as Record<string, unknown>).apiKey
-          : undefined;
-      const apiKey =
-        typeof sessionApiKey === 'string' && sessionApiKey.trim()
-          ? sessionApiKey.trim()
-          : typeof amasterConfig.apiKey === 'string' && amasterConfig.apiKey.trim()
-            ? amasterConfig.apiKey.trim()
-            : undefined;
-      delete amasterConfig.apiKey;
-      const amasterExec: ExecFn = apiKey
-        ? (command, args) =>
-            command === 'amaster-employee'
-              ? execWithEnv(command, args, { AMASTER_BOARD_API_KEY: apiKey }, ctx.cwd)
-              : exec(command, args)
-        : exec;
-      const adapter = await initAmasterProvider(amasterConfig, amasterExec);
+      applyAmasterRuntimeAuth(amasterConfig, _event);
+      const adapter = await initAmasterProvider(amasterConfig, exec);
       if (generation !== sessionGeneration) return;
       provider = adapter;
       registerProviderTools(adapter);
@@ -557,6 +539,50 @@ function execWithEnv(
       finish({ stdout, stderr, code: code ?? 0 });
     });
   });
+}
+
+function applyAmasterRuntimeAuth(config: AmasterAdapterConfig, event: unknown): void {
+  const paperclipApiKey = process.env.PAPERCLIP_API_KEY?.trim();
+  if (paperclipApiKey) {
+    const paperclipApiBase = process.env.PAPERCLIP_API_URL?.trim();
+    if (paperclipApiBase) config.apiBase = paperclipApiBase;
+    const paperclipCompanyId = process.env.PAPERCLIP_COMPANY_ID?.trim();
+    if (paperclipCompanyId) config.companyId = paperclipCompanyId;
+    delete config.apiKey;
+    return;
+  }
+
+  const sessionAuth = amasterAuthFromSessionStart(event);
+  const apiKey = sessionAuth.apiKey ?? process.env.AMASTER_BOARD_API_KEY?.trim();
+  if (apiKey) config.apiKey = apiKey;
+  const apiBase = sessionAuth.apiBase ?? process.env.AMASTER_EMPLOYEE_API_BASE?.trim();
+  if (apiBase) config.apiBase = apiBase;
+  const companyId = sessionAuth.companyId ?? process.env.AMASTER_EMPLOYEE_COMPANY_ID?.trim();
+  if (companyId) config.companyId = companyId;
+}
+
+function amasterAuthFromSessionStart(event: unknown): {
+  apiKey?: string;
+  apiBase?: string;
+  companyId?: string;
+} {
+  if (!event || typeof event !== 'object' || Array.isArray(event)) return {};
+  const amasterEmployee = (event as Record<string, unknown>).amasterEmployee;
+  if (!amasterEmployee || typeof amasterEmployee !== 'object' || Array.isArray(amasterEmployee)) {
+    return {};
+  }
+  const record = amasterEmployee as Record<string, unknown>;
+  return {
+    ...optionalTrimmed('apiKey', record.apiKey),
+    ...optionalTrimmed('apiBase', record.apiBase),
+    ...optionalTrimmed('companyId', record.companyId),
+  };
+}
+
+function optionalTrimmed<K extends string>(key: K, value: unknown): Partial<Record<K, string>> {
+  if (typeof value !== 'string') return {};
+  const trimmed = value.trim();
+  return trimmed ? ({ [key]: trimmed } as Record<K, string>) : {};
 }
 
 function loadConfig(cwd: string): TeamworkConfig {

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -549,16 +549,46 @@ function applyAmasterRuntimeAuth(config: AmasterAdapterConfig, event: unknown): 
     const paperclipCompanyId = process.env.PAPERCLIP_COMPANY_ID?.trim();
     if (paperclipCompanyId) config.companyId = paperclipCompanyId;
     delete config.apiKey;
+    config.authMode = 'agent_run';
+    config.authEnv = {
+      PAPERCLIP_API_KEY: paperclipApiKey,
+      AMASTER_BOARD_API_KEY: '',
+      ...optionalEnvValue('PAPERCLIP_RUN_ID', process.env.PAPERCLIP_RUN_ID),
+      ...optionalEnvValue('PAPERCLIP_API_URL', process.env.PAPERCLIP_API_URL),
+      ...optionalEnvValue('PAPERCLIP_COMPANY_ID', process.env.PAPERCLIP_COMPANY_ID),
+    };
     return;
   }
 
   const sessionAuth = amasterAuthFromSessionStart(event);
-  const apiKey = sessionAuth.apiKey ?? process.env.AMASTER_BOARD_API_KEY?.trim();
-  if (apiKey) config.apiKey = apiKey;
+  const apiKey =
+    sessionAuth.apiKey ?? process.env.AMASTER_BOARD_API_KEY?.trim() ?? config.apiKey?.trim();
+  if (apiKey) {
+    config.apiKey = apiKey;
+    config.authMode = 'board';
+    config.authEnv = {
+      AMASTER_BOARD_API_KEY: apiKey,
+      PAPERCLIP_API_KEY: '',
+      PAPERCLIP_RUN_ID: '',
+      PAPERCLIP_API_URL: '',
+      PAPERCLIP_COMPANY_ID: '',
+    };
+  } else {
+    config.authMode = 'none';
+    delete config.authEnv;
+  }
   const apiBase = sessionAuth.apiBase ?? process.env.AMASTER_EMPLOYEE_API_BASE?.trim();
   if (apiBase) config.apiBase = apiBase;
   const companyId = sessionAuth.companyId ?? process.env.AMASTER_EMPLOYEE_COMPANY_ID?.trim();
   if (companyId) config.companyId = companyId;
+}
+
+function optionalEnvValue<K extends string>(
+  key: K,
+  value: string | undefined,
+): Partial<Record<K, string>> {
+  const trimmed = value?.trim();
+  return trimmed ? ({ [key]: trimmed } as Record<K, string>) : {};
 }
 
 function amasterAuthFromSessionStart(event: unknown): {

--- a/packages/pi-teamwork/src/types.ts
+++ b/packages/pi-teamwork/src/types.ts
@@ -104,6 +104,8 @@ export type ExecFn = (
   options?: ExecOptions,
 ) => Promise<{ stdout: string; stderr: string; code: number }>;
 
+export type AmasterAuthMode = 'agent_run' | 'board' | 'none';
+
 export type MulticaAdapterConfig = {
   binary?: string;
   workspace?: string;
@@ -120,6 +122,8 @@ export type AmasterAdapterConfig = {
   authStore?: string;
   companyId?: string;
   apiKey?: string;
+  authMode?: AmasterAuthMode;
+  authEnv?: Record<string, string>;
 };
 
 export type TeamworkConfig = {

--- a/packages/pi-teamwork/src/types.ts
+++ b/packages/pi-teamwork/src/types.ts
@@ -94,9 +94,14 @@ export interface TeamworkProvider {
   status(): Promise<Record<string, unknown>>;
 }
 
+export type ExecOptions = {
+  env?: Record<string, string>;
+};
+
 export type ExecFn = (
   command: string,
   args: string[],
+  options?: ExecOptions,
 ) => Promise<{ stdout: string; stderr: string; code: number }>;
 
 export type MulticaAdapterConfig = {


### PR DESCRIPTION
## Summary
- move the AMaster task-tools auth preference from the runtime patch into upstream @amaster.ai/pi-teamwork
- prefer PAPERCLIP_* agent-run auth over session/board/config auth for AMaster Employee CLI calls
- keep amaster-runtime status probes on plain pi.exec and add regression coverage for the auth precedence

## Validation
- pnpm --filter @amaster.ai/pi-teamwork test
- pnpm --filter @amaster.ai/pi-teamwork typecheck
- pnpm --filter @amaster.ai/pi-teamwork build
- pnpm exec biome check packages/pi-teamwork/src/index.ts packages/pi-teamwork/src/adapters/amaster.ts packages/pi-teamwork/src/types.ts packages/pi-teamwork/src/__tests__/index.test.ts
- pnpm typecheck
- pre-commit: pnpm lint && pnpm typecheck && pnpm test && pnpm build

## Notes
- Local Node is v22.22.3, so pnpm prints the repo's Node >=24 engine warning locally. Commands above completed with exit 0.
- tests/extension-loading.test.ts still has an unrelated local failure before full workspace build/install: pi-memory cannot resolve @amaster.ai/pi-memory-mem0/dedup and @amaster.ai/pi-storage/json. Full pnpm test passed during the commit hook after workspace artifacts were present.