### PR TITLE
feat(pi-web-access): add Firecrawl search + scrape provider

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -198,7 +198,7 @@ jobs:
   # setup because self-hosted matrix jobs don't share workspace state.
   # ──────────────────────────────────────────────────────────────────────
   extension-tool-matrix:
-    name: Extension E2E (${{ matrix.extension }})
+    name: Extension E2E (${{ matrix.extension }}${{ matrix.provider && format('-{0}', matrix.provider) || '' }})
     needs: pi-runtime
     if: >
       (github.event_name != 'pull_request' ||
@@ -233,6 +233,16 @@ jobs:
             tools: web_fetch
             prompt: "Use web_fetch on https://www.baidu.com once. Tell me the page title in one sentence."
             assert_pattern: "(baidu|百度|bing|google|search|title)"
+          # Firecrawl provider E2E — exercises web_search (/v2/search) and
+          # web_fetch (/v2/scrape) against the real Firecrawl API. Uses the
+          # same pi-web-access extension but a distinct matrix `provider` key
+          # so the settings step below injects Firecrawl config only here.
+          # Gated on FIRECRAWL_API_KEY: skips cleanly until the secret is set.
+          - extension: pi-web-access
+            provider: firecrawl
+            tools: web_search,web_fetch
+            prompt: "Step 1 — use web_search once with query='Firecrawl web scraping API'. Step 2 — use web_fetch once on https://docs.firecrawl.dev/. Report the search result count and the fetched page title in one sentence."
+            assert_pattern: "(firecrawl|scrap|crawl|docs|title|result)"
           - extension: pi-image-gen
             tools: image_generate
             prompt: "Use image_generate to generate a test image with prompt 'a solid red square'. Report the generated file path."
@@ -245,6 +255,7 @@ jobs:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
       PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
       PI_INTEGRATION_MULTICA_TOKEN: ${{ secrets.PI_INTEGRATION_MULTICA_TOKEN }}
+      FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
       PI_OFFLINE: '0'
 
     steps:
@@ -266,6 +277,41 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$PI_CODING_AGENT_DIR"
+
+          # pi-web-access settings vary by matrix `provider`: the default
+          # entry only wires the summary model (fetch falls back to Jina),
+          # while the firecrawl entry configures Firecrawl as both the search
+          # and fetch provider so web_search (/v2/search) and web_fetch
+          # (/v2/scrape) hit the real API. The apiKey pulls FIRECRAWL_API_KEY
+          # from the environment at pi runtime via ${ENV_VAR} interpolation.
+          # (Single-quoted heredoc-var: ${FIRECRAWL_API_KEY} stays literal —
+          # bash does not recursively expand a variable's contents, so pi's
+          # own ${ENV_VAR} resolver sees the placeholder verbatim.)
+          if [ "${{ matrix.provider }}" = "firecrawl" ]; then
+            WEB_ACCESS_SETTINGS='{
+              "search": { "provider": "firecrawl" },
+              "fetch": {
+                "provider": "firecrawl",
+                "summary": {
+                  "provider": "deepseek-integration",
+                  "model": "deepseek-v4-flash"
+                }
+              },
+              "providers": {
+                "firecrawl": { "apiKey": "${FIRECRAWL_API_KEY}" }
+              }
+            }'
+          else
+            WEB_ACCESS_SETTINGS='{
+              "fetch": {
+                "summary": {
+                  "provider": "deepseek-integration",
+                  "model": "deepseek-v4-flash"
+                }
+              }
+            }'
+          fi
+
 
           # NOTE on ordering: this step writes settings.json BEFORE the
           # `pi install` step below. `pi install` appends to settings.json's
@@ -323,14 +369,7 @@ jobs:
                 "autoInstall": true
               }
             },
-            "pi-web-access": {
-              "fetch": {
-                "summary": {
-                  "provider": "deepseek-integration",
-                  "model": "deepseek-v4-flash"
-                }
-              }
-            },
+            "pi-web-access": ${WEB_ACCESS_SETTINGS},
             "pi-scheduler": {
               "dataDir": "${RUNNER_TEMP}/pi-scheduler"
             },
@@ -432,6 +471,12 @@ jobs:
         if: env.PI_INTEGRATION_BASE_URL != '' && env.PI_INTEGRATION_API_KEY != ''
         run: |
           set -euo pipefail
+          # The firecrawl matrix entry needs a real Firecrawl API key. Skip it
+          # cleanly (rather than fail) when the secret isn't configured yet.
+          if [ "${{ matrix.provider }}" = "firecrawl" ] && [ -z "${FIRECRAWL_API_KEY:-}" ]; then
+            echo "::warning::FIRECRAWL_API_KEY secret unset — skipping Firecrawl E2E."
+            exit 0
+          fi
           unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
           unset http_proxy https_proxy all_proxy no_proxy
           set +e

--- a/packages/pi-web-access/README.md
+++ b/packages/pi-web-access/README.md
@@ -46,6 +46,7 @@ Search X (Twitter) for posts and social media content. Only registered when xai 
 |----------|:------:|:-----:|:--------:|------------------|---------|---------------|
 | `tavily` | ✓ | ✓ | ✗ | `https://api.tavily.com` | `TAVILY_API_KEY` | - |
 | `brave` | ✓ | ✗ | ✗ | `https://api.search.brave.com` | `BRAVE_API_KEY` | - |
+| `firecrawl` | ✓ | ✓ | ✗ | `https://api.firecrawl.dev` | `FIRECRAWL_API_KEY` | - |
 | `kimi` | ✓ | ✗ | ✗ | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` | `kimi-k2.6` |
 | `mimo` | ✓ | ✗ | ✗ | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` | `mimo-v2.5-pro` |
 | `zai` | ✓ | ✓ | ✗ | `https://api.z.ai` | `ZAI_API_KEY` | - |

--- a/packages/pi-web-access/src/__tests__/config.test.ts
+++ b/packages/pi-web-access/src/__tests__/config.test.ts
@@ -24,6 +24,17 @@ describe('resolveProvider', () => {
     }
   });
 
+  it('resolves firecrawl with env var', () => {
+    process.env.FIRECRAWL_API_KEY = 'test-fc-key';
+    const result = resolveProvider('firecrawl', {});
+    expect(result).not.toHaveProperty('error');
+    if (!('error' in result)) {
+      expect(result.id).toBe('firecrawl');
+      expect(result.baseUrl).toBe('https://api.firecrawl.dev');
+      expect(result.apiKey).toBe('test-fc-key');
+    }
+  });
+
   it('resolves kimi with env var and default model', () => {
     process.env.MOONSHOT_API_KEY = 'test-kimi-key';
     const result = resolveProvider('kimi', {});
@@ -308,5 +319,15 @@ describe('resolveFetchProvider', () => {
     const result = resolveFetchProvider(settings);
     expect(result).not.toBeNull();
     expect(result!.id).toBe('tavily');
+  });
+
+  it('supports firecrawl as fetch provider', () => {
+    const settings: WebToolSettings = {
+      fetch: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'fc-key' } },
+    };
+    const result = resolveFetchProvider(settings);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('firecrawl');
   });
 });

--- a/packages/pi-web-access/src/__tests__/providers-fetch.test.ts
+++ b/packages/pi-web-access/src/__tests__/providers-fetch.test.ts
@@ -167,6 +167,53 @@ describe('webFetch - all providers', () => {
     );
   });
 
+  it('firecrawl: scrapes via v2/scrape API with markdown format', async () => {
+    const settings: WebToolSettings = {
+      fetch: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'fc-key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          markdown: '# Firecrawl\n\nScraped content',
+          metadata: { title: 'Firecrawl Home', sourceURL: 'https://firecrawl.dev/' },
+        },
+      }),
+    });
+
+    const result = await webFetch({ url: 'https://firecrawl.dev' }, settings);
+
+    expect(result.title).toBe('Firecrawl Home');
+    expect(result.url).toBe('https://firecrawl.dev/');
+    expect(result.content).toContain('Scraped content');
+
+    const [url, opts] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://api.firecrawl.dev/v2/scrape');
+    expect(opts.headers.Authorization).toBe('Bearer fc-key');
+    const body = JSON.parse(opts.body);
+    expect(body.url).toBe('https://firecrawl.dev');
+    expect(body.formats).toEqual(['markdown']);
+    expect(body.onlyMainContent).toBe(true);
+  });
+
+  it('firecrawl: throws on HTTP error', async () => {
+    const settings: WebToolSettings = {
+      fetch: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => 'Server error',
+    });
+
+    await expect(webFetch({ url: 'https://example.com' }, settings)).rejects.toThrow(
+      'Firecrawl Scrape API error 500',
+    );
+  });
+
   it('uses custom baseUrl for fetch provider', async () => {
     const settings: WebToolSettings = {
       fetch: { provider: 'openrouter' },

--- a/packages/pi-web-access/src/__tests__/providers.test.ts
+++ b/packages/pi-web-access/src/__tests__/providers.test.ts
@@ -216,6 +216,125 @@ describe('search - all providers', () => {
     expect(opts.headers['anthropic-version']).toBe('2023-06-01');
   });
 
+  it('firecrawl: calls v2/search API with Bearer token', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'fc-key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          web: [
+            {
+              title: 'Result 1',
+              url: 'https://example.com',
+              description: 'Example description',
+              position: 1,
+            },
+            {
+              title: 'Result 2',
+              url: 'https://other.com',
+              description: 'Other description',
+              position: 2,
+            },
+          ],
+        },
+      }),
+    });
+
+    const result = await search({ query: 'test query' }, settings);
+
+    expect(result.provider).toBe('firecrawl');
+    expect(result.query).toBe('test query');
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]!.title).toBe('Result 1');
+    expect(result.results[0]!.url).toBe('https://example.com');
+    expect(result.results[0]!.content).toBe('Example description');
+
+    const [url, opts] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('https://api.firecrawl.dev/v2/search');
+    expect(opts.headers.Authorization).toBe('Bearer fc-key');
+    const body = JSON.parse(opts.body);
+    expect(body.query).toBe('test query');
+    expect(body.sources).toEqual(['web']);
+  });
+
+  it('firecrawl: maps timeRange to tbs and passes limit', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: { web: [] } }),
+    });
+
+    await search({ query: 'test', timeRange: 'week', maxResults: 10 }, settings);
+
+    const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(body.tbs).toBe('qdr:w');
+    expect(body.limit).toBe(10);
+  });
+
+  it('firecrawl: uses news source and snippet when topic is news', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          news: [{ title: 'News Item', url: 'https://news.com', snippet: 'Breaking news' }],
+        },
+      }),
+    });
+
+    const result = await search({ query: 'test', topic: 'news' }, settings);
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]!.title).toBe('News Item');
+    expect(result.results[0]!.content).toBe('Breaking news');
+
+    const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(body.sources).toEqual(['news']);
+  });
+
+  it('firecrawl: passes domain filters', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: { web: [] } }),
+    });
+
+    await search({ query: 'test', includeDomains: ['example.com'] }, settings);
+
+    const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    expect(body.includeDomains).toEqual(['example.com']);
+  });
+
+  it('firecrawl: throws on HTTP error', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'firecrawl' },
+      providers: { firecrawl: { apiKey: 'key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 402,
+      text: async () => 'Payment required',
+    });
+
+    await expect(search({ query: 'test' }, settings)).rejects.toThrow(
+      'Firecrawl Search API error 402',
+    );
+  });
+
   it('brave: calls web search API with X-Subscription-Token', async () => {
     const settings: WebToolSettings = {
       search: { provider: 'brave' },

--- a/packages/pi-web-access/src/config.ts
+++ b/packages/pi-web-access/src/config.ts
@@ -9,6 +9,7 @@ const SETTINGS_KEY = 'pi-web-access';
 const DEFAULT_BASE_URL: Record<BuiltInProviderId, string> = {
   tavily: 'https://api.tavily.com',
   brave: 'https://api.search.brave.com',
+  firecrawl: 'https://api.firecrawl.dev',
   kimi: 'https://api.moonshot.cn/v1',
   mimo: 'https://api.xiaomimimo.com/v1',
   zai: 'https://api.z.ai',
@@ -23,6 +24,7 @@ const DEFAULT_BASE_URL: Record<BuiltInProviderId, string> = {
 const ENV_VARS: Record<BuiltInProviderId, string> = {
   tavily: 'TAVILY_API_KEY',
   brave: 'BRAVE_API_KEY',
+  firecrawl: 'FIRECRAWL_API_KEY',
   kimi: 'MOONSHOT_API_KEY',
   mimo: 'MIMO_API_KEY',
   zai: 'ZAI_API_KEY',
@@ -112,6 +114,7 @@ export function resolveProvider(
 const ALL_SEARCH_PROVIDER_IDS: BuiltInProviderId[] = [
   'tavily',
   'brave',
+  'firecrawl',
   'kimi',
   'mimo',
   'zai',

--- a/packages/pi-web-access/src/providers/firecrawl.ts
+++ b/packages/pi-web-access/src/providers/firecrawl.ts
@@ -1,0 +1,146 @@
+import type {
+  FetchResponse,
+  ResolvedProvider,
+  SearchParams,
+  SearchResponse,
+  SearchResult,
+} from './base.js';
+import { BaseProvider } from './base.js';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+// Map SearchParams.timeRange → Firecrawl `tbs` (query-date-range) value.
+const TBS_MAP: Record<string, string> = {
+  day: 'qdr:d',
+  week: 'qdr:w',
+  month: 'qdr:m',
+  year: 'qdr:y',
+};
+
+interface FirecrawlWebResult {
+  url: string;
+  title?: string;
+  description?: string;
+  position?: number;
+}
+
+/**
+ * Firecrawl provider — https://docs.firecrawl.dev
+ *
+ * - search: POST /v2/search (grouped-by-source response, we use `web`)
+ * - fetch:  POST /v2/scrape (markdown format, clean LLM-ready content)
+ */
+export class FirecrawlProvider extends BaseProvider {
+  readonly id = 'firecrawl' as const;
+
+  override async search(params: SearchParams, provider: ResolvedProvider): Promise<SearchResponse> {
+    if (!provider.apiKey) {
+      throw new Error(
+        'Firecrawl API key not configured. Set FIRECRAWL_API_KEY env var or configure in settings.json.',
+      );
+    }
+
+    const body: Record<string, unknown> = {
+      query: params.query,
+      limit: params.maxResults ?? 5,
+      sources: [params.topic === 'news' ? 'news' : 'web'],
+    };
+    if (params.timeRange) body.tbs = TBS_MAP[params.timeRange];
+    if (params.includeDomains?.length) body.includeDomains = params.includeDomains;
+    if (params.excludeDomains?.length) body.excludeDomains = params.excludeDomains;
+
+    const url = `${provider.baseUrl.replace(/\/$/, '')}/v2/search`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${provider.apiKey}`,
+      ...provider.headers,
+    };
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(provider.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Firecrawl Search API error ${response.status}: ${text}`);
+    }
+
+    const data = (await response.json()) as {
+      success?: boolean;
+      error?: string;
+      data?: {
+        web?: FirecrawlWebResult[];
+        news?: Array<{ url: string; title?: string; snippet?: string }>;
+      };
+    };
+
+    if (data.success === false) {
+      throw new Error(`Firecrawl Search failed: ${data.error ?? 'unknown error'}`);
+    }
+
+    let results: SearchResult[];
+    if (params.topic === 'news') {
+      results = (data.data?.news ?? []).map((r) => ({
+        title: r.title ?? r.url,
+        url: r.url,
+        content: r.snippet ?? '',
+      }));
+    } else {
+      results = (data.data?.web ?? []).map((r) => ({
+        title: r.title ?? r.url,
+        url: r.url,
+        content: r.description ?? '',
+      }));
+    }
+
+    return { provider: provider.id, query: params.query, results };
+  }
+
+  override async fetch(url: string, provider: ResolvedProvider): Promise<FetchResponse> {
+    if (!provider.apiKey) {
+      throw new Error(
+        'Firecrawl API key not configured. Set FIRECRAWL_API_KEY env var or configure in settings.json.',
+      );
+    }
+
+    const endpoint = `${provider.baseUrl.replace(/\/$/, '')}/v2/scrape`;
+    const body = { url, formats: ['markdown'], onlyMainContent: true };
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${provider.apiKey}`,
+      ...provider.headers,
+    };
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(provider.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`Firecrawl Scrape API error ${response.status}: ${text}`);
+    }
+
+    const data = (await response.json()) as {
+      success?: boolean;
+      error?: string;
+      data?: {
+        markdown?: string;
+        metadata?: { title?: string; sourceURL?: string };
+      };
+    };
+
+    if (data.success === false || !data.data) {
+      throw new Error(`Firecrawl Scrape failed: ${data.error ?? 'no content returned'}`);
+    }
+
+    const title = data.data.metadata?.title ?? url;
+    const sourceUrl = data.data.metadata?.sourceURL ?? url;
+    return { url: sourceUrl, title, content: data.data.markdown ?? '' };
+  }
+}

--- a/packages/pi-web-access/src/providers/index.ts
+++ b/packages/pi-web-access/src/providers/index.ts
@@ -2,6 +2,7 @@ import type { BuiltInProviderId } from '../types.js';
 import { AnthropicProvider } from './anthropic.js';
 import type { WebProvider } from './base.js';
 import { BraveProvider } from './brave.js';
+import { FirecrawlProvider } from './firecrawl.js';
 import { GeminiProvider } from './gemini.js';
 import { KimiProvider } from './kimi.js';
 import { MimoProvider } from './mimo.js';
@@ -27,6 +28,7 @@ export { BaseProvider, getEnvironmentContext, SEARCH_SYSTEM_PROMPT } from './bas
 const providers: WebProvider[] = [
   new TavilyProvider(),
   new BraveProvider(),
+  new FirecrawlProvider(),
   new KimiProvider(),
   new MimoProvider(),
   new ZaiProvider(),

--- a/packages/pi-web-access/src/types.ts
+++ b/packages/pi-web-access/src/types.ts
@@ -2,6 +2,7 @@
 export type BuiltInProviderId =
   | 'tavily'
   | 'brave'
+  | 'firecrawl'
   | 'kimi'
   | 'mimo'
   | 'zai'


### PR DESCRIPTION
## What

Adds [Firecrawl](https://docs.firecrawl.dev) as a `web_search` + `web_fetch` provider in `pi-web-access`, following the existing Tavily/Brave provider pattern.

## Changes

**Provider**
- `src/providers/firecrawl.ts` — `FirecrawlProvider`:
  - `search` → `POST /v2/search` — uses the `web`/`news` source groups, maps `timeRange` → Firecrawl `tbs` (`qdr:d/w/m/y`), `maxResults` → `limit`, and `include/excludeDomains`
  - `fetch` → `POST /v2/scrape` — `formats: ["markdown"]`, `onlyMainContent: true`, pulls title/sourceURL from `metadata`
- Registered in the provider registry and added to `ALL_SEARCH_PROVIDER_IDS`

**Wiring**
- `types.ts` — `'firecrawl'` added to `BuiltInProviderId`
- `config.ts` — base URL `https://api.firecrawl.dev`, env var `FIRECRAWL_API_KEY`
- `README.md` — provider table row (search ✓ / fetch ✓)

**Tests**
- Search: Bearer auth, `tbs`/`limit` mapping, news source, domain filters, HTTP error
- Scrape/fetch round-trip + HTTP error
- Config resolution (`resolveProvider` + `resolveFetchProvider`)

## CI

New Stage C matrix entry `pi-web-access-firecrawl` in `integration.yml` that drives `web_search` (`/v2/search`) then `web_fetch` (`/v2/scrape`) against the real Firecrawl API. Gated on the `FIRECRAWL_API_KEY` secret — skips cleanly with a warning until the secret is configured. The existing baidu `web_fetch` entry (fallback path) is untouched.

## Config example

```json
{
  "pi-web-access": {
    "search": { "provider": "firecrawl" },
    "fetch": { "provider": "firecrawl" },
    "providers": { "firecrawl": { "apiKey": "${FIRECRAWL_API_KEY}" } }
  }
}
```

## Notes

- Firecrawl slots in behind the existing generic `web_search`/`web_fetch` tools (same as Tavily/Brave), so no new dedicated tool/command was added.
- `pr-check` (lint + typecheck + 1043 tests + build) passes locally.