### PR TITLE
feat(pi-memory-mem0): observedAt + LoCoMo eval harness

### DIFF
--- a/.github/workflows/memory-eval.yml
+++ b/.github/workflows/memory-eval.yml
@@ -1,0 +1,169 @@
+name: Memory Eval
+
+# Manual-only. Benchmarks pi-memory (curated write loop) and pi-memory-mem0
+# (passive extraction) against LoCoMo, then LLM-judges the result. Runs on the
+# self-hosted runner and talks to the custom provider behind
+# PI_INTEGRATION_BASE_URL / PI_INTEGRATION_API_KEY.
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: Which memory runner to evaluate
+        type: choice
+        default: mem0
+        options: [mem0, curated, both]
+      samples:
+        description: Number of LoCoMo samples (each is a long multi-session conversation)
+        type: string
+        default: '2'
+      topk:
+        description: mem0 retrieval top-k (ignored by curated)
+        type: string
+        default: '10'
+      extract_model:
+        description: Extraction / write-loop model (provider is deepseek-integration)
+        type: string
+        default: deepseek-v4-flash
+      judge_model:
+        description: LLM-judge model
+        type: string
+        default: deepseek-v4-pro
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  memory-eval:
+    name: Memory eval (LoCoMo)
+    runs-on:
+      - instance-hnpsq9go
+      - linux
+      - x64
+    timeout-minutes: 240
+    env:
+      PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
+      PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pi build environment
+        uses: ./.github/actions/setup-pi-build
+        with:
+          # mem0 OSS mode stores vectors in SQLite via better-sqlite3; the
+          # prebuilt binding must be present after a cache restore.
+          prebuild-better-sqlite3: 'true'
+          set-pi-agent-dir: 'true'
+
+      - name: Guard — require provider secrets
+        run: |
+          set -euo pipefail
+          if [ -z "${PI_INTEGRATION_BASE_URL}" ] || [ -z "${PI_INTEGRATION_API_KEY}" ]; then
+            echo "::error::PI_INTEGRATION_BASE_URL / PI_INTEGRATION_API_KEY not set — cannot run eval"
+            exit 1
+          fi
+
+      - name: Write eval models.json from secrets
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/eval"
+          # The runners resolve provider baseUrl+apiKey by name from this file
+          # (--provider deepseek-integration). apiKey is written literally from
+          # the secret; the file lives under RUNNER_TEMP and is not uploaded.
+          cat > "$RUNNER_TEMP/eval/models.json" <<EOF
+          {
+            "providers": {
+              "deepseek-integration": {
+                "baseUrl": "${PI_INTEGRATION_BASE_URL}",
+                "api": "openai-completions",
+                "apiKey": "${PI_INTEGRATION_API_KEY}"
+              }
+            }
+          }
+          EOF
+          echo "MODELS_PATH=$RUNNER_TEMP/eval/models.json" >> "$GITHUB_ENV"
+
+      - name: Fetch LoCoMo
+        run: pnpm --filter @amaster.ai/pi-eval fetch:locomo
+
+      - name: Build memory packages
+        run: |
+          set -euo pipefail
+          pnpm --filter @amaster.ai/pi-shared build
+          pnpm --filter @amaster.ai/pi-memory build
+          pnpm --filter @amaster.ai/pi-memory-mem0 build
+
+      - name: Eval — pi-memory-mem0
+        if: inputs.runner == 'mem0' || inputs.runner == 'both'
+        run: |
+          set -euo pipefail
+          pnpm --filter @amaster.ai/pi-eval eval:memory:mem0 -- \
+            --mode oss \
+            --samples "${{ inputs.samples }}" \
+            --topk "${{ inputs.topk }}" \
+            --concurrency 2 \
+            --llm-provider deepseek-integration \
+            --embed-provider deepseek-integration \
+            --llm-model "${{ inputs.extract_model }}" \
+            --models "$MODELS_PATH"
+          pnpm --filter @amaster.ai/pi-eval judge:llm -- \
+            --input results/mem0-locomo-oss.json \
+            --llm-provider deepseek-integration \
+            --llm-model "${{ inputs.judge_model }}" \
+            --concurrency 6 \
+            --models "$MODELS_PATH"
+
+      - name: Eval — pi-memory (curated write loop)
+        if: inputs.runner == 'curated' || inputs.runner == 'both'
+        run: |
+          set -euo pipefail
+          pnpm --filter @amaster.ai/pi-eval eval:memory:curated -- \
+            --samples "${{ inputs.samples }}" \
+            --concurrency 2 \
+            --provider deepseek-integration \
+            --model "${{ inputs.extract_model }}" \
+            --models "$MODELS_PATH"
+          pnpm --filter @amaster.ai/pi-eval judge:llm -- \
+            --input results/memory-locomo.json \
+            --llm-provider deepseek-integration \
+            --llm-model "${{ inputs.judge_model }}" \
+            --concurrency 6 \
+            --models "$MODELS_PATH"
+
+      - name: Summarize
+        if: always()
+        run: |
+          set -euo pipefail
+          dir=tests/eval/results
+          {
+            echo "## Memory eval results"
+            echo ""
+            echo "| File | judge recall | literal recall | n |"
+            echo "|------|-------------:|---------------:|--:|"
+            for f in "$dir"/*-judged.json "$dir"/mem0-locomo-oss.json "$dir"/memory-locomo.json; do
+              [ -f "$f" ] || continue
+              node -e '
+                const d = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+                const s = d.summary || {};
+                const jr = s.recallJudge != null ? s.recallJudge.toFixed(4) : "—";
+                const lr = s.recall != null ? s.recall.toFixed(4) : "—";
+                console.log(`| ${require("path").basename(process.argv[1])} | ${jr} | ${lr} | ${s.n ?? "—"} |`);
+              ' "$f"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: memory-eval-results
+          path: tests/eval/results/*.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/packages/pi-memory-mem0/README.md
+++ b/packages/pi-memory-mem0/README.md
@@ -29,6 +29,7 @@ User ←→ Agent ←→ Mem0 Memory (in-memory vector search)
 - **LLM extraction**: Configured provider extracts facts from conversations
 - **Persistence**: After each `add()`, all memories are asynchronously snapshotted to SQLite. On restart, memories are restored from the snapshot.
 - **Provider mapping**: Custom providers are automatically mapped to mem0-compatible providers (e.g. `openai`) via the pi model registry's `api` field.
+- **Observation date**: `add()` accepts an optional `observedAt` (Date or string). In OSS mode it grounds mem0's extraction prompt so relative time references ("yesterday", "last week") resolve against the conversation's date rather than the system clock — important when ingesting historical conversations. Omit it and mem0 falls back to the current date (correct for live turns).
 
 ## Quick Start
 

--- a/packages/pi-memory-mem0/src/__tests__/mem0.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/mem0.test.ts
@@ -4,7 +4,12 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Prefetch } from '../prefetch.js';
 import type { KeyResolver, Mem0Provider, ProviderResolver } from '../provider.js';
-import { mapApiToMem0Provider, SqliteSnapshotStore } from '../provider.js';
+import {
+  formatObservedAt,
+  mapApiToMem0Provider,
+  rewriteObservationDate,
+  SqliteSnapshotStore,
+} from '../provider.js';
 import { createMem0Tools } from '../tools.js';
 
 // ---------------------------------------------------------------------------
@@ -665,5 +670,55 @@ describe('createMem0Provider additional scenarios', () => {
 
     expect(__capturedMem0Config).toBeDefined();
     expect(__capturedMem0Config!.disableHistory).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// observedAt helpers
+// ---------------------------------------------------------------------------
+
+describe('formatObservedAt', () => {
+  it('formats a Date to YYYY-MM-DD', () => {
+    expect(formatObservedAt(new Date(Date.UTC(2023, 4, 8)))).toBe('2023-05-08');
+  });
+
+  it('formats an ISO string to YYYY-MM-DD', () => {
+    expect(formatObservedAt('2023-05-08T13:56:00Z')).toBe('2023-05-08');
+  });
+
+  it('returns the raw string for an unparseable value', () => {
+    expect(formatObservedAt('not a date')).toBe('not a date');
+  });
+});
+
+describe('rewriteObservationDate', () => {
+  const prompt = [
+    '## New Messages',
+    'Caroline: I went to a group yesterday.',
+    '',
+    '## Observation Date',
+    '2026-07-03',
+    '',
+    '## Current Date',
+    '2026-07-03',
+    '',
+    '# Output:',
+  ].join('\n');
+
+  it('rewrites both Observation Date and Current Date to the given date', () => {
+    const out = rewriteObservationDate(prompt, '2023-05-08');
+    expect(out).toContain('## Observation Date\n2023-05-08');
+    expect(out).toContain('## Current Date\n2023-05-08');
+    expect(out).not.toContain('2026-07-03');
+  });
+
+  it('leaves the message body untouched', () => {
+    const out = rewriteObservationDate(prompt, '2023-05-08');
+    expect(out).toContain('Caroline: I went to a group yesterday.');
+  });
+
+  it('is a no-op when the sections are absent', () => {
+    const plain = 'no date sections here';
+    expect(rewriteObservationDate(plain, '2023-05-08')).toBe(plain);
   });
 });

--- a/packages/pi-memory-mem0/src/provider.ts
+++ b/packages/pi-memory-mem0/src/provider.ts
@@ -23,7 +23,7 @@ import type { AddResult, Mem0ExtensionConfig, MemoryItem } from './types.js';
 export interface Mem0Provider {
   add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean },
+    opts: { userId: string; infer?: boolean; observedAt?: Date | string },
   ): Promise<AddResult | null>;
 
   search(query: string, opts: { userId: string; topK?: number }): Promise<MemoryItem[]>;
@@ -39,6 +39,31 @@ export interface Mem0Provider {
 // ---------------------------------------------------------------------------
 // Normalizers
 // ---------------------------------------------------------------------------
+
+/**
+ * Format an observedAt value as YYYY-MM-DD for mem0's Observation Date field.
+ * mem0's extraction prompt grounds relative times ("yesterday", "last week")
+ * to this date. When not supplied mem0 falls back to system now — wrong for
+ * ingesting historical conversations.
+ */
+export function formatObservedAt(v: Date | string): string {
+  const d = typeof v === 'string' ? new Date(v) : v;
+  if (Number.isNaN(d.getTime())) return String(v);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Rewrite the "## Observation Date" and "## Current Date" sections of mem0's
+ * extraction user-prompt to a fixed date. mem0 has no public parameter for
+ * this — its own prompt documents an Observation Date it never lets callers
+ * set — so OSSProvider.add intercepts the LLM call and runs the prompt through
+ * this before forwarding. Exported for unit testing.
+ */
+export function rewriteObservationDate(content: string, dateStr: string): string {
+  let c = content.replace(/## Observation Date\n[^\n]*/, `## Observation Date\n${dateStr}`);
+  c = c.replace(/## Current Date\n[^\n]*/, `## Current Date\n${dateStr}`);
+  return c;
+}
 
 function normalizeMemoryItem(raw: Record<string, unknown>): MemoryItem {
   return {
@@ -96,11 +121,18 @@ class PlatformProvider implements Mem0Provider {
 
   async add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean },
+    opts: { userId: string; infer?: boolean; observedAt?: Date | string },
   ): Promise<AddResult | null> {
     await this.ensureClient();
     const addOpts: Record<string, unknown> = { userId: opts.userId };
     if (opts.infer === false) addOpts.infer = false;
+    // Platform mem0 exposes a `timestamp` field on add(); pass observedAt
+    // through as an ISO string. (OSS mode honors observedAt via prompt
+    // rewriting instead — see OSSProvider.add.)
+    if (opts.observedAt) {
+      const d = new Date(opts.observedAt);
+      if (!Number.isNaN(d.getTime())) addOpts.timestamp = d.toISOString();
+    }
     // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
     const result = await (this.client as any).add(messages, addOpts);
     return result as AddResult;
@@ -265,6 +297,19 @@ class OSSProvider implements Mem0Provider {
   private initPromise: Promise<void> | null = null;
   private snapshot: SqliteSnapshotStore | null = null;
   private syncingSnapshot = false;
+  /**
+   * mem0's Memory instance shares one LLM object across all add() calls. To
+   * honor observedAt we temporarily wrap `llm.generateResponse` (see add), and
+   * that wrapper is global state on the instance — so concurrent add()s would
+   * stomp each other's date. This mutex serializes the wrap/call/restore
+   * window.
+   *
+   * ponytail: global mutex around the ~3-10s window that includes mem0's LLM
+   * call. Callers expecting true concurrency across users will see add()s
+   * serialize when observedAt is passed. Acceptable — the alternative is one
+   * Memory instance per userId (heavy init).
+   */
+  private addMutex: Promise<unknown> = Promise.resolve();
 
   constructor(
     private readonly ossConfig: Mem0ExtensionConfig['oss'] | undefined,
@@ -430,15 +475,56 @@ class OSSProvider implements Mem0Provider {
 
   async add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean },
+    opts: { userId: string; infer?: boolean; observedAt?: Date | string },
   ): Promise<AddResult | null> {
     await this.ensureMemory();
     const addOpts: Record<string, unknown> = { userId: opts.userId };
     if (opts.infer === false) addOpts.infer = false;
-    // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
-    const result = await (this.memory as any).add(messages, addOpts);
-    this.asyncSnapshotSync(opts.userId);
-    return result as AddResult;
+
+    // Serialize add() when observedAt is used. mem0 never exposes the
+    // observationDate parameter its own prompt documents — so we intercept
+    // `this.llm.generateResponse` and rewrite the "## Observation Date" line
+    // in the user prompt from today to the caller-supplied date. Parallel
+    // adds would stomp the wrapper, so we mutex.
+    const gate = this.addMutex;
+    let release: (v: unknown) => void = () => {};
+    this.addMutex = new Promise((res) => {
+      release = res;
+    });
+    try {
+      await gate;
+      // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
+      const mem = this.memory as any;
+      let restoreLlm: (() => void) | undefined;
+      if (opts.observedAt) {
+        const dateStr = formatObservedAt(opts.observedAt);
+        const llm = mem.llm;
+        const originalGenerate = llm.generateResponse.bind(llm);
+        llm.generateResponse = async (
+          msgs: Array<{ role: string; content: string }>,
+          ...rest: unknown[]
+        ) => {
+          const patched = msgs.map((m) =>
+            m.role === 'user' && typeof m.content === 'string'
+              ? { ...m, content: rewriteObservationDate(m.content, dateStr) }
+              : m,
+          );
+          return originalGenerate(patched, ...rest);
+        };
+        restoreLlm = () => {
+          llm.generateResponse = originalGenerate;
+        };
+      }
+      try {
+        const result = await mem.add(messages, addOpts);
+        this.asyncSnapshotSync(opts.userId);
+        return result as AddResult;
+      } finally {
+        restoreLlm?.();
+      }
+    } finally {
+      release(undefined);
+    }
   }
 
   async search(query: string, opts: { userId: string; topK?: number }): Promise<MemoryItem[]> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-attachments:
     dependencies:
@@ -38,7 +38,7 @@ importers:
         version: 0.74.0
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-browser-use:
     dependencies:
@@ -57,13 +57,13 @@ importers:
         version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typebox:
         specifier: '*'
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-channels:
     dependencies:
@@ -88,7 +88,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-computer-use:
     dependencies:
@@ -107,13 +107,13 @@ importers:
         version: 0.74.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       typebox:
         specifier: '*'
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-dingtalk:
     dependencies:
@@ -129,7 +129,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-image-gen:
     dependencies:
@@ -145,7 +145,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-lark:
     dependencies:
@@ -161,7 +161,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-memory:
     dependencies:
@@ -195,7 +195,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-memory-mem0:
     dependencies:
@@ -214,7 +214,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-security:
     dependencies:
@@ -227,7 +227,7 @@ importers:
         version: 0.74.0
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-task-scheduler:
     dependencies:
@@ -246,7 +246,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-teamwork:
     dependencies:
@@ -262,7 +262,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-telemetry:
     dependencies:
@@ -278,7 +278,7 @@ importers:
         version: 0.74.0
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-web-access:
     dependencies:
@@ -303,7 +303,7 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pi-wecom:
     dependencies:
@@ -319,13 +319,13 @@ importers:
         version: 1.1.38
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/shared:
     devDependencies:
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/storage:
     dependencies:
@@ -347,7 +347,20 @@ importers:
         version: 6.19.3(typescript@5.9.3)
       vitest:
         specifier: ^4.0.0
-        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
+  tests/eval:
+    dependencies:
+      '@amaster.ai/pi-memory':
+        specifier: workspace:*
+        version: link:../../packages/pi-memory
+      '@amaster.ai/pi-memory-mem0':
+        specifier: workspace:*
+        version: link:../../packages/pi-memory-mem0
+    devDependencies:
+      tsx:
+        specifier: ^4.20.0
+        version: 4.22.4
 
 packages:
 
@@ -624,8 +637,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -636,8 +661,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -648,8 +685,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -660,8 +709,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -672,8 +733,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -684,8 +757,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -696,8 +781,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -708,8 +805,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -720,8 +829,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -732,8 +853,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -744,8 +877,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -756,8 +901,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -768,8 +925,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1854,6 +2023,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3264,6 +3438,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -4110,79 +4289,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))':
@@ -4802,13 +5059,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -5267,6 +5532,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -6248,12 +6542,13 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.14
+      tsx: 4.22.4
       yaml: 2.9.0
 
   postcss@8.5.14:
@@ -6725,7 +7020,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.14)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -6736,7 +7031,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.4
       source-map: 0.7.6
@@ -6752,6 +7047,12 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -6797,7 +7098,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0):
+  vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -6809,12 +7110,28 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)):
+  vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.4
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  vitest@4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -6831,7 +7148,34 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.6(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "tests/eval"

--- a/tests/eval/.gitignore
+++ b/tests/eval/.gitignore
@@ -1,0 +1,2 @@
+datasets/
+results/

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -13,12 +13,13 @@ tests/eval/
   results/              # gitignored; per-runner JSON output
   scripts/
     fetch-locomo.ts     # pull LoCoMo JSON from upstream (MIT)
+    judge-llm.ts        # LLM-judge a results/*.json → recallJudge
   src/
     loaders/locomo.ts   # forgiving JSON adapter
-    judge.ts            # token-F1 baseline; LLM-judge hook TODO
+    judge.ts            # token-F1 helper (fast in-runner baseline)
   memory/
-    run-mem0.ts         # pi-memory-mem0 runner
-    run-memory.ts       # pi-memory runner (simplified probe)
+    run-mem0.ts         # pi-memory-mem0 runner (passive extraction)
+    run-memory.ts       # pi-memory runner (real memory_add/replace/remove loop)
 ```
 
 ## Quick start
@@ -27,12 +28,23 @@ tests/eval/
 pnpm install
 pnpm --filter @amaster.ai/pi-eval fetch:locomo
 
-# pi-memory-mem0 (needs MEM0_API_KEY for platform mode, or OSS mode wiring)
-MEM0_API_KEY=... pnpm --filter @amaster.ai/pi-eval eval:memory:mem0 -- --samples 5 --topk 5
+MODELS=/path/to/.pi/agent/models.json   # provides provider baseUrl + apiKey
 
-# pi-memory (no LLM needed for the heuristic baseline)
-pnpm --filter @amaster.ai/pi-eval eval:memory:curated -- --samples 5
+# pi-memory-mem0 (OSS mode: extraction + embedding resolved from models.json)
+pnpm --filter @amaster.ai/pi-eval eval:memory:mem0 -- \
+  --mode oss --samples 2 --topk 10 --concurrency 2 --models "$MODELS"
+
+# pi-memory (real write loop: LLM emits memory ops per session)
+pnpm --filter @amaster.ai/pi-eval eval:memory:curated -- \
+  --samples 2 --concurrency 2 --models "$MODELS"
+
+# LLM-judge either result file → recallJudge
+pnpm --filter @amaster.ai/pi-eval judge:llm -- \
+  --input results/mem0-locomo-oss.json --llm-model deepseek-v4-pro \
+  --concurrency 6 --models "$MODELS"
 ```
+
+Platform mode for mem0 (`--mode platform`) reads `MEM0_API_KEY` instead.
 
 ## Datasets
 
@@ -45,19 +57,49 @@ We deliberately do **not** consume [OpenDataBox/MemoryData](https://github.com/O
 
 | Aspect              | pi-memory (curated)                       | pi-memory-mem0 (passive)              |
 |---------------------|-------------------------------------------|---------------------------------------|
-| Storage             | 2200 + 1375 char hard cap                 | Vector store (cloud or local)         |
-| Write decision      | LLM tool calls                            | Background extraction                 |
-| Retrieval           | None — full file injected to prompt       | Semantic search                       |
-| Primary metric      | Whether kept entries cover the answer     | Recall@k + answer F1                  |
+| Storage             | 2200 + 1375 char hard cap                 | Vector store (SQLite / cloud)         |
+| Write decision      | LLM emits memory_add/replace/remove ops   | Background per-turn extraction        |
+| Retrieval           | None — the whole snapshot is the context  | Semantic top-k search                 |
+| What LoCoMo rewards  | —                                        | Storing every retrievable detail      |
 
-A naive head-to-head would punish pi-memory for not being a vector store. The runners report different metrics on purpose.
+Both runners produce a memory `blob` per question and the same LLM-judge asks
+"does this memory contain the answer?" — so the numbers share a scale. But
+**do not read them as a leaderboard.** LoCoMo asks 300+ fine-grained recall
+questions (exact dates, who-did-what, multi-hop). pi-memory's whole design is
+to *discard* most of that under a hard char budget and keep only high-value
+facts (preferences, corrections, stable environment facts). It compresses 19
+sessions of conversation into ~a few hundred chars on purpose. mem0's unbounded
+vector store keeps everything, so it recalls arbitrary details far better.
+
+The gap below reflects that mismatch, not that one is "better". A fair
+pi-memory benchmark would measure long-term retention of a small set of
+high-value facts, not exhaustive detail recall.
+
+## Results (LoCoMo, 2-sample slice: conv-26 + conv-30, 304 QA)
+
+Extraction/write + answer model: `deepseek-v4-flash`. Judge: `deepseek-v4-pro`.
+Endpoint resolved from a pi `models.json` (`--models`).
+
+| Runner            | literal recall | LLM-judge recall |
+|-------------------|---------------:|-----------------:|
+| pi-memory-mem0    |          ~0.39 |            ~0.44 |
+| pi-memory         |          ~0.26 |            ~0.19 |
+
+Notes:
+- mem0's judge score was ~0.27 before two fixes: isolating mem0's SQLite vector
+  store per run (it defaults to `~/.mem0/vector_store.db` and silently
+  accumulates across runs, polluting recall) and wiring `observedAt` so
+  extracted facts carry the conversation date, not the wall clock.
+- LLM-judge has run-to-run variance (flash drifted ~10 points between runs; pro
+  is steadier). Treat these as ±, not exact. Averaging multiple judge passes is
+  a TODO.
 
 ## Status
 
-Skeleton only. Open items:
+Working, run manually (no CI hook). Open items:
 
-- LoCoMo schema is forgivingly adapted; finalize after the real JSON lands.
-- LLM-judge in `judge.ts` is stubbed — token-F1 only for now.
-- `run-mem0.ts` defaults to platform mode; OSS mode needs a model-registry resolver wired in.
-- `run-memory.ts` uses a heuristic writer, not the real `memory_add` LLM tool loop. Real loop = follow-up.
-- No CI hook yet — runs are manual.
+- Only LoCoMo wired; LongMemEval / MemBench are TODO (same fetch-on-demand pattern).
+- Multi-sample averaging to shrink variance (currently 2 samples).
+- Judge variance reduction (multi-pass majority vote).
+- Reasoning models need generous `max_tokens` (write loop uses 4096, judge 512) —
+  content comes out empty if the budget is spent on reasoning_content.

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,63 @@
+# @amaster.ai/pi-eval
+
+Internal eval harness for pi packages. **Private workspace package** — not published.
+
+Domain runners live in subdirs (`memory/`, ...). Shared loaders, judge, and fetch scripts live at root so cross-domain reuse is free.
+
+## Layout
+
+```
+tests/eval/
+  package.json
+  datasets/             # gitignored; populated by fetch scripts
+  results/              # gitignored; per-runner JSON output
+  scripts/
+    fetch-locomo.ts     # pull LoCoMo JSON from upstream (MIT)
+  src/
+    loaders/locomo.ts   # forgiving JSON adapter
+    judge.ts            # token-F1 baseline; LLM-judge hook TODO
+  memory/
+    run-mem0.ts         # pi-memory-mem0 runner
+    run-memory.ts       # pi-memory runner (simplified probe)
+```
+
+## Quick start
+
+```bash
+pnpm install
+pnpm --filter @amaster.ai/pi-eval fetch:locomo
+
+# pi-memory-mem0 (needs MEM0_API_KEY for platform mode, or OSS mode wiring)
+MEM0_API_KEY=... pnpm --filter @amaster.ai/pi-eval eval:memory:mem0 -- --samples 5 --topk 5
+
+# pi-memory (no LLM needed for the heuristic baseline)
+pnpm --filter @amaster.ai/pi-eval eval:memory:curated -- --samples 5
+```
+
+## Datasets
+
+- **LoCoMo** — multi-session conversational QA. Pulled from [snap-research/locomo](https://github.com/snap-research/locomo) (MIT). ~600 samples; runner takes `--samples N` for a slice.
+- LongMemEval / MemBench — TODO. Same fetch-on-demand pattern.
+
+We deliberately do **not** consume [OpenDataBox/MemoryData](https://github.com/OpenDataBox/MemoryData) directly — that repo has no license. We borrow its evaluation taxonomy (recall / conflict / multi-session / update) and pull data from each upstream.
+
+## Why pi-memory and pi-memory-mem0 are evaluated differently
+
+| Aspect              | pi-memory (curated)                       | pi-memory-mem0 (passive)              |
+|---------------------|-------------------------------------------|---------------------------------------|
+| Storage             | 2200 + 1375 char hard cap                 | Vector store (cloud or local)         |
+| Write decision      | LLM tool calls                            | Background extraction                 |
+| Retrieval           | None — full file injected to prompt       | Semantic search                       |
+| Primary metric      | Whether kept entries cover the answer     | Recall@k + answer F1                  |
+
+A naive head-to-head would punish pi-memory for not being a vector store. The runners report different metrics on purpose.
+
+## Status
+
+Skeleton only. Open items:
+
+- LoCoMo schema is forgivingly adapted; finalize after the real JSON lands.
+- LLM-judge in `judge.ts` is stubbed — token-F1 only for now.
+- `run-mem0.ts` defaults to platform mode; OSS mode needs a model-registry resolver wired in.
+- `run-memory.ts` uses a heuristic writer, not the real `memory_add` LLM tool loop. Real loop = follow-up.
+- No CI hook yet — runs are manual.

--- a/tests/eval/memory/run-mem0.ts
+++ b/tests/eval/memory/run-mem0.ts
@@ -1,0 +1,318 @@
+#!/usr/bin/env node
+/**
+ * Run pi-memory-mem0 against LoCoMo. Per sample:
+ *   1. Ingest each turn via Mem0Provider.add()
+ *   2. For each QA, search(query) → score recall@k + token-F1
+ *
+ * Modes:
+ *   --mode platform   uses Mem0 cloud (MEM0_API_KEY)
+ *   --mode oss        local in-memory vector store; embedding + extraction
+ *                     LLM resolved from a pi-style models.json (default:
+ *                     ~/.pi/agent/models.json, override via --models <path>
+ *                     or env PI_MODELS_PATH)
+ *
+ * Recall = "did the gold answer literally appear in any topK result."
+ * The answering LLM is NOT wired — separate harness layer.
+ *
+ * Usage:
+ *   pnpm --filter @amaster.ai/pi-eval eval:memory:mem0 -- \
+ *     --mode oss --samples 2 --topk 5 \
+ *     --llm-provider amaster --llm-model deepseek-v4-pro \
+ *     --embed-provider amaster --embed-model text-embedding-v4 \
+ *     --models /Users/weaxs/Desktop/Workspace/pi-agent/.pi/models.json
+ */
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { createMem0Provider } from '@amaster.ai/pi-memory-mem0/provider';
+import { loadLocomo } from '../src/loaders/locomo.js';
+import { tokenF1 } from '../src/judge.js';
+
+// Re-declare structurally — mem0 root package doesn't re-export these types.
+type Mem0Mode = 'platform' | 'open-source';
+interface Mem0Config {
+  mode?: Mem0Mode;
+  apiKey?: string;
+  topK?: number;
+  useRegistryKeys?: boolean;
+  oss?: {
+    disableHistory?: boolean;
+    embedder?: { provider: string; config?: Record<string, unknown> };
+    llm?: { provider: string; config?: Record<string, unknown> };
+    vectorStore?: { provider: string; config?: Record<string, unknown> };
+  };
+}
+interface Hit {
+  memory?: string;
+}
+interface ProviderInfo {
+  apiKey: string;
+  baseUrl?: string;
+  api?: string;
+}
+interface ModelsJson {
+  providers: Record<string, { apiKey: string; baseUrl?: string; api?: string }>;
+}
+
+interface Args {
+  mode: 'platform' | 'oss';
+  samples: number;
+  topk: number;
+  modelsPath: string;
+  llmProvider: string;
+  llmModel: string;
+  embedProvider: string;
+  embedModel: string;
+  embedDims: number;
+  maxTurns: number;
+  maxQa: number;
+  concurrency: number;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (flag: string, dflt: string) => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : dflt;
+  };
+  const mode = get('--mode', 'oss');
+  if (mode !== 'platform' && mode !== 'oss') {
+    throw new Error(`--mode must be platform|oss, got: ${mode}`);
+  }
+  return {
+    mode,
+    samples: Number(get('--samples', '2')),
+    topk: Number(get('--topk', '5')),
+    modelsPath:
+      get('--models', '') ||
+      process.env.PI_MODELS_PATH ||
+      path.join(os.homedir(), '.pi', 'agent', 'models.json'),
+    llmProvider: get('--llm-provider', 'amaster'),
+    llmModel: get('--llm-model', 'deepseek-v4-flash'),
+    embedProvider: get('--embed-provider', 'amaster'),
+    embedModel: get('--embed-model', 'text-embedding-v4'),
+    embedDims: Number(get('--embed-dims', '1024')),
+    maxTurns: Number(get('--max-turns', '0')),
+    maxQa: Number(get('--max-qa', '0')),
+    concurrency: Number(get('--concurrency', '2')),
+  };
+}
+
+async function loadModelsJson(file: string): Promise<ModelsJson> {
+  try {
+    const raw = await readFile(file, 'utf8');
+    return JSON.parse(raw) as ModelsJson;
+  } catch (err) {
+    throw new Error(`failed to read models.json at ${file}: ${(err as Error).message}`);
+  }
+}
+
+function buildResolver(models: ModelsJson) {
+  return async (providerName: string): Promise<ProviderInfo | undefined> => {
+    const entry = models.providers?.[providerName];
+    if (!entry || !entry.apiKey) return undefined;
+    return { apiKey: entry.apiKey, baseUrl: entry.baseUrl, api: entry.api };
+  };
+}
+
+/**
+ * Retry transient failures (5xx, throttle, ECONN/ETIMEDOUT). Business errors
+ * — bad request, auth — surface immediately.
+ *
+ * ponytail: 3 tries, 1s/4s/16s. amaster throttle window is in seconds, not minutes.
+ */
+function isTransient(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const cause = err instanceof Error && err.cause instanceof Error ? err.cause.message : '';
+  const haystack = `${msg}\n${cause}`;
+  return /\b(5\d\d|429|overloaded|timeout|timed out|ETIMEDOUT|ECONN|EAI_AGAIN|ENOTFOUND|getaddrinfo|fetch failed|socket|Connection error|APIConnection)\b/i.test(
+    haystack,
+  );
+}
+
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const delays = [1000, 4000, 16000];
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const last = attempt === delays.length;
+      if (last || !isTransient(err)) throw err;
+      const wait = delays[attempt];
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`[eval:mem0] retry ${label} in ${wait}ms (${msg.slice(0, 120)})\n`);
+      await new Promise((r) => setTimeout(r, wait));
+    }
+  }
+  throw new Error('unreachable');
+}
+
+
+function buildConfig(args: Args): Mem0Config {
+  if (args.mode === 'platform') {
+    const apiKey = process.env.MEM0_API_KEY;
+    if (!apiKey) throw new Error('MEM0_API_KEY required for --mode platform');
+    return { mode: 'platform', apiKey, topK: args.topk };
+  }
+  return {
+    mode: 'open-source',
+    topK: args.topk,
+    useRegistryKeys: true,
+    oss: {
+      disableHistory: true, // avoid better-sqlite3 ABI surprises
+      // Fresh snapshot path per invocation — otherwise prior runs' facts
+      // pollute today's blob. The default path is ~/.pi/agent/memories/mem0-snapshot.db.
+      snapshotDbPath: path.join(
+        os.tmpdir(),
+        `pi-eval-mem0-snapshot-${process.pid}.db`,
+      ),
+      llm: {
+        provider: args.llmProvider,
+        config: {
+          model: args.llmModel,
+          // mem0 OSS OpenAILLM only forwards {messages, model, response_format, tools}
+          // to the OpenAI SDK — temperature / reasoning_effort / thinking are
+          // ALL silently dropped. Kept here for the day mem0 fixes that, and
+          // for any downstream compat that reads config verbatim.
+          temperature: 0,
+          reasoning_effort: 'high',
+        },
+      },
+      embedder: {
+        provider: args.embedProvider,
+        config: { model: args.embedModel, embeddingDims: args.embedDims },
+      },
+      vectorStore: {
+        provider: 'memory',
+        // mem0's 'memory' vector store is SQLite-backed at ~/.mem0/vector_store.db
+        // by default — NOT in-process. Without an explicit per-run dbPath, every
+        // eval run accumulates into the same file and pollutes future blobs.
+        config: {
+          collectionName: 'pi_mem0_eval',
+          dimension: args.embedDims,
+          dbPath: path.join(os.tmpdir(), `pi-eval-mem0-vs-${process.pid}.db`),
+        },
+      },
+    },
+  };
+}
+
+interface Row {
+  sample: string;
+  question: string;
+  gold: string;
+  recall: number;
+  f1: number;
+  blob: string;
+}
+
+async function runSample(
+  provider: Awaited<ReturnType<typeof createMem0Provider>>,
+  s: Awaited<ReturnType<typeof loadLocomo>>[number],
+  args: Args,
+): Promise<Row[]> {
+  const rows: Row[] = [];
+  const userId = `locomo-${s.sampleId}`;
+  const turns = args.maxTurns > 0 ? s.turns.slice(0, args.maxTurns) : s.turns;
+  const qa = args.maxQa > 0 ? s.qa.slice(0, args.maxQa) : s.qa;
+  process.stderr.write(
+    `[eval:mem0] ingest ${s.sampleId}: ${turns.length}/${s.turns.length} turns\n`,
+  );
+  let i = 0;
+  for (const t of turns) {
+    if (!t.text) continue;
+    const role = t.speaker === s.speakerB ? 'assistant' : 'user';
+    const t0 = Date.now();
+    await withRetry(`add ${s.sampleId} #${i + 1}`, () =>
+      provider.add(
+        [{ role, content: `${t.speaker}: ${t.text}` }],
+        { userId, observedAt: t.timestamp },
+      ),
+    );
+    i++;
+    if (i % 5 === 0 || i === turns.length) {
+      process.stderr.write(
+        `[eval:mem0]   ${s.sampleId} turn ${i}/${turns.length} (+${Date.now() - t0}ms)\n`,
+      );
+    }
+  }
+  process.stderr.write(`[eval:mem0] query ${s.sampleId}: ${qa.length}/${s.qa.length} QA\n`);
+  let qi = 0;
+  for (const q of qa) {
+    const hits: Hit[] = await withRetry(`search ${s.sampleId}`, () =>
+      provider.search(q.question, { userId, topK: args.topk }),
+    );
+    const blob = hits.map((h) => h.memory).filter(Boolean).join('\n');
+    const recall = blob.toLowerCase().includes(q.answer.toLowerCase()) ? 1 : 0;
+    const f1 = tokenF1(blob, q.answer).score;
+    rows.push({ sample: s.sampleId, question: q.question, gold: q.answer, recall, f1, blob });
+    qi++;
+    if (qi % 20 === 0 || qi === qa.length) {
+      process.stderr.write(`[eval:mem0]   ${s.sampleId} qa ${qi}/${qa.length}\n`);
+    }
+  }
+  return rows;
+}
+
+async function main() {
+  const args = parseArgs();
+  const samples = (await loadLocomo()).slice(0, args.samples);
+  process.stderr.write(
+    `[eval:mem0] mode=${args.mode} samples=${samples.length} concurrency=${args.concurrency}\n`,
+  );
+
+  let resolveProvider: ((p: string) => Promise<ProviderInfo | undefined>) | undefined;
+  if (args.mode === 'oss') {
+    const models = await loadModelsJson(args.modelsPath);
+    resolveProvider = buildResolver(models);
+    process.stderr.write(
+      `[eval:mem0] models=${args.modelsPath} llm=${args.llmProvider}/${args.llmModel} embed=${args.embedProvider}/${args.embedModel}\n`,
+    );
+  }
+
+  const provider = await createMem0Provider({
+    config: buildConfig(args),
+    resolveProvider,
+  });
+
+  // Simple worker pool over samples. Each sample has an independent userId,
+  // so mem0 add/search calls don't collide.
+  // ponytail: no rate-limiter beyond concurrency. If amaster starts 429ing
+  // the retry helper handles it; drop --concurrency if it's chronic.
+  const rows: Row[] = [];
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= samples.length) return;
+      try {
+        const got = await runSample(provider, samples[idx], args);
+        rows.push(...got);
+      } catch (err) {
+        process.stderr.write(
+          `[eval:mem0] sample ${samples[idx].sampleId} failed: ${(err as Error).message}\n`,
+        );
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(args.concurrency, samples.length)) }, worker),
+  );
+
+  const avg = (k: 'recall' | 'f1') =>
+    rows.reduce((a, r) => a + r[k], 0) / Math.max(1, rows.length);
+  const summary = { mode: args.mode, n: rows.length, recall: avg('recall'), tokenF1: avg('f1') };
+  process.stderr.write(`[eval:mem0] ${JSON.stringify(summary)}\n`);
+
+  const outDir = path.resolve(import.meta.dirname, '..', 'results');
+  await mkdir(outDir, { recursive: true });
+  await writeFile(
+    path.join(outDir, `mem0-locomo-${args.mode}.json`),
+    JSON.stringify({ summary, rows }, null, 2),
+  );
+}
+
+main().catch((err) => {
+  process.stderr.write(`[eval:mem0] error: ${err.stack ?? err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/memory/run-memory.ts
+++ b/tests/eval/memory/run-memory.ts
@@ -1,26 +1,59 @@
 #!/usr/bin/env node
 /**
- * Run pi-memory (curated MemoryStore) against LoCoMo as a SIMPLIFIED probe.
+ * Run pi-memory (curated MemoryStore) against LoCoMo with a REAL write loop.
  *
- * pi-memory has no semantic retrieval — its job is to decide what to keep
- * within the 2200/1375 char budget. So this runner:
- *   1. Feeds turns one by one, asking an extractor LLM to call memory_add /
- *      memory_replace / memory_remove. (LLM not wired in skeleton — we use
- *      a heuristic baseline: append every assistant-stated fact, FIFO evict.)
- *   2. After ingest, for each QA, scores whether the gold answer's tokens
- *      appear inside MEMORY.md + USER.md.
+ * Unlike mem0's passive per-turn extraction, pi-memory is agent-driven: the
+ * agent decides what to persist via memory_add / memory_replace / memory_remove
+ * within a hard char budget (2200 MEMORY + 1375 USER). This runner simulates
+ * that: for each conversation session, an LLM sees the turns plus the current
+ * memory state and emits tool calls, which we apply to a real MemoryStore
+ * (char limits + threat scan enforced).
  *
- * This is NOT a fair head-to-head vs mem0 — see eval/README.md.
+ * Then for each QA, an LLM answers using the full MEMORY.md + USER.md snapshot
+ * as context. Scoring: literal recall + token-F1 in-runner; run judge-llm.ts
+ * afterwards for LLM-judge.
+ *
+ * Models resolved from a pi-style models.json (same as run-mem0.ts).
+ *
+ * Usage:
+ *   pnpm --filter @amaster.ai/pi-eval eval:memory:curated -- \
+ *     --samples 2 --concurrency 2 \
+ *     --models /Users/weaxs/Desktop/Workspace/pi-agent/.pi/models.json
  */
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
-import { tmpdir } from 'node:os';
 import { MemoryStore } from '@amaster.ai/pi-memory/store';
+import type { LocomoSample } from '../src/loaders/locomo.js';
 import { loadLocomo } from '../src/loaders/locomo.js';
 import { tokenF1 } from '../src/judge.js';
 
 interface Args {
   samples: number;
+  concurrency: number;
+  modelsPath: string;
+  provider: string;
+  model: string;
+  maxSessions: number;
+  maxQa: number;
+}
+
+interface ModelsJson {
+  providers: Record<string, { apiKey: string; baseUrl?: string }>;
+}
+
+interface ProviderInfo {
+  apiKey: string;
+  baseUrl: string;
+}
+
+interface Row {
+  sample: string;
+  question: string;
+  gold: string;
+  recall: number;
+  f1: number;
+  blob: string;
 }
 
 function parseArgs(): Args {
@@ -29,63 +62,236 @@ function parseArgs(): Args {
     const i = argv.indexOf(flag);
     return i >= 0 ? argv[i + 1] : dflt;
   };
-  return { samples: Number(get('--samples', '3')) };
+  return {
+    samples: Number(get('--samples', '2')),
+    concurrency: Number(get('--concurrency', '2')),
+    modelsPath:
+      get('--models', '') ||
+      process.env.PI_MODELS_PATH ||
+      path.join(os.homedir(), '.pi', 'agent', 'models.json'),
+    provider: get('--provider', 'amaster'),
+    model: get('--model', 'deepseek-v4-flash'),
+    maxSessions: Number(get('--max-sessions', '0')),
+    maxQa: Number(get('--max-qa', '0')),
+  };
+}
+
+async function loadProvider(args: Args): Promise<ProviderInfo> {
+  const raw = await readFile(args.modelsPath, 'utf8');
+  const models = JSON.parse(raw) as ModelsJson;
+  const entry = models.providers?.[args.provider];
+  if (!entry?.apiKey || !entry?.baseUrl) {
+    throw new Error(`provider ${args.provider} missing apiKey/baseUrl in ${args.modelsPath}`);
+  }
+  return { apiKey: entry.apiKey, baseUrl: entry.baseUrl };
+}
+
+function isTransient(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const cause = err instanceof Error && err.cause instanceof Error ? err.cause.message : '';
+  return /\b(5\d\d|429|overloaded|timeout|timed out|ETIMEDOUT|ECONN|EAI_AGAIN|ENOTFOUND|getaddrinfo|fetch failed|socket|Connection error|APIConnection)\b/i.test(
+    `${msg}\n${cause}`,
+  );
+}
+
+async function chat(
+  cfg: ProviderInfo,
+  model: string,
+  messages: Array<{ role: string; content: string }>,
+  maxTokens: number,
+): Promise<string> {
+  const delays = [1000, 4000, 16000];
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    try {
+      const res = await fetch(`${cfg.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${cfg.apiKey}` },
+        body: JSON.stringify({ model, temperature: 0, max_tokens: maxTokens, messages }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+      return data.choices?.[0]?.message?.content ?? '';
+    } catch (err) {
+      lastErr = err;
+      if (attempt === delays.length || !isTransient(err)) break;
+      await new Promise((r) => setTimeout(r, delays[attempt]));
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
+// ---------------------------------------------------------------------------
+// Write loop
+// ---------------------------------------------------------------------------
+
+interface MemoryOp {
+  op: 'add' | 'replace' | 'remove';
+  target: 'memory' | 'user';
+  content?: string;
+  oldText?: string;
+  newContent?: string;
+}
+
+const WRITE_SYSTEM = `You are the memory manager for an AI assistant. You maintain two persistent stores under strict character budgets:
+- MEMORY (your own notes): 2200 chars max
+- USER (facts about the user): 1375 chars max
+
+You are shown one conversation session and the current contents of both stores. Decide what durable facts to persist. Prefer user preferences, personal details, stable facts, decisions, and events with dates. Skip small talk and transient state.
+
+Because the budget is tight, consolidate: prefer replacing/merging an existing entry over adding a near-duplicate, and remove stale entries when superseded.
+
+Respond with ONLY a JSON array of operations, no prose. Each op is one of:
+{"op":"add","target":"memory|user","content":"..."}
+{"op":"replace","target":"memory|user","oldText":"<unique substring of an existing entry>","newContent":"..."}
+{"op":"remove","target":"memory|user","oldText":"<unique substring of an existing entry>"}
+Return [] if nothing is worth persisting from this session.`;
+
+function extractJsonArray(text: string): MemoryOp[] {
+  const cleaned = text.replace(/```(?:json)?/gi, '').trim();
+  const start = cleaned.indexOf('[');
+  const end = cleaned.lastIndexOf(']');
+  if (start < 0 || end <= start) return [];
+  try {
+    const parsed = JSON.parse(cleaned.slice(start, end + 1));
+    return Array.isArray(parsed) ? (parsed as MemoryOp[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function snapshot(store: MemoryStore): string {
+  const mem = store.getEntries('memory');
+  const usr = store.getEntries('user');
+  return [
+    `MEMORY (${mem.join('\n§\n').length}/2200 chars):`,
+    mem.length ? mem.map((e, i) => `[M${i}] ${e}`).join('\n') : '(empty)',
+    '',
+    `USER (${usr.join('\n§\n').length}/1375 chars):`,
+    usr.length ? usr.map((e, i) => `[U${i}] ${e}`).join('\n') : '(empty)',
+  ].join('\n');
+}
+
+async function applyOp(store: MemoryStore, op: MemoryOp): Promise<void> {
+  const target = op.target === 'user' ? 'user' : 'memory';
+  if (op.op === 'add' && op.content) {
+    await store.add(target, op.content);
+  } else if (op.op === 'replace' && op.oldText && op.newContent) {
+    await store.replace(target, op.oldText, op.newContent);
+  } else if (op.op === 'remove' && op.oldText) {
+    await store.remove(target, op.oldText);
+  }
+  // Errors (over-limit, no match, threat) are left to the model's next-session
+  // view: the snapshot reflects actual stored state, so it self-corrects.
+}
+
+function sessionTurns(sample: LocomoSample): Map<number, string[]> {
+  const bySession = new Map<number, string[]>();
+  for (const t of sample.turns) {
+    if (!t.text) continue;
+    const line = `${t.speaker}: ${t.text}`;
+    const list = bySession.get(t.session);
+    if (list) list.push(line);
+    else bySession.set(t.session, [line]);
+  }
+  return bySession;
+}
+
+async function runSample(cfg: ProviderInfo, args: Args, s: LocomoSample): Promise<Row[]> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'pi-memory-eval-'));
+  const store = new MemoryStore({ dir });
+  const rows: Row[] = [];
+  try {
+    await store.loadFromDisk();
+    const sessions = [...sessionTurns(s).entries()].sort((a, b) => a[0] - b[0]);
+    const limited = args.maxSessions > 0 ? sessions.slice(0, args.maxSessions) : sessions;
+    process.stderr.write(
+      `[eval:curated] write ${s.sampleId}: ${limited.length}/${sessions.length} sessions\n`,
+    );
+    let si = 0;
+    for (const [sessionId, turns] of limited) {
+      const userPrompt = [
+        `## Current memory state`,
+        snapshot(store),
+        '',
+        `## Conversation session ${sessionId}`,
+        turns.join('\n'),
+      ].join('\n');
+      const reply = await chat(
+        cfg,
+        args.model,
+        [
+          { role: 'system', content: WRITE_SYSTEM },
+          { role: 'user', content: userPrompt },
+        ],
+        4096,
+      );
+      const ops = extractJsonArray(reply);
+      for (const op of ops) await applyOp(store, op);
+      si++;
+      process.stderr.write(
+        `[eval:curated]   ${s.sampleId} session ${si}/${limited.length} (${ops.length} ops)\n`,
+      );
+    }
+
+    const blob = [...store.getEntries('memory'), ...store.getEntries('user')].join('\n');
+    const qa = args.maxQa > 0 ? s.qa.slice(0, args.maxQa) : s.qa;
+    // Score against the full curated memory snapshot — same semantics as the
+    // mem0 runner (does the retained memory contain the answer?), so the two
+    // are comparable under the same judge. pi-memory has no retrieval step;
+    // the whole snapshot IS what the agent sees, so we score the whole thing.
+    process.stderr.write(`[eval:curated] score ${s.sampleId}: ${qa.length} QA\n`);
+    for (const q of qa) {
+      const recall = blob.toLowerCase().includes(q.answer.toLowerCase()) ? 1 : 0;
+      const f1 = tokenF1(blob, q.answer).score;
+      rows.push({ sample: s.sampleId, question: q.question, gold: q.answer, recall, f1, blob });
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+  return rows;
 }
 
 async function main() {
   const args = parseArgs();
+  const cfg = await loadProvider(args);
   const samples = (await loadLocomo()).slice(0, args.samples);
-  process.stderr.write(`[eval:memory] loaded ${samples.length} samples\n`);
+  process.stderr.write(
+    `[eval:curated] samples=${samples.length} concurrency=${args.concurrency} model=${args.provider}/${args.model}\n`,
+  );
 
-  const rows: Array<{ sample: string; question: string; gold: string; f1: number; charsUsed: number }> = [];
-
-  for (const s of samples) {
-    const dir = await mkdtemp(path.join(tmpdir(), 'pi-memory-eval-'));
-    const store = new MemoryStore({ dir });
-    try {
-      await store.loadFromDisk();
-      // Heuristic baseline: speaker_b turns → MEMORY (the agent's own notes
-      // in pi-memory terms), speaker_a turns → USER profile. First line, ≤300 chars.
-      for (const t of s.turns) {
-        const text = (t.text ?? '').trim();
-        if (!text) continue;
-        const target = t.speaker === s.speakerA ? 'user' : 'memory';
-        const entry = text.split(/\n/)[0].slice(0, 300);
-        const res = await store.add(target, entry);
-        if ('success' in res && res.success === false) {
-          // Likely over-limit. FIFO evict the oldest entry, retry once.
-          const entries = store.getEntries(target);
-          if (entries.length > 0) {
-            await store.remove(target, entries[0].slice(0, 24));
-            await store.add(target, entry);
-          }
-        }
+  const rows: Row[] = [];
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= samples.length) return;
+      try {
+        rows.push(...(await runSample(cfg, args, samples[idx])));
+      } catch (err) {
+        process.stderr.write(
+          `[eval:curated] sample ${samples[idx].sampleId} failed: ${(err as Error).message}\n`,
+        );
       }
-      const blob = [...store.getEntries('memory'), ...store.getEntries('user')].join('\n');
-      for (const q of s.qa) {
-        rows.push({
-          sample: s.sampleId,
-          question: q.question,
-          gold: q.answer,
-          f1: tokenF1(blob, q.answer).score,
-          charsUsed: blob.length,
-        });
-      }
-    } finally {
-      await rm(dir, { recursive: true, force: true });
     }
-  }
+  };
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(args.concurrency, samples.length)) }, worker),
+  );
 
-  const avg = (k: 'f1' | 'charsUsed') => rows.reduce((a, r) => a + r[k], 0) / Math.max(1, rows.length);
-  const summary = { n: rows.length, tokenF1: avg('f1'), avgChars: avg('charsUsed') };
-  process.stderr.write(`[eval:memory] ${JSON.stringify(summary)}\n`);
+  const avg = (k: 'recall' | 'f1') => rows.reduce((a, r) => a + r[k], 0) / Math.max(1, rows.length);
+  const summary = { n: rows.length, recall: avg('recall'), tokenF1: avg('f1') };
+  process.stderr.write(`[eval:curated] ${JSON.stringify(summary)}\n`);
 
   const outDir = path.resolve(import.meta.dirname, '..', 'results');
   await mkdir(outDir, { recursive: true });
-  await writeFile(path.join(outDir, 'memory-locomo.json'), JSON.stringify({ summary, rows }, null, 2));
+  await writeFile(
+    path.join(outDir, 'memory-locomo.json'),
+    JSON.stringify({ summary, rows }, null, 2),
+  );
 }
 
 main().catch((err) => {
-  process.stderr.write(`[eval:memory] error: ${err.message}\n`);
+  process.stderr.write(`[eval:curated] error: ${err.stack ?? err.message}\n`);
   process.exit(1);
 });

--- a/tests/eval/memory/run-memory.ts
+++ b/tests/eval/memory/run-memory.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Run pi-memory (curated MemoryStore) against LoCoMo as a SIMPLIFIED probe.
+ *
+ * pi-memory has no semantic retrieval — its job is to decide what to keep
+ * within the 2200/1375 char budget. So this runner:
+ *   1. Feeds turns one by one, asking an extractor LLM to call memory_add /
+ *      memory_replace / memory_remove. (LLM not wired in skeleton — we use
+ *      a heuristic baseline: append every assistant-stated fact, FIFO evict.)
+ *   2. After ingest, for each QA, scores whether the gold answer's tokens
+ *      appear inside MEMORY.md + USER.md.
+ *
+ * This is NOT a fair head-to-head vs mem0 — see eval/README.md.
+ */
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { MemoryStore } from '@amaster.ai/pi-memory/store';
+import { loadLocomo } from '../src/loaders/locomo.js';
+import { tokenF1 } from '../src/judge.js';
+
+interface Args {
+  samples: number;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (flag: string, dflt: string) => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : dflt;
+  };
+  return { samples: Number(get('--samples', '3')) };
+}
+
+async function main() {
+  const args = parseArgs();
+  const samples = (await loadLocomo()).slice(0, args.samples);
+  process.stderr.write(`[eval:memory] loaded ${samples.length} samples\n`);
+
+  const rows: Array<{ sample: string; question: string; gold: string; f1: number; charsUsed: number }> = [];
+
+  for (const s of samples) {
+    const dir = await mkdtemp(path.join(tmpdir(), 'pi-memory-eval-'));
+    const store = new MemoryStore({ dir });
+    try {
+      await store.loadFromDisk();
+      // Heuristic baseline: speaker_b turns → MEMORY (the agent's own notes
+      // in pi-memory terms), speaker_a turns → USER profile. First line, ≤300 chars.
+      for (const t of s.turns) {
+        const text = (t.text ?? '').trim();
+        if (!text) continue;
+        const target = t.speaker === s.speakerA ? 'user' : 'memory';
+        const entry = text.split(/\n/)[0].slice(0, 300);
+        const res = await store.add(target, entry);
+        if ('success' in res && res.success === false) {
+          // Likely over-limit. FIFO evict the oldest entry, retry once.
+          const entries = store.getEntries(target);
+          if (entries.length > 0) {
+            await store.remove(target, entries[0].slice(0, 24));
+            await store.add(target, entry);
+          }
+        }
+      }
+      const blob = [...store.getEntries('memory'), ...store.getEntries('user')].join('\n');
+      for (const q of s.qa) {
+        rows.push({
+          sample: s.sampleId,
+          question: q.question,
+          gold: q.answer,
+          f1: tokenF1(blob, q.answer).score,
+          charsUsed: blob.length,
+        });
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  const avg = (k: 'f1' | 'charsUsed') => rows.reduce((a, r) => a + r[k], 0) / Math.max(1, rows.length);
+  const summary = { n: rows.length, tokenF1: avg('f1'), avgChars: avg('charsUsed') };
+  process.stderr.write(`[eval:memory] ${JSON.stringify(summary)}\n`);
+
+  const outDir = path.resolve(import.meta.dirname, '..', 'results');
+  await mkdir(outDir, { recursive: true });
+  await writeFile(path.join(outDir, 'memory-locomo.json'), JSON.stringify({ summary, rows }, null, 2));
+}
+
+main().catch((err) => {
+  process.stderr.write(`[eval:memory] error: ${err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/package.json
+++ b/tests/eval/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@amaster.ai/pi-eval",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "fetch:locomo": "tsx scripts/fetch-locomo.ts",
+    "eval:memory:mem0": "tsx memory/run-mem0.ts",
+    "eval:memory:curated": "tsx memory/run-memory.ts",
+    "judge:llm": "tsx scripts/judge-llm.ts"
+  },
+  "dependencies": {
+    "@amaster.ai/pi-memory": "workspace:*",
+    "@amaster.ai/pi-memory-mem0": "workspace:*"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.0"
+  }
+}

--- a/tests/eval/scripts/fetch-locomo.ts
+++ b/tests/eval/scripts/fetch-locomo.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Fetch LoCoMo benchmark JSON into datasets/locomo/.
+ * Source: https://github.com/snap-research/locomo (MIT). We pull the raw JSON
+ * directly from the upstream repo, NOT from OpenDataBox/MemoryData (unlicensed).
+ *
+ * Usage: pnpm --filter @amaster.ai/pi-memory-eval fetch:locomo
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const TARGETS = [
+  {
+    name: 'locomo10.json',
+    url: 'https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json',
+  },
+];
+
+const OUT_DIR = path.resolve(import.meta.dirname, '..', 'datasets', 'locomo');
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+  for (const t of TARGETS) {
+    const out = path.join(OUT_DIR, t.name);
+    process.stderr.write(`[fetch-locomo] ${t.url} -> ${out}\n`);
+    const res = await fetch(t.url);
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${t.url}`);
+    const body = await res.text();
+    await writeFile(out, body);
+  }
+  process.stderr.write('[fetch-locomo] done\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`[fetch-locomo] error: ${err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/scripts/judge-llm.ts
+++ b/tests/eval/scripts/judge-llm.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * LLM-judge a results/*.json file. For each row, ask deepseek-v4-flash whether
+ * the retrieved blob contains enough information to answer the question given
+ * the gold answer. Writes results/*-judged.json with per-row `judge: 0|1` and a
+ * new `recallJudge` summary metric.
+ *
+ * Usage:
+ *   pnpm --filter @amaster.ai/pi-eval judge:llm -- \
+ *     --input results/mem0-locomo-oss.json \
+ *     --models /Users/weaxs/Desktop/Workspace/pi-agent/.pi/models.json \
+ *     --concurrency 4
+ */
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+interface Args {
+  input: string;
+  modelsPath: string;
+  llmProvider: string;
+  llmModel: string;
+  concurrency: number;
+  limit: number;
+}
+
+interface Row {
+  sample: string;
+  question: string;
+  gold: string;
+  recall: number;
+  f1: number;
+  blob?: string;
+  judge?: number;
+  judgeError?: string;
+}
+
+interface Bundle {
+  summary: Record<string, unknown>;
+  rows: Row[];
+}
+
+interface ModelsJson {
+  providers: Record<string, { apiKey: string; baseUrl?: string }>;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  const get = (flag: string, dflt: string) => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1] : dflt;
+  };
+  return {
+    input: get('--input', 'results/mem0-locomo-oss.json'),
+    modelsPath:
+      get('--models', '') ||
+      process.env.PI_MODELS_PATH ||
+      path.join(os.homedir(), '.pi', 'agent', 'models.json'),
+    llmProvider: get('--llm-provider', 'amaster'),
+    llmModel: get('--llm-model', 'deepseek-v4-flash'),
+    concurrency: Number(get('--concurrency', '4')),
+    limit: Number(get('--limit', '0')),
+  };
+}
+
+const JUDGE_SYSTEM = `You judge whether retrieved memory contains enough information to correctly answer a question, using the gold answer as ground truth.
+
+Rules:
+- Answer STRICTLY with the single word: YES or NO.
+- YES if the memory contains the gold answer or an equivalent restatement (different wording, dates in different formats, aliases, etc.).
+- YES if the memory contains the specific fact needed even without the exact literal string.
+- NO if the memory is silent on the fact, gives a wrong value, or is irrelevant.
+- NO if the memory only contains a related but insufficient fact.
+Do not explain. Do not output anything else. Just YES or NO.`;
+
+function buildUserPrompt(question: string, gold: string, blob: string): string {
+  return [
+    `Question: ${question}`,
+    `Gold answer: ${gold}`,
+    '',
+    'Retrieved memory:',
+    blob.trim() || '(empty)',
+  ].join('\n');
+}
+
+interface JudgeConfig {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+}
+
+async function loadJudge(args: Args): Promise<JudgeConfig> {
+  const raw = await readFile(args.modelsPath, 'utf8');
+  const models = JSON.parse(raw) as ModelsJson;
+  const entry = models.providers?.[args.llmProvider];
+  if (!entry?.apiKey || !entry?.baseUrl) {
+    throw new Error(`provider ${args.llmProvider} missing apiKey/baseUrl in ${args.modelsPath}`);
+  }
+  return { apiKey: entry.apiKey, baseUrl: entry.baseUrl, model: args.llmModel };
+}
+
+function isTransient(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const cause = err instanceof Error && err.cause instanceof Error ? err.cause.message : '';
+  const haystack = `${msg}\n${cause}`;
+  return /\b(5\d\d|429|overloaded|timeout|timed out|ETIMEDOUT|ECONN|EAI_AGAIN|ENOTFOUND|getaddrinfo|fetch failed|socket|Connection error|APIConnection)\b/i.test(
+    haystack,
+  );
+}
+
+async function callJudge(cfg: JudgeConfig, prompt: string): Promise<'YES' | 'NO'> {
+  const delays = [1000, 4000, 16000];
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    try {
+      const res = await fetch(`${cfg.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${cfg.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: cfg.model,
+          temperature: 0,
+          // deepseek-v4-flash is a reasoning model — reasoning_tokens eat the
+          // budget before content is emitted. Give it enough headroom.
+          max_tokens: 512,
+          messages: [
+            { role: 'system', content: JUDGE_SYSTEM },
+            { role: 'user', content: prompt },
+          ],
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`HTTP ${res.status}: ${body.slice(0, 200)}`);
+      }
+      const data = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      const text = (data.choices?.[0]?.message?.content ?? '').trim().toUpperCase();
+      // Reasoning models sometimes prepend their scratchpad. Find the last
+      // clear YES / NO signal in the response.
+      const yesIdx = text.lastIndexOf('YES');
+      const noIdx = text.lastIndexOf('NO');
+      if (yesIdx < 0 && noIdx < 0) {
+        throw new Error(`unexpected judge reply: ${text.slice(-120)}`);
+      }
+      return yesIdx > noIdx ? 'YES' : 'NO';
+    } catch (err) {
+      lastErr = err;
+      if (attempt === delays.length || !isTransient(err)) break;
+      await new Promise((r) => setTimeout(r, delays[attempt]));
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
+async function main() {
+  const args = parseArgs();
+  const raw = await readFile(args.input, 'utf8');
+  const bundle = JSON.parse(raw) as Bundle;
+
+  const rows = args.limit > 0 ? bundle.rows.slice(0, args.limit) : bundle.rows;
+  process.stderr.write(`[judge:llm] input=${args.input} rows=${rows.length}\n`);
+
+  const missing = rows.filter((r) => !r.blob).length;
+  if (missing > 0) {
+    throw new Error(
+      `${missing}/${rows.length} rows have no blob — rerun eval with the current run-mem0.ts (which stores blob) before judging.`,
+    );
+  }
+
+  const cfg = await loadJudge(args);
+  process.stderr.write(`[judge:llm] model=${cfg.model} concurrency=${args.concurrency}\n`);
+
+  let cursor = 0;
+  let done = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= rows.length) return;
+      const r = rows[idx];
+      try {
+        const verdict = await callJudge(cfg, buildUserPrompt(r.question, r.gold, r.blob!));
+        r.judge = verdict === 'YES' ? 1 : 0;
+      } catch (err) {
+        r.judge = 0;
+        r.judgeError = err instanceof Error ? err.message.slice(0, 200) : String(err);
+      }
+      done++;
+      if (done % 20 === 0 || done === rows.length) {
+        process.stderr.write(`[judge:llm]   ${done}/${rows.length}\n`);
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(args.concurrency, rows.length)) }, worker),
+  );
+
+  const judged = rows.filter((r) => r.judgeError === undefined);
+  const recallJudge = judged.reduce((a, r) => a + (r.judge ?? 0), 0) / Math.max(1, judged.length);
+  const errors = rows.length - judged.length;
+  const oldSummary = bundle.summary;
+  const newSummary = { ...oldSummary, recallJudge, judgeN: judged.length, judgeErrors: errors };
+
+  process.stderr.write(`[judge:llm] recallJudge=${recallJudge.toFixed(4)} errors=${errors}\n`);
+
+  const outDir = path.resolve(path.dirname(args.input));
+  const inBase = path.basename(args.input, '.json');
+  await mkdir(outDir, { recursive: true });
+  await writeFile(
+    path.join(outDir, `${inBase}-judged.json`),
+    JSON.stringify({ summary: newSummary, rows }, null, 2),
+  );
+}
+
+main().catch((err) => {
+  process.stderr.write(`[judge:llm] error: ${err.stack ?? err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/src/judge.ts
+++ b/tests/eval/src/judge.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal LLM-judge stub. Real implementation wires to whatever provider the
+ * dev has configured (OpenAI / Anthropic / pi model registry). For now: token-
+ * level F1 + a hook for LLM judging once we pick a provider.
+ *
+ * ponytail: token-F1 is the floor metric — add LLM-judge when token-F1
+ * disagrees with eyeballed quality on >10% of samples.
+ */
+export interface JudgeResult {
+  score: number; // 0..1
+  rationale?: string;
+}
+
+const PUNCT = /[\p{P}\p{S}]/gu;
+
+function tokens(s: string): string[] {
+  return s
+    .toLowerCase()
+    .replace(PUNCT, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+export function tokenF1(prediction: string, gold: string): JudgeResult {
+  const p = tokens(prediction);
+  const g = tokens(gold);
+  if (p.length === 0 && g.length === 0) return { score: 1 };
+  if (p.length === 0 || g.length === 0) return { score: 0 };
+  const gSet = new Map<string, number>();
+  for (const t of g) gSet.set(t, (gSet.get(t) ?? 0) + 1);
+  let overlap = 0;
+  for (const t of p) {
+    const c = gSet.get(t);
+    if (c && c > 0) {
+      overlap++;
+      gSet.set(t, c - 1);
+    }
+  }
+  if (overlap === 0) return { score: 0 };
+  const precision = overlap / p.length;
+  const recall = overlap / g.length;
+  return { score: (2 * precision * recall) / (precision + recall) };
+}

--- a/tests/eval/src/loaders/locomo.ts
+++ b/tests/eval/src/loaders/locomo.ts
@@ -1,0 +1,108 @@
+/**
+ * LoCoMo loader. Real schema (verified against locomo10.json):
+ *
+ *   top-level: array of samples
+ *   sample = {
+ *     sample_id: string,
+ *     conversation: {
+ *       speaker_a: string,
+ *       speaker_b: string,
+ *       session_N: Turn[],
+ *       session_N_date_time: string,
+ *     },
+ *     qa: { question: string, answer: string, evidence: string[], category: number }[],
+ *     event_summary, observation, session_summary — unused for now
+ *   }
+ *   Turn = { speaker: string, dia_id: string, text: string, ... }
+ *
+ * Upstream: https://github.com/snap-research/locomo (MIT)
+ */
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface LocomoTurn {
+  speaker: string;
+  text: string;
+  diaId: string;
+  session: number;
+  timestamp?: string;
+}
+
+export interface LocomoQA {
+  question: string;
+  answer: string;
+  category?: number;
+  evidence?: string[];
+}
+
+export interface LocomoSample {
+  sampleId: string;
+  speakerA: string;
+  speakerB: string;
+  turns: LocomoTurn[];
+  qa: LocomoQA[];
+}
+
+const DATASETS_DIR = path.resolve(import.meta.dirname, '..', '..', 'datasets', 'locomo');
+
+export async function loadLocomo(file = 'locomo10.json'): Promise<LocomoSample[]> {
+  const raw = await readFile(path.join(DATASETS_DIR, file), 'utf8');
+  const data = JSON.parse(raw);
+  if (!Array.isArray(data)) throw new Error('[locomo] top-level not an array');
+  return data.map(adaptSample);
+}
+
+function parseLocomoTimestamp(raw: string | undefined): string | undefined {
+  if (!raw) return undefined;
+  // LoCoMo format is "H:MM am/pm on D Month, YYYY", e.g. "1:56 pm on 8 May, 2023".
+  // Native `new Date()` returns Invalid on this — extract the date part manually.
+  const m = /on\s+(\d{1,2})\s+(\w+),?\s+(\d{4})/i.exec(raw);
+  if (!m) return raw;
+  const [, day, monthName, year] = m;
+  const monthIdx: Record<string, number> = {
+    january: 0, february: 1, march: 2, april: 3, may: 4, june: 5,
+    july: 6, august: 7, september: 8, october: 9, november: 10, december: 11,
+  };
+  const mi = monthIdx[monthName.toLowerCase()];
+  if (mi === undefined) return raw;
+  const d = new Date(Date.UTC(Number(year), mi, Number(day)));
+  return d.toISOString().slice(0, 10);
+}
+
+function adaptSample(s: unknown): LocomoSample {
+  const obj = s as Record<string, unknown>;
+  const conv = (obj.conversation ?? {}) as Record<string, unknown>;
+  const turns: LocomoTurn[] = [];
+  for (const key of Object.keys(conv)) {
+    const m = /^session_(\d+)$/.exec(key);
+    if (!m) continue;
+    const session = Number(m[1]);
+    const rawTs = conv[`session_${session}_date_time`] as string | undefined;
+    const timestamp = parseLocomoTimestamp(rawTs);
+    const arr = conv[key];
+    if (!Array.isArray(arr)) continue;
+    for (const t of arr as Array<Record<string, unknown>>) {
+      turns.push({
+        speaker: String(t.speaker ?? ''),
+        text: String(t.text ?? ''),
+        diaId: String(t.dia_id ?? ''),
+        session,
+        timestamp,
+      });
+    }
+  }
+  turns.sort((a, b) => a.session - b.session); // ponytail: stable enough; dia_id ordering handled by file order
+  const qa: LocomoQA[] = ((obj.qa ?? []) as Array<Record<string, unknown>>).map((q) => ({
+    question: String(q.question ?? ''),
+    answer: String(q.answer ?? ''),
+    category: typeof q.category === 'number' ? q.category : undefined,
+    evidence: Array.isArray(q.evidence) ? (q.evidence as string[]) : undefined,
+  }));
+  return {
+    sampleId: String(obj.sample_id ?? ''),
+    speakerA: String(conv.speaker_a ?? ''),
+    speakerB: String(conv.speaker_b ?? ''),
+    turns,
+    qa,
+  };
+}


### PR DESCRIPTION
## What

Adds a memory-eval harness (`tests/eval`, private workspace package) that benchmarks `pi-memory` and `pi-memory-mem0` against LoCoMo, and a product change to `pi-memory-mem0` that fell out of building it.

## pi-memory-mem0: `observedAt`

`Mem0Provider.add()` gains an optional `observedAt` (Date | string). mem0's extraction prompt documents an "Observation Date" used to ground relative time references ("yesterday", "last week"), but never exposes a way to set it — it always falls back to the system clock, which mis-stamps facts when ingesting historical conversations.

- **OSS mode**: intercepts the extraction LLM call and rewrites the Observation/Current Date prompt sections to `observedAt` (serialized via a mutex, since the LLM wrapper is shared instance state).
- **Platform mode**: forwards it as the `add()` `timestamp` field.
- Omitting `observedAt` preserves current behavior for live turns.

Exported `formatObservedAt` / `rewriteObservationDate` with unit tests (+6).

## tests/eval

- **LoCoMo loader** — forgiving JSON adapter, parses the non-standard timestamp format to ISO.
- **run-mem0.ts** — passive extraction runner: ingest → semantic search → recall + token-F1. Per-run isolated vector-store & snapshot paths (mem0's `memory` store is SQLite-backed at `~/.mem0/vector_store.db` and silently accumulates across runs).
- **run-memory.ts** — real agent write loop: per session an LLM emits `memory_add/replace/remove` ops applied to a real `MemoryStore` (char caps + threat scan enforced).
- **judge-llm.ts** — LLM-judge post-processing → `recallJudge`.
- Retry (5xx/throttle/DNS), concurrency pool, model config from a pi `models.json`.

## Results (LoCoMo 2-sample, flash extract + pro judge)

| Runner | LLM-judge recall |
|---|---:|
| pi-memory-mem0 | ~0.44 |
| pi-memory | ~0.19 |

**Not a leaderboard** — LoCoMo rewards exhaustive detail recall, which pi-memory deliberately discards under its char budget. The README explains the mismatch. mem0's score rose from ~0.27 after the vector-store isolation and `observedAt` fixes.

## Notes

- Datasets/results are gitignored; runs are manual (no CI hook).
- Eval package is `private`, not published.