### PR TITLE
feat(pi-goal): add goal extension that works until a condition is met

### DIFF
--- a/.github/workflows/agentic-eval.yml
+++ b/.github/workflows/agentic-eval.yml
@@ -1,0 +1,223 @@
+name: Agentic Eval
+
+# Manual-only. Effect evaluation (task-completion rate) for the agentic
+# extensions — distinct from integration.yml, which is a pass/fail smoke test.
+# This runs each extension through the real `pi` CLI on a set of scored tasks and
+# reports successRate / failure mix, the same harness pattern as memory-eval.yml.
+#
+# - browser: pi-browser-use on a Linux runner with a real headless Chrome.
+# - computer: pi-computer-use — macOS + Accessibility/Screen Recording only; the
+#   runner skips gracefully elsewhere, and there is no hosted macOS runner wired
+#   here yet, so it is expected to no-op until one is added.
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Which eval to run
+        type: choice
+        default: browser
+        options: [browser, computer, both]
+      model:
+        description: Model (provider is deepseek-integration)
+        type: string
+        default: deepseek-v4-flash
+      thinking:
+        description: Thinking level
+        type: choice
+        default: high
+        options: [minimal, low, medium, high, xhigh]
+      tasks:
+        description: Limit to first N tasks (0 = all)
+        type: string
+        default: '0'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  browser-eval:
+    name: Browser eval (task completion)
+    if: inputs.target == 'browser' || inputs.target == 'both'
+    runs-on:
+      - instance-hnpsq9go
+      - linux
+      - x64
+    timeout-minutes: 60
+    env:
+      PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
+      PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pi build environment
+        uses: ./.github/actions/setup-pi-build
+        with:
+          install-pi-cli: 'true'
+          set-pi-agent-dir: 'true'
+
+      - name: Guard — require provider secrets
+        run: |
+          set -euo pipefail
+          if [ -z "${PI_INTEGRATION_BASE_URL}" ] || [ -z "${PI_INTEGRATION_API_KEY}" ]; then
+            echo "::error::PI_INTEGRATION_BASE_URL / PI_INTEGRATION_API_KEY not set — cannot run eval"
+            exit 1
+          fi
+
+      - name: Verify pi installation
+        run: pi --version
+
+      - name: Write eval models.json from secrets
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/eval"
+          # Same as memory-eval.yml: apiKey is written literally from the secret;
+          # the file lives under RUNNER_TEMP and is not uploaded.
+          cat > "$RUNNER_TEMP/eval/models.json" <<EOF
+          {
+            "providers": {
+              "deepseek-integration": {
+                "baseUrl": "${PI_INTEGRATION_BASE_URL}",
+                "api": "openai-completions",
+                "apiKey": "${PI_INTEGRATION_API_KEY}",
+                "models": [
+                  { "id": "${{ inputs.model }}", "name": "${{ inputs.model }}", "input": ["text"] }
+                ]
+              }
+            }
+          }
+          EOF
+          echo "MODELS_PATH=$RUNNER_TEMP/eval/models.json" >> "$GITHUB_ENV"
+
+      - name: Install Chromium
+        run: |
+          set -euo pipefail
+          # Same step integration.yml uses; npmmirror CDN avoids slow Google CDN.
+          npx -y @puppeteer/browsers install chrome@stable \
+            --path "$RUNNER_TEMP/chrome-install" \
+            --base-url https://cdn.npmmirror.com/binaries/chrome-for-testing
+          CHROME_BIN=$(find "$RUNNER_TEMP/chrome-install" -name "chrome" -type f | head -1)
+          if [ -z "$CHROME_BIN" ]; then
+            echo "::error::Could not find chrome binary after install"
+            exit 1
+          fi
+          "$CHROME_BIN" --version --no-sandbox || true
+          echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
+
+      - name: Eval — pi-browser-use
+        run: |
+          set -euo pipefail
+          pnpm --filter @amaster.ai/pi-eval eval:browser -- \
+            --provider deepseek-integration \
+            --model "${{ inputs.model }}" \
+            --thinking "${{ inputs.thinking }}" \
+            --tasks "${{ inputs.tasks }}" \
+            --models "$MODELS_PATH"
+
+      - name: Summarize
+        if: always()
+        run: |
+          set -euo pipefail
+          f=tests/eval/results/browser-tasks.json
+          [ -f "$f" ] || { echo "no results"; exit 0; }
+          {
+            echo "## Browser eval — task completion"
+            node -e '
+              const d = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+              const s = d.summary || {};
+              console.log("");
+              console.log(`- model: \`${s.model ?? "?"}\``);
+              console.log(`- successRate: **${(s.successRate ?? 0).toFixed(3)}** (${s.nChecked ?? 0} checked / ${s.n ?? 0} tasks)`);
+              console.log(`- avgTurns (to success): ${(s.avgTurns ?? 0).toFixed(1)}`);
+              console.log(`- avgToolCalls: ${(s.avgToolCalls ?? 0).toFixed(1)}`);
+              console.log(`- failureMix: \`${JSON.stringify(s.failureMix ?? {})}\``);
+              console.log("");
+              console.log("| task | success | mode | turns | tools |");
+              console.log("|------|:-------:|------|------:|------:|");
+              for (const r of d.rows ?? []) {
+                console.log(`| ${r.task} | ${r.success ? "✅" : "❌"} | ${r.failureMode} | ${r.turns} | ${r.toolCalls} |`);
+              }
+            ' "$f"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: browser-eval-results
+          path: tests/eval/results/browser-tasks.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  computer-eval:
+    name: Computer eval (task completion, macOS)
+    if: inputs.target == 'computer' || inputs.target == 'both'
+    # No hosted macOS runner is wired here yet. When one is available, point
+    # runs-on at it (the runner needs Accessibility + Screen Recording grants).
+    # Until then this job is a placeholder that documents the requirement; the
+    # runner itself skips gracefully on non-macOS, so a Linux fallback no-ops.
+    runs-on:
+      - instance-hnpsq9go
+      - linux
+      - x64
+    timeout-minutes: 60
+    env:
+      PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
+      PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pi build environment
+        uses: ./.github/actions/setup-pi-build
+        with:
+          install-pi-cli: 'true'
+          set-pi-agent-dir: 'true'
+
+      - name: Write eval models.json from secrets
+        if: env.PI_INTEGRATION_BASE_URL != ''
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/eval"
+          cat > "$RUNNER_TEMP/eval/models.json" <<EOF
+          {
+            "providers": {
+              "deepseek-integration": {
+                "baseUrl": "${PI_INTEGRATION_BASE_URL}",
+                "api": "openai-completions",
+                "apiKey": "${PI_INTEGRATION_API_KEY}",
+                "models": [
+                  { "id": "${{ inputs.model }}", "name": "${{ inputs.model }}", "input": ["text"] }
+                ]
+              }
+            }
+          }
+          EOF
+          echo "MODELS_PATH=$RUNNER_TEMP/eval/models.json" >> "$GITHUB_ENV"
+
+      - name: Eval — pi-computer-use (macOS only; skips elsewhere)
+        run: |
+          set -euo pipefail
+          # On a non-macOS runner run-computer.ts writes {skipped:true} and exits 0.
+          pnpm --filter @amaster.ai/pi-eval eval:computer -- \
+            --provider deepseek-integration \
+            --model "${{ inputs.model }}" \
+            --thinking "${{ inputs.thinking }}" \
+            --tasks "${{ inputs.tasks }}" \
+            --models "${MODELS_PATH:-}"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: computer-eval-results
+          path: tests/eval/results/computer-tasks.json
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -227,13 +227,13 @@ jobs:
             assert_pattern: "(0|task|tasks|empty|none)"
           # pi-goal registers no LLM tool — it is driven by the /goal command
           # (TUI) or the --goal flag (CLI). Print mode can't dispatch slash
-          # commands, so this entry uses `goal_flag` to pass a startup
-          # condition via `--goal`. The extension sets the goal and injects an
-          # activation message; the assistant acknowledges the condition, which
-          # the assert pattern matches. maxIterations=1 in settings bounds the
-          # continuation loop so CI can't spin.
+          # commands and won't run an agent turn without a prompt, so this entry
+          # uses `--goal '' -p <prompt>`: the prompt drives one real agent run
+          # (whose reply we assert on) and, at before_agent_start, pi-goal
+          # derives a goal from that same prompt. maxIterations=1 in settings
+          # bounds the continuation loop so CI can't spin.
           - extension: pi-goal
-            goal_flag: "reply with the exact token ci-goal-ok and nothing else"
+            prompt: "Reply with exactly the token ci-goal-ok and nothing else."
             assert_pattern: "ci-goal-ok"
           - extension: pi-teamwork
             tools: workspace_list
@@ -532,8 +532,10 @@ jobs:
           # observed to occasionally hang >5min on tool-call prompts. Stage B
           # smoke keeps xhigh per the original spec.
           if [ "${{ matrix.extension }}" = "pi-goal" ]; then
-            # pi-goal has no LLM tool and no prompt: --goal sets the goal at
-            # startup, whose activation message triggers a turn. No -p / --tools.
+            # pi-goal has no LLM tool. --goal '' enables auto-derivation; -p
+            # drives one real agent run (print mode won't run a turn without a
+            # prompt). pi-goal derives the goal from the prompt at
+            # before_agent_start; we assert on the assistant's reply.
             output="$(pi \
               --provider deepseek-integration \
               --model deepseek-v4-flash \
@@ -541,7 +543,8 @@ jobs:
               --no-session \
               --no-context-files \
               --mode json \
-              --goal '${{ matrix.goal_flag }}' 2>&1)"
+              --goal '' \
+              -p '${{ matrix.prompt }}' 2>&1)"
             rc=$?
           else
             output="$(pi \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -225,6 +225,16 @@ jobs:
             tools: scheduler_list
             prompt: "Use the scheduler_list tool exactly once to list scheduled tasks, then tell me how many tasks there are."
             assert_pattern: "(0|task|tasks|empty|none)"
+          # pi-goal registers no LLM tool — it is driven by the /goal command
+          # (TUI) or the --goal flag (CLI). Print mode can't dispatch slash
+          # commands, so this entry uses `goal_flag` to pass a startup
+          # condition via `--goal`. The extension sets the goal and injects an
+          # activation message; the assistant acknowledges the condition, which
+          # the assert pattern matches. maxIterations=1 in settings bounds the
+          # continuation loop so CI can't spin.
+          - extension: pi-goal
+            goal_flag: "reply with the exact token ci-goal-ok and nothing else"
+            assert_pattern: "ci-goal-ok"
           - extension: pi-teamwork
             tools: workspace_list
             prompt: "Use workspace_list to fetch teamwork workspaces, then tell me the names of the workspaces. Call the tool exactly once."
@@ -396,6 +406,14 @@ jobs:
             "pi-scheduler": {
               "dataDir": "${RUNNER_TEMP}/pi-scheduler"
             },
+            "pi-goal": {
+              "model": {
+                "provider": "deepseek-integration",
+                "model": "deepseek-v4-flash"
+              },
+              "maxIterations": 1,
+              "requireConfirmForDerived": false
+            },
             "pi-memory-mem0": {
               "mode": "open-source",
               "userId": "ci-integration",
@@ -513,15 +531,28 @@ jobs:
           # `reasoning_effort: max`, which on the amaster gateway has been
           # observed to occasionally hang >5min on tool-call prompts. Stage B
           # smoke keeps xhigh per the original spec.
-          output="$(pi \
-            --provider deepseek-integration \
-            --model deepseek-v4-flash \
-            --thinking high \
-            --no-session \
-            --no-context-files \
-            --tools '${{ matrix.tools }}' \
-            --mode json \
-            -p '${{ matrix.prompt }}' 2>&1)"
+          if [ "${{ matrix.extension }}" = "pi-goal" ]; then
+            # pi-goal has no LLM tool and no prompt: --goal sets the goal at
+            # startup, whose activation message triggers a turn. No -p / --tools.
+            output="$(pi \
+              --provider deepseek-integration \
+              --model deepseek-v4-flash \
+              --thinking high \
+              --no-session \
+              --no-context-files \
+              --mode json \
+              --goal '${{ matrix.goal_flag }}' 2>&1)"
+          else
+            output="$(pi \
+              --provider deepseek-integration \
+              --model deepseek-v4-flash \
+              --thinking high \
+              --no-session \
+              --no-context-files \
+              --tools '${{ matrix.tools }}' \
+              --mode json \
+              -p '${{ matrix.prompt }}' 2>&1)"
+          fi
           rc=$?
           set -e
           echo "--- raw event stream (${{ matrix.extension }}, exit=$rc) ---"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -542,6 +542,7 @@ jobs:
               --no-context-files \
               --mode json \
               --goal '${{ matrix.goal_flag }}' 2>&1)"
+            rc=$?
           else
             output="$(pi \
               --provider deepseek-integration \
@@ -552,8 +553,8 @@ jobs:
               --tools '${{ matrix.tools }}' \
               --mode json \
               -p '${{ matrix.prompt }}' 2>&1)"
+            rc=$?
           fi
-          rc=$?
           set -e
           echo "--- raw event stream (${{ matrix.extension }}, exit=$rc) ---"
           echo "$output"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -228,14 +228,17 @@ jobs:
           # pi-goal registers no LLM tool — it is driven by the /goal command
           # (TUI) or the --goal flag (CLI). Print mode can't dispatch slash
           # commands and won't run an agent turn without a prompt, so this entry
-          # uses `--goal '' -p <prompt>`: the prompt drives one real agent run
-          # (whose reply we assert on) and, at before_agent_start, pi-goal
-          # derives a goal from that same prompt. The prompt states a concrete
-          # objective (a bare format instruction derives to NONE), with a
-          # completion marker we assert on. maxIterations=1 bounds continuation.
+          # uses `--goal '' -p <prompt>` with a plain, real task (write a file).
+          # pi-goal derives a goal from that task at before_agent_start and
+          # evaluates it at agent_end — the task itself has nothing to do with
+          # "goal". We assert the engine's stderr diagnostics ran AND the file
+          # was actually written (a filesystem check can't be self-matched by
+          # prompt/thinking echo the way a text token can). maxIterations=1
+          # bounds continuation. `write` tool only, for predictability.
           - extension: pi-goal
-            prompt: "Task: confirm the CI health check succeeded. When the check is confirmed, print the exact token ci-goal-ok on its own line. The task is complete once that token has been printed."
-            assert_pattern: "ci-goal-ok"
+            tools: write
+            prompt: "Create a file at /tmp/pi-goal-ci.txt containing exactly the line: integration test complete"
+            assert_pattern: "integration test complete"
           - extension: pi-teamwork
             tools: workspace_list
             prompt: "Use workspace_list to fetch teamwork workspaces, then tell me the names of the workspaces. Call the tool exactly once."
@@ -535,14 +538,16 @@ jobs:
           if [ "${{ matrix.extension }}" = "pi-goal" ]; then
             # pi-goal has no LLM tool. --goal '' enables auto-derivation; -p
             # drives one real agent run (print mode won't run a turn without a
-            # prompt). pi-goal derives the goal from the prompt at
-            # before_agent_start; we assert on the assistant's reply.
+            # prompt). The task is a plain file write; pi-goal derives a goal
+            # from it at before_agent_start and evaluates at agent_end. Restrict
+            # to the write tool for predictability.
             output="$(pi \
               --provider deepseek-integration \
               --model deepseek-v4-flash \
               --thinking high \
               --no-session \
               --no-context-files \
+              --tools '${{ matrix.tools }}' \
               --mode json \
               --goal '' \
               -p '${{ matrix.prompt }}' 2>&1)"
@@ -603,18 +608,24 @@ jobs:
           # pattern still matches when the assistant doesn't quote them back.
           HAYSTACK="${ASSISTANT_TEXT:-$output}"
           [ -z "$HAYSTACK" ] && HAYSTACK="$output"
-          if ! grep -qiE '${{ matrix.assert_pattern }}' <<<"$HAYSTACK"; then
-            echo "::error::Expected pattern '${{ matrix.assert_pattern }}' not found in ${{ matrix.extension }} output"
-            exit 1
+          # pi-goal is asserted below by the goal engine's diagnostics and a
+          # filesystem check, not by grepping assistant text (which would be
+          # self-matched by prompt/thinking echo). Skip the generic assert here.
+          if [ "${{ matrix.extension }}" != "pi-goal" ]; then
+            if ! grep -qiE '${{ matrix.assert_pattern }}' <<<"$HAYSTACK"; then
+              echo "::error::Expected pattern '${{ matrix.assert_pattern }}' not found in ${{ matrix.extension }} output"
+              exit 1
+            fi
           fi
 
-          # pi-goal: the generic assert above only proves the assistant echoed
-          # the token the prompt asked for — it does not prove the goal engine
-          # ran. Assert the engine's stderr diagnostics (merged via 2>&1) show
-          # it derived a condition. Derivation happens at before_agent_start, so
-          # it always completes before the run ends — a hard gate. Evaluation
-          # runs in the async agent_end handler, which print mode may not await
-          # before exit, so it is a soft check (warn only).
+          # pi-goal: prove the goal engine actually ran and the task completed.
+          #   1. [pi-goal] derived condition:  — derivation ran (hard gate;
+          #      happens at before_agent_start, always before the run ends).
+          #   2. [pi-goal] evaluation:         — evaluation ran (soft; the
+          #      agent_end handler is async and print mode may exit first).
+          #   3. the file the task asked for exists with the expected line —
+          #      the real proof of completion. A filesystem check can't be
+          #      self-matched by prompt/thinking echo the way a text token can.
           if [ "${{ matrix.extension }}" = "pi-goal" ]; then
             echo "--- pi-goal engine diagnostics ---"
             grep -E '\[pi-goal\] (derived condition|evaluation):' <<<"$output" || true
@@ -625,6 +636,14 @@ jobs:
             if ! grep -qE '\[pi-goal\] evaluation: ok=' <<<"$output"; then
               echo "::warning::pi-goal: no 'evaluation' line — agent_end evaluation may not have completed before print-mode exit."
             fi
+            GOAL_FILE=/tmp/pi-goal-ci.txt
+            if [ ! -f "$GOAL_FILE" ] || ! grep -qiE '${{ matrix.assert_pattern }}' "$GOAL_FILE"; then
+              echo "::error::pi-goal: $GOAL_FILE missing or missing expected line — the task the goal was derived from did not complete."
+              rm -f "$GOAL_FILE"
+              exit 1
+            fi
+            echo "✓ pi-goal wrote $GOAL_FILE and the goal engine derived+evaluated a condition."
+            rm -f "$GOAL_FILE"
           fi
 
       - name: Verify pi-memory-mem0 captured turn (memory job only)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -230,10 +230,11 @@ jobs:
           # commands and won't run an agent turn without a prompt, so this entry
           # uses `--goal '' -p <prompt>`: the prompt drives one real agent run
           # (whose reply we assert on) and, at before_agent_start, pi-goal
-          # derives a goal from that same prompt. maxIterations=1 in settings
-          # bounds the continuation loop so CI can't spin.
+          # derives a goal from that same prompt. The prompt states a concrete
+          # objective (a bare format instruction derives to NONE), with a
+          # completion marker we assert on. maxIterations=1 bounds continuation.
           - extension: pi-goal
-            prompt: "Reply with exactly the token ci-goal-ok and nothing else."
+            prompt: "Task: confirm the CI health check succeeded. When the check is confirmed, print the exact token ci-goal-ok on its own line. The task is complete once that token has been printed."
             assert_pattern: "ci-goal-ok"
           - extension: pi-teamwork
             tools: workspace_list

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -607,6 +607,25 @@ jobs:
             exit 1
           fi
 
+          # pi-goal: the generic assert above only proves the assistant echoed
+          # the token the prompt asked for — it does not prove the goal engine
+          # ran. Assert the engine's stderr diagnostics (merged via 2>&1) show
+          # it derived a condition. Derivation happens at before_agent_start, so
+          # it always completes before the run ends — a hard gate. Evaluation
+          # runs in the async agent_end handler, which print mode may not await
+          # before exit, so it is a soft check (warn only).
+          if [ "${{ matrix.extension }}" = "pi-goal" ]; then
+            echo "--- pi-goal engine diagnostics ---"
+            grep -E '\[pi-goal\] (derived condition|evaluation):' <<<"$output" || true
+            if ! grep -qE '\[pi-goal\] derived condition:' <<<"$output"; then
+              echo "::error::pi-goal: no 'derived condition' in output — auto-derivation did not run."
+              exit 1
+            fi
+            if ! grep -qE '\[pi-goal\] evaluation: ok=' <<<"$output"; then
+              echo "::warning::pi-goal: no 'evaluation' line — agent_end evaluation may not have completed before print-mode exit."
+            fi
+          fi
+
       - name: Verify pi-memory-mem0 captured turn (memory job only)
         if: matrix.extension == 'pi-memory' && env.PI_INTEGRATION_BASE_URL != ''
         run: |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ product-specific UI.
 | Extension | `@amaster.ai/pi-attachments` | Attachment normalization, local/remote upload handling, document parsing, and model-readable attachment prompts. |
 | Extension | `@amaster.ai/pi-telemetry` | Runtime telemetry with Langfuse and OpenTelemetry exporters. |
 | Extension | `@amaster.ai/pi-task-scheduler` | Cron-based scheduled task management with LLM-callable tools. |
+| Extension | `@amaster.ai/pi-goal` | Derives a goal from the conversation and keeps the agent working until the condition is met, with iteration/token backstops. |
 | Extension | `@amaster.ai/pi-browser-use` | Browser automation wrapping chrome-devtools-mcp with `browser_`-prefixed tools. |
 | Extension | `@amaster.ai/pi-web-access` | Web search and URL content extraction across configurable providers. |
 | Extension | `@amaster.ai/pi-computer-use` | Computer-use extension for CUA computer-server with desktop automation tools. |

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -37,7 +37,7 @@ session_start                                 ← session-level, once
   │    message_end      { message (user) }
   │    message_start    { message (assistant) }
   │    message_end      { message (assistant) }
-  │    turn_end         { turnIndex, message, toolResults }  ← pi-goal buffers messages here
+  │    turn_end         { turnIndex, message, toolResults }
   │
   agent_end           { messages: [...] }       ← engine evaluates + stops/continues, once per prompt
   │   If a goal is active: build a transcript from `messages`, ask the
@@ -56,10 +56,12 @@ Events pi-goal uses:
 | Event | What pi-goal does | Notes |
 |-------|-------------------|-------|
 | `session_start` | Load config; read the `--goal` flag | Session-level, fires once |
-| `before_agent_start` | If a `--goal` derivation is pending, derive the condition from `event.prompt` (this turn's user input) + buffered transcript, then set + activate the goal | Fires once per prompt; the right anchor for auto-derivation since no transcript exists yet at `session_start` |
-| `turn_end` | Buffer `event.message` into the rolling transcript | Feeds derive/evaluate |
-| `agent_end` | If a goal is active, run the engine: evaluate → mark achieved/impossible or `sendUserMessage` to continue | Engine core |
-| `session_shutdown` | Clear the goal and the buffered transcript | Cleanup |
+| `before_agent_start` | If a `--goal` derivation is pending, derive the condition from `event.prompt` (this turn's user input), then set the goal | Fires once per prompt; the right anchor for auto-derivation since no transcript exists yet at `session_start` |
+| `agent_end` | If a goal is active, run the engine on `event.messages`: evaluate → mark achieved/impossible or `sendUserMessage` to continue | Engine core. `event.messages` is the full conversation, so no separate buffering is needed |
+| `session_shutdown` | Clear the goal | Cleanup |
+
+The interactive `/goal` command (no argument) derives from the session's own
+history, read via `ctx.sessionManager` — not a buffer this extension maintains.
 
 Note on derivation timing: a condition can only be derived once there is
 conversation to derive from. `session_start` is too early (no transcript

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -54,6 +54,7 @@ Prefer a small, cheap model for `model` — the evaluator runs after every agent
 ## Relationship to Claude Code / Codex
 
 - **Engine (from Claude Code):** goal = a stop condition; Pi keeps going until an evaluator judges it met. Passive — it drives continuation off `agent_end`, not a background scheduler.
-- **Auto-derivation:** you don't have to phrase the condition; it's inferred and confirmed.
+- **Prompts (from Claude Code):** the evaluator and activation prompts are adapted almost verbatim from Claude Code's own stop-hook prompts — including the quote-the-evidence requirement, the "insufficient evidence in transcript" fallback, the impossible-judgment discipline (the assistant's claim is *evidence, not proof*), and the truncated-transcript note.
+- **Auto-derivation:** you don't have to phrase the condition; it's inferred and confirmed. (No CC analogue — CC always takes an explicit condition.)
 - **Budget backstop (from Codex):** token + iteration limits prevent runaway loops.
 - **Not included:** Codex's idle auto-resume, pause/resume dialogs, file-backed objectives, and cross-session persistence.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -1,0 +1,59 @@
+# @amaster.ai/pi-goal
+
+A Pi extension that lets Pi **keep working until a goal is met**. You don't have to write the completion condition yourself — run `/goal` with no argument and the extension derives a measurable condition from the conversation, shows it to you for a quick confirmation, then keeps the agent working (re-checking after each run) until the condition holds.
+
+Modeled on Claude Code's stop-condition mechanism, with a token/iteration budget backstop borrowed from Codex's goal mode.
+
+## How it works
+
+1. **Set a goal.** Either give an explicit condition (`/goal all tests pass and lint is clean`) or let the extension derive one from the conversation (`/goal` with no argument).
+2. **Derived goals are confirmed** in interactive (TUI) mode before they start, so a mis-derived goal can't run off on its own. Non-interactive modes skip the confirmation.
+3. **After each agent run** (`agent_end`), a small evaluator model judges whether the condition is met:
+   - **Met** → the goal is marked achieved and cleared. Pi stops.
+   - **Not yet** → Pi is nudged to continue, told what still remains.
+   - **Impossible** → Pi stops and tells you why.
+4. **Backstops.** Continuation stops after `maxIterations` rounds or once an optional `tokenBudget` is exceeded, so a bad goal can't loop forever.
+
+Goal state is session-scoped and held in memory (no cross-session persistence), matching Claude Code's behavior.
+
+## Usage
+
+```
+/goal <condition>   Set an explicit completion condition.
+/goal               No active goal → derive one from the conversation (with confirmation).
+                    Active goal → show its status.
+/goal clear         Clear the active goal (also: stop, off, reset, none, cancel).
+```
+
+## Configuration
+
+Settings key: `pi-goal` (in `~/.pi/agent/settings.json`, agent dir, or project `.pi/settings.json`).
+
+```json
+{
+  "pi-goal": {
+    "model": { "provider": "anthropic", "model": "claude-haiku-4-5-20251001" },
+    "maxIterations": 10,
+    "tokenBudget": 200000,
+    "transcriptMaxChars": 8000,
+    "requireConfirmForDerived": true
+  }
+}
+```
+
+| Key | Default | Purpose |
+|-----|---------|---------|
+| `model` | — | Provider/model for deriving and evaluating conditions. **Omit to disable the automatic engine** — `/goal <condition>` still sets a goal, but nothing auto-derives or auto-continues. |
+| `maxIterations` | `10` | Max continuation rounds before Pi stops pushing. |
+| `tokenBudget` | — | Optional hard token ceiling; the goal is paused (`budget_limited`) once exceeded. |
+| `transcriptMaxChars` | `8000` | Max transcript chars fed to derive/evaluate. |
+| `requireConfirmForDerived` | `true` | Ask before starting a derived goal (TUI only). |
+
+Prefer a small, cheap model for `model` — the evaluator runs after every agent run.
+
+## Relationship to Claude Code / Codex
+
+- **Engine (from Claude Code):** goal = a stop condition; Pi keeps going until an evaluator judges it met. Passive — it drives continuation off `agent_end`, not a background scheduler.
+- **Auto-derivation:** you don't have to phrase the condition; it's inferred and confirmed.
+- **Budget backstop (from Codex):** token + iteration limits prevent runaway loops.
+- **Not included:** Codex's idle auto-resume, pause/resume dialogs, file-backed objectives, and cross-session persistence.

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -16,6 +16,56 @@ Modeled on Claude Code's stop-condition mechanism, with a token/iteration budget
 
 Goal state is session-scoped and held in memory (no cross-session persistence), matching Claude Code's behavior.
 
+## Pi lifecycle (how the engine hooks in)
+
+The goal engine is driven by Pi's lifecycle events. For one `pi -p '<prompt>'`
+run (non-interactive), events fire in this order:
+
+```
+session_start                                 ← session-level, once
+  │   pi-goal: load config, read the --goal flag
+  ▼
+[ per user prompt — the "agent-level" block below repeats ]
+  │
+  before_agent_start  { prompt, systemPrompt } ← carries the user's input for this turn, once per prompt
+  │
+  agent_start         { }
+  │
+  ├─ [ per turn, may repeat ]
+  │    turn_start       { turnIndex }
+  │    message_start    { message (user) }
+  │    message_end      { message (user) }
+  │    message_start    { message (assistant) }
+  │    message_end      { message (assistant) }
+  │    turn_end         { turnIndex, message, toolResults }  ← pi-goal buffers messages here
+  │
+  agent_end           { messages: [...] }       ← engine evaluates + stops/continues, once per prompt
+  │   If a goal is active: build a transcript from `messages`, ask the
+  │   evaluator ok / impossible / not-yet. Not-yet → sendUserMessage(continue)
+  │   → triggers a new agent run (back to before_agent_start).
+  │
+  agent_settled       { }                        ← this prompt is fully done
+  ▼
+[ interactive: wait for next input · print mode: process exits here ]
+
+session_shutdown                               ← on exit/switch; pi-goal clears state
+```
+
+Events pi-goal uses:
+
+| Event | What pi-goal does | Notes |
+|-------|-------------------|-------|
+| `session_start` | Load config; read the `--goal` flag | Session-level, fires once |
+| `before_agent_start` | If a `--goal` derivation is pending, derive the condition from `event.prompt` (this turn's user input) + buffered transcript, then set + activate the goal | Fires once per prompt; the right anchor for auto-derivation since no transcript exists yet at `session_start` |
+| `turn_end` | Buffer `event.message` into the rolling transcript | Feeds derive/evaluate |
+| `agent_end` | If a goal is active, run the engine: evaluate → mark achieved/impossible or `sendUserMessage` to continue | Engine core |
+| `session_shutdown` | Clear the goal and the buffered transcript | Cleanup |
+
+Note on derivation timing: a condition can only be derived once there is
+conversation to derive from. `session_start` is too early (no transcript
+yet); `before_agent_start` is the first point that carries the user's prompt
+for the turn, so auto-derivation keys off it rather than firing at startup.
+
 ## Usage
 
 ```
@@ -23,6 +73,14 @@ Goal state is session-scoped and held in memory (no cross-session persistence), 
 /goal               No active goal → derive one from the conversation (with confirmation).
                     Active goal → show its status.
 /goal clear         Clear the active goal (also: stop, off, reset, none, cancel).
+```
+
+The slash command is for interactive (TUI) use; print mode can't dispatch it.
+For the CLI / non-interactive runs, use the `--goal` flag instead:
+
+```
+pi --goal '<condition>' -p '<prompt>'   Set an explicit goal, then run the prompt.
+pi --goal '' -p '<prompt>'              Derive the goal from the prompt (at before_agent_start).
 ```
 
 ## Configuration

--- a/packages/pi-goal/package.json
+++ b/packages/pi-goal/package.json
@@ -1,0 +1,78 @@
+{
+  "name": "@amaster.ai/pi-goal",
+  "version": "0.1.0-beta.0",
+  "description": "Pi extension that derives a goal from the conversation and keeps the agent working until the condition is met",
+  "keywords": ["pi-package", "pi", "extension", "goal", "autonomous", "stop-condition"],
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./extension": {
+      "types": "./dist/extension.d.ts",
+      "default": "./dist/extension.js"
+    },
+    "./package.json": {
+      "default": "./package.json"
+    }
+  },
+  "pi": {
+    "image": "https://raw.githubusercontent.com/TGYD-helige/pi/master/packages/pi-goal/preview.png",
+    "extensions": [
+      "./dist/index.js"
+    ]
+  },
+  "files": [
+    "dist",
+    "preview.png",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TGYD-helige/pi.git",
+    "directory": "packages/pi-goal"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@amaster.ai/pi-shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-agent-core": ">=0.74.0",
+    "@earendil-works/pi-ai": ">=0.80.3",
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-agent-core": {
+      "optional": true
+    },
+    "@earendil-works/pi-ai": {
+      "optional": true
+    },
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@earendil-works/pi-agent-core": "0.80.3",
+    "@earendil-works/pi-ai": "0.80.3",
+    "@earendil-works/pi-coding-agent": "0.80.3",
+    "typebox": "*",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/pi-goal/src/__tests__/config.test.ts
+++ b/packages/pi-goal/src/__tests__/config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULTS, resolveConfig } from '../config.js';
+
+describe('resolveConfig', () => {
+  it('applies defaults when nothing is provided', () => {
+    const config = resolveConfig();
+    expect(config.maxIterations).toBe(DEFAULTS.maxIterations);
+    expect(config.transcriptMaxChars).toBe(DEFAULTS.transcriptMaxChars);
+    expect(config.requireConfirmForDerived).toBe(true);
+    expect(config.model).toBeUndefined();
+    expect(config.tokenBudget).toBeUndefined();
+  });
+
+  it('accepts a valid model', () => {
+    const config = resolveConfig({ model: { provider: 'anthropic', model: 'haiku' } });
+    expect(config.model).toEqual({ provider: 'anthropic', model: 'haiku' });
+  });
+
+  it('drops an invalid/partial model (degrades to disabled engine)', () => {
+    expect(resolveConfig({ model: { provider: '', model: 'x' } }).model).toBeUndefined();
+    expect(resolveConfig({ model: { provider: 'p' } as never }).model).toBeUndefined();
+  });
+
+  it('sanitizes positive integers and ignores non-positive values', () => {
+    expect(resolveConfig({ maxIterations: 3.9 }).maxIterations).toBe(3);
+    expect(resolveConfig({ maxIterations: 0 }).maxIterations).toBe(DEFAULTS.maxIterations);
+    expect(resolveConfig({ maxIterations: -5 }).maxIterations).toBe(DEFAULTS.maxIterations);
+    expect(resolveConfig({ transcriptMaxChars: 100 }).transcriptMaxChars).toBe(100);
+  });
+
+  it('keeps a positive tokenBudget and drops invalid ones', () => {
+    expect(resolveConfig({ tokenBudget: 5000 }).tokenBudget).toBe(5000);
+    expect(resolveConfig({ tokenBudget: 0 }).tokenBudget).toBeUndefined();
+    expect(resolveConfig({ tokenBudget: -1 }).tokenBudget).toBeUndefined();
+  });
+
+  it('honors requireConfirmForDerived override', () => {
+    expect(resolveConfig({ requireConfirmForDerived: false }).requireConfirmForDerived).toBe(false);
+  });
+});

--- a/packages/pi-goal/src/__tests__/derive.test.ts
+++ b/packages/pi-goal/src/__tests__/derive.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the LLM layer so derive is tested without a live model / real Agent.
+const completeOnce = vi.fn();
+vi.mock('../llm.js', () => ({ completeOnce: (...args: unknown[]) => completeOnce(...args) }));
+
+import { deriveCondition } from '../derive.js';
+import type { GoalModelRegistry } from '../llm.js';
+
+const registry: GoalModelRegistry = {
+  find: () => ({}),
+  getApiKeyAndHeaders: async () => ({ ok: true }),
+};
+const modelConfig = { provider: 'p', model: 'm' };
+
+describe('deriveCondition', () => {
+  beforeEach(() => {
+    completeOnce.mockReset();
+  });
+
+  it('returns a normalized one-line condition', async () => {
+    completeOnce.mockResolvedValue('  All unit tests pass and lint is clean  ');
+    const result = await deriveCondition({ registry, modelConfig, transcript: 'work' });
+    expect(result).toBe('All unit tests pass and lint is clean');
+  });
+
+  it('strips wrapping quotes/backticks and takes the first line', () => {
+    completeOnce.mockResolvedValue('"The build succeeds"\nextra chatter');
+    return deriveCondition({ registry, modelConfig, transcript: 'work' }).then((r) =>
+      expect(r).toBe('The build succeeds'),
+    );
+  });
+
+  it('returns null when the model says NONE', async () => {
+    completeOnce.mockResolvedValue('NONE');
+    expect(await deriveCondition({ registry, modelConfig, transcript: 'work' })).toBeNull();
+  });
+
+  it('returns null when the model call fails', async () => {
+    completeOnce.mockResolvedValue(null);
+    expect(await deriveCondition({ registry, modelConfig, transcript: 'work' })).toBeNull();
+  });
+
+  it('returns null (and skips the model) for an empty transcript', async () => {
+    expect(await deriveCondition({ registry, modelConfig, transcript: '   ' })).toBeNull();
+    expect(completeOnce).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pi-goal/src/__tests__/derive.test.ts
+++ b/packages/pi-goal/src/__tests__/derive.test.ts
@@ -24,6 +24,16 @@ describe('deriveCondition', () => {
     expect(result).toBe('All unit tests pass and lint is clean');
   });
 
+  it('logs the derived condition to stderr', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    completeOnce.mockResolvedValue('All tests pass');
+    await deriveCondition({ registry, modelConfig, transcript: 'work' });
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('[pi-goal] derived condition: All tests pass'),
+    );
+    spy.mockRestore();
+  });
+
   it('strips wrapping quotes/backticks and takes the first line', () => {
     completeOnce.mockResolvedValue('"The build succeeds"\nextra chatter');
     return deriveCondition({ registry, modelConfig, transcript: 'work' }).then((r) =>

--- a/packages/pi-goal/src/__tests__/engine.test.ts
+++ b/packages/pi-goal/src/__tests__/engine.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock evaluate so the engine gets deterministic verdicts (no live model).
+const evaluateCondition = vi.fn();
+vi.mock('../evaluate.js', () => ({
+  evaluateCondition: (...args: unknown[]) => evaluateCondition(...args),
+}));
+
+import { type ResolvedGoalConfig, resolveConfig } from '../config.js';
+import { type GoalEngineDeps, runGoalEngine } from '../extension.js';
+import { GoalState } from '../goal-state.js';
+import type { GoalModelRegistry } from '../llm.js';
+
+const registry: GoalModelRegistry = {
+  find: () => ({}),
+  getApiKeyAndHeaders: async () => ({ ok: true }),
+};
+
+function makeDeps(
+  state: GoalState,
+  configOverrides: Partial<ResolvedGoalConfig> = {},
+  disableModel = false,
+): GoalEngineDeps & {
+  sendUserMessage: ReturnType<typeof vi.fn>;
+  notify: ReturnType<typeof vi.fn>;
+} {
+  const config: ResolvedGoalConfig = {
+    ...resolveConfig({ model: { provider: 'p', model: 'm' } }),
+    ...configOverrides,
+  };
+  if (disableModel) {
+    delete config.model;
+  }
+  const sendUserMessage = vi.fn();
+  const notify = vi.fn();
+  return {
+    state,
+    config,
+    registry,
+    sendUserMessage,
+    notify,
+    setStatus: vi.fn(),
+    // deterministic token estimate
+    estimateTokens: () => 100,
+  };
+}
+
+const messages = [
+  { role: 'user', content: 'fix the bug' },
+  { role: 'assistant', content: 'done' },
+];
+
+describe('runGoalEngine', () => {
+  beforeEach(() => {
+    evaluateCondition.mockReset();
+  });
+
+  it('skips when there is no active goal', async () => {
+    const state = new GoalState();
+    const deps = makeDeps(state);
+    expect(await runGoalEngine(deps, messages)).toBe('skipped');
+    expect(evaluateCondition).not.toHaveBeenCalled();
+  });
+
+  it('skips when no model is configured (engine disabled)', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    const deps = makeDeps(state, {}, true);
+    expect(await runGoalEngine(deps, messages)).toBe('skipped');
+    expect(evaluateCondition).not.toHaveBeenCalled();
+  });
+
+  it('marks achieved and does not continue', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    const deps = makeDeps(state);
+    evaluateCondition.mockResolvedValue({ ok: true, impossible: false, reason: 'all green' });
+
+    expect(await runGoalEngine(deps, messages)).toBe('achieved');
+    expect(state.get()?.status).toBe('achieved');
+    expect(deps.sendUserMessage).not.toHaveBeenCalled();
+    expect(deps.notify).toHaveBeenCalledWith(expect.stringMatching(/achieved/i), 'info');
+  });
+
+  it('marks impossible and does not continue', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    const deps = makeDeps(state);
+    evaluateCondition.mockResolvedValue({ ok: false, impossible: true, reason: 'cannot' });
+
+    expect(await runGoalEngine(deps, messages)).toBe('impossible');
+    expect(state.get()?.status).toBe('impossible');
+    expect(deps.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('injects a continuation message with the reason when not yet met', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    const deps = makeDeps(state);
+    evaluateCondition.mockResolvedValue({
+      ok: false,
+      impossible: false,
+      reason: '2 tests failing',
+    });
+
+    expect(await runGoalEngine(deps, messages)).toBe('continued');
+    expect(state.get()?.iterations).toBe(1);
+    expect(state.get()?.lastReason).toBe('2 tests failing');
+    expect(deps.sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(deps.sendUserMessage.mock.calls[0]?.[0]).toContain('2 tests failing');
+  });
+
+  it('stops at the iteration limit instead of continuing', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    const deps = makeDeps(state, { maxIterations: 1 });
+    evaluateCondition.mockResolvedValue({ ok: false, impossible: false, reason: 'still failing' });
+
+    expect(await runGoalEngine(deps, messages)).toBe('iteration_limited');
+    expect(state.get()?.status).toBe('iteration_limited');
+    expect(deps.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('stops when the token budget is reached', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived', { tokenBudget: 50 });
+    const deps = makeDeps(state, { tokenBudget: 50 });
+    evaluateCondition.mockResolvedValue({ ok: false, impossible: false, reason: 'nope' });
+
+    // estimate is 100 > budget 50 → budget_limited on first round
+    expect(await runGoalEngine(deps, messages)).toBe('budget_limited');
+    expect(state.get()?.status).toBe('budget_limited');
+    expect(deps.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the evaluator call fails (returns null)', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    const deps = makeDeps(state);
+    evaluateCondition.mockResolvedValue(null);
+
+    expect(await runGoalEngine(deps, messages)).toBe('skipped');
+    expect(state.get()?.status).toBe('active');
+    expect(deps.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips when transcript is empty', async () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    const deps = makeDeps(state);
+    expect(await runGoalEngine(deps, [])).toBe('skipped');
+  });
+});

--- a/packages/pi-goal/src/__tests__/evaluate.test.ts
+++ b/packages/pi-goal/src/__tests__/evaluate.test.ts
@@ -33,7 +33,7 @@ describe('parseVerdict', () => {
     const v = parseVerdict('I think it is probably fine, hard to say.');
     expect(v.ok).toBe(false);
     expect(v.impossible).toBe(false);
-    expect(v.reason).toMatch(/continu/i);
+    expect(v.reason).toMatch(/insufficient evidence/i);
   });
 
   it('fills a default reason when reason is missing', () => {

--- a/packages/pi-goal/src/__tests__/evaluate.test.ts
+++ b/packages/pi-goal/src/__tests__/evaluate.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { parseVerdict } from '../evaluate.js';
+
+describe('parseVerdict', () => {
+  it('parses a clean "met" verdict', () => {
+    const v = parseVerdict('{"ok": true, "reason": "tests pass"}');
+    expect(v).toEqual({ ok: true, impossible: false, reason: 'tests pass' });
+  });
+
+  it('parses a "not yet" verdict', () => {
+    const v = parseVerdict('{"ok": false, "reason": "2 tests failing"}');
+    expect(v).toEqual({ ok: false, impossible: false, reason: '2 tests failing' });
+  });
+
+  it('parses an "impossible" verdict', () => {
+    const v = parseVerdict('{"ok": false, "impossible": true, "reason": "contradictory"}');
+    expect(v).toEqual({ ok: false, impossible: true, reason: 'contradictory' });
+  });
+
+  it('ignores impossible when ok is true', () => {
+    const v = parseVerdict('{"ok": true, "impossible": true, "reason": "done"}');
+    expect(v.ok).toBe(true);
+    expect(v.impossible).toBe(false);
+  });
+
+  it('extracts JSON embedded in prose / code fences', () => {
+    const v = parseVerdict('Here is my verdict:\n```json\n{"ok": true, "reason": "ok"}\n```');
+    expect(v.ok).toBe(true);
+    expect(v.reason).toBe('ok');
+  });
+
+  it('treats unparseable output conservatively as not-yet-met', () => {
+    const v = parseVerdict('I think it is probably fine, hard to say.');
+    expect(v.ok).toBe(false);
+    expect(v.impossible).toBe(false);
+    expect(v.reason).toMatch(/continu/i);
+  });
+
+  it('fills a default reason when reason is missing', () => {
+    expect(parseVerdict('{"ok": true}').reason).toBeTruthy();
+    expect(parseVerdict('{"ok": false}').reason).toBeTruthy();
+  });
+});

--- a/packages/pi-goal/src/__tests__/evaluate.test.ts
+++ b/packages/pi-goal/src/__tests__/evaluate.test.ts
@@ -1,5 +1,44 @@
-import { describe, expect, it } from 'vitest';
-import { parseVerdict } from '../evaluate.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const completeOnce = vi.fn();
+vi.mock('../llm.js', () => ({ completeOnce: (...args: unknown[]) => completeOnce(...args) }));
+
+import { evaluateCondition, parseVerdict } from '../evaluate.js';
+import type { GoalModelRegistry } from '../llm.js';
+
+describe('evaluateCondition', () => {
+  const registry: GoalModelRegistry = {
+    find: () => ({}),
+    getApiKeyAndHeaders: async () => ({ ok: true }),
+  };
+  const base = {
+    registry,
+    modelConfig: { provider: 'p', model: 'm' },
+    condition: 'c',
+    transcript: 't',
+  };
+
+  beforeEach(() => completeOnce.mockReset());
+
+  it('returns null and logs when the model call fails', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    completeOnce.mockResolvedValue(null);
+    expect(await evaluateCondition(base)).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('[pi-goal] evaluate: model unavailable'),
+    );
+    spy.mockRestore();
+  });
+
+  it('logs the verdict to stderr', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    completeOnce.mockResolvedValue('{"ok": true, "reason": "done"}');
+    const v = await evaluateCondition(base);
+    expect(v).toEqual({ ok: true, impossible: false, reason: 'done' });
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('[pi-goal] evaluation: ok=true'));
+    spy.mockRestore();
+  });
+});
 
 describe('parseVerdict', () => {
   it('parses a clean "met" verdict', () => {

--- a/packages/pi-goal/src/__tests__/extension.test.ts
+++ b/packages/pi-goal/src/__tests__/extension.test.ts
@@ -79,6 +79,7 @@ describe('goalExtension wiring', () => {
       expect.objectContaining({ type: 'string' }),
     );
     expect(pi.eventHandlers.session_start).toBeDefined();
+    expect(pi.eventHandlers.before_agent_start).toBeDefined();
     expect(pi.eventHandlers.agent_end).toBeDefined();
     expect(pi.eventHandlers.session_shutdown).toBeDefined();
   });
@@ -99,6 +100,49 @@ describe('goalExtension wiring', () => {
     const ctx = createMockCtx();
     await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
     expect(pi.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('defers empty --goal derivation to before_agent_start, using the prompt', async () => {
+    const pi = createMockPi(''); // bare --goal (empty value)
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+
+    // session_start must NOT derive yet — no transcript exists.
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    expect(deriveCondition).not.toHaveBeenCalled();
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+
+    // First before_agent_start carries the prompt → derive and activate.
+    deriveCondition.mockResolvedValue('The login endpoint returns 200 for valid credentials');
+    await pi.eventHandlers.before_agent_start![0]!(
+      { type: 'before_agent_start', prompt: 'make the login endpoint work' },
+      ctx,
+    );
+    expect(deriveCondition).toHaveBeenCalledTimes(1);
+    // The current turn's prompt must be part of the derivation transcript.
+    expect(deriveCondition.mock.calls[0]?.[0]?.transcript).toContain(
+      'make the login endpoint work',
+    );
+    expect(pi.sendUserMessage).toHaveBeenCalledWith(
+      expect.stringContaining('The login endpoint returns 200 for valid credentials'),
+    );
+  });
+
+  it('only derives once even across multiple before_agent_start events', async () => {
+    const pi = createMockPi('');
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    deriveCondition.mockResolvedValue('some derived condition');
+    await pi.eventHandlers.before_agent_start![0]!(
+      { type: 'before_agent_start', prompt: 'first' },
+      ctx,
+    );
+    await pi.eventHandlers.before_agent_start![0]!(
+      { type: 'before_agent_start', prompt: 'second' },
+      ctx,
+    );
+    expect(deriveCondition).toHaveBeenCalledTimes(1);
   });
 
   it('sets an explicit goal and injects an activation message', async () => {

--- a/packages/pi-goal/src/__tests__/extension.test.ts
+++ b/packages/pi-goal/src/__tests__/extension.test.ts
@@ -10,6 +10,12 @@ const evaluateCondition = vi.fn();
 vi.mock('../evaluate.js', () => ({
   evaluateCondition: (...args: unknown[]) => evaluateCondition(...args),
 }));
+// Mock buildSessionContext so the interactive /goal path reads controllable
+// conversation history from the (mocked) session manager.
+const sessionMessages = vi.fn(() => [] as unknown[]);
+vi.mock('@earendil-works/pi-coding-agent', () => ({
+  buildSessionContext: () => ({ messages: sessionMessages() }),
+}));
 
 import goalExtension from '../extension.js';
 
@@ -58,6 +64,10 @@ function createMockCtx(hasUI = true) {
       find: () => ({}),
       getApiKeyAndHeaders: async () => ({ ok: true }),
     },
+    sessionManager: {
+      getEntries: () => [],
+      getLeafId: () => null,
+    },
   };
 }
 
@@ -68,6 +78,8 @@ describe('goalExtension wiring', () => {
   beforeEach(() => {
     deriveCondition.mockReset();
     evaluateCondition.mockReset();
+    sessionMessages.mockReset();
+    sessionMessages.mockReturnValue([]);
   });
 
   it('registers the /goal command and lifecycle handlers', () => {
@@ -177,11 +189,9 @@ describe('goalExtension wiring', () => {
     const ctx = createMockCtx(true);
     await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
 
-    // Feed a transcript via turn_end so derive has something.
-    await pi.eventHandlers.turn_end![0]!(
-      { type: 'turn_end', message: { role: 'user', content: 'make login work' } },
-      ctx,
-    );
+    // Session history (read via the mocked buildSessionContext) gives derive
+    // something to work with.
+    sessionMessages.mockReturnValue([{ role: 'user', content: 'make login work' }]);
     deriveCondition.mockResolvedValue('The login flow authenticates valid users');
 
     await pi.commands.get('goal')!.handler('', ctx);
@@ -197,10 +207,7 @@ describe('goalExtension wiring', () => {
     const ctx = createMockCtx(true);
     ctx.ui.confirm = vi.fn(async () => false);
     await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
-    await pi.eventHandlers.turn_end![0]!(
-      { type: 'turn_end', message: { role: 'user', content: 'x' } },
-      ctx,
-    );
+    sessionMessages.mockReturnValue([{ role: 'user', content: 'x' }]);
     deriveCondition.mockResolvedValue('some condition');
 
     await pi.commands.get('goal')!.handler('', ctx);

--- a/packages/pi-goal/src/__tests__/extension.test.ts
+++ b/packages/pi-goal/src/__tests__/extension.test.ts
@@ -112,7 +112,7 @@ describe('goalExtension wiring', () => {
     expect(deriveCondition).not.toHaveBeenCalled();
     expect(pi.sendUserMessage).not.toHaveBeenCalled();
 
-    // First before_agent_start carries the prompt → derive and activate.
+    // First before_agent_start carries the prompt → derive and set the goal.
     deriveCondition.mockResolvedValue('The login endpoint returns 200 for valid credentials');
     await pi.eventHandlers.before_agent_start![0]!(
       { type: 'before_agent_start', prompt: 'make the login endpoint work' },
@@ -123,9 +123,11 @@ describe('goalExtension wiring', () => {
     expect(deriveCondition.mock.calls[0]?.[0]?.transcript).toContain(
       'make the login endpoint work',
     );
-    expect(pi.sendUserMessage).toHaveBeenCalledWith(
-      expect.stringContaining('The login endpoint returns 200 for valid credentials'),
-    );
+    // Goal is active…
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith('pi-goal', expect.stringContaining('active'));
+    // …but no activation message is injected here — the agent is about to run
+    // this prompt; injecting would throw "already processing".
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
   });
 
   it('only derives once even across multiple before_agent_start events', async () => {

--- a/packages/pi-goal/src/__tests__/extension.test.ts
+++ b/packages/pi-goal/src/__tests__/extension.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock derive so `/goal` (no-arg) derivation is deterministic.
+const deriveCondition = vi.fn();
+vi.mock('../derive.js', () => ({
+  deriveCondition: (...args: unknown[]) => deriveCondition(...args),
+}));
+// Mock evaluate so agent_end doesn't hit a live model.
+const evaluateCondition = vi.fn();
+vi.mock('../evaluate.js', () => ({
+  evaluateCondition: (...args: unknown[]) => evaluateCondition(...args),
+}));
+
+import goalExtension from '../extension.js';
+
+type Handler = (event: unknown, ctx: unknown) => Promise<void>;
+type CommandOpts = {
+  description: string;
+  getArgumentCompletions?: (prefix: string) => Array<{ label: string; value: string }>;
+  handler: (args: string, ctx: unknown) => Promise<void>;
+};
+
+function createMockPi(flagValue?: string) {
+  const commands = new Map<string, CommandOpts>();
+  const eventHandlers: Record<string, Handler[]> = {};
+  const sendUserMessage = vi.fn();
+  const flags = new Map<string, boolean | string>();
+  return {
+    commands,
+    eventHandlers,
+    sendUserMessage,
+    flags,
+    registerTool: vi.fn(),
+    registerCommand: vi.fn((name: string, opts: CommandOpts) => commands.set(name, opts)),
+    registerFlag: vi.fn((name: string) => {
+      if (flagValue !== undefined) flags.set(name, flagValue);
+    }),
+    getFlag: vi.fn((name: string) => flags.get(name)),
+    on: vi.fn((event: string, handler: Handler) => {
+      if (!eventHandlers[event]) eventHandlers[event] = [];
+      eventHandlers[event].push(handler);
+    }),
+    appendEntry: vi.fn(),
+  };
+}
+
+function createMockCtx(hasUI = true) {
+  return {
+    cwd: '/tmp/pi-goal-test',
+    hasUI,
+    signal: undefined,
+    ui: {
+      setStatus: vi.fn(),
+      notify: vi.fn(),
+      confirm: vi.fn(async () => true),
+    },
+    modelRegistry: {
+      find: () => ({}),
+      getApiKeyAndHeaders: async () => ({ ok: true }),
+    },
+  };
+}
+
+// Inject a model so the engine is enabled without depending on settings files.
+const injected = { model: { provider: 'p', model: 'm' } };
+
+describe('goalExtension wiring', () => {
+  beforeEach(() => {
+    deriveCondition.mockReset();
+    evaluateCondition.mockReset();
+  });
+
+  it('registers the /goal command and lifecycle handlers', () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    expect(pi.commands.has('goal')).toBe(true);
+    expect(pi.registerFlag).toHaveBeenCalledWith(
+      'goal',
+      expect.objectContaining({ type: 'string' }),
+    );
+    expect(pi.eventHandlers.session_start).toBeDefined();
+    expect(pi.eventHandlers.agent_end).toBeDefined();
+    expect(pi.eventHandlers.session_shutdown).toBeDefined();
+  });
+
+  it('sets and activates a goal from the --goal flag at session start', async () => {
+    const pi = createMockPi('all tests pass');
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    expect(pi.sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(pi.sendUserMessage.mock.calls[0]?.[0]).toContain('all tests pass');
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith('pi-goal', expect.stringContaining('active'));
+  });
+
+  it('does not set a goal when the --goal flag is absent', async () => {
+    const pi = createMockPi(); // no flag value
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('sets an explicit goal and injects an activation message', async () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+
+    await pi.commands.get('goal')!.handler('all tests pass', ctx);
+    expect(pi.sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(pi.sendUserMessage.mock.calls[0]?.[0]).toContain('all tests pass');
+    expect(ctx.ui.setStatus).toHaveBeenLastCalledWith('pi-goal', expect.stringContaining('active'));
+  });
+
+  it('clears a goal via keyword', async () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+
+    await pi.commands.get('goal')!.handler('build succeeds', ctx);
+    pi.sendUserMessage.mockClear();
+    await pi.commands.get('goal')!.handler('clear', ctx);
+    expect(ctx.ui.notify).toHaveBeenLastCalledWith(expect.stringMatching(/cleared/i), 'info');
+  });
+
+  it('derives a goal on no-arg /goal and confirms in TUI', async () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx(true);
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+
+    // Feed a transcript via turn_end so derive has something.
+    await pi.eventHandlers.turn_end![0]!(
+      { type: 'turn_end', message: { role: 'user', content: 'make login work' } },
+      ctx,
+    );
+    deriveCondition.mockResolvedValue('The login flow authenticates valid users');
+
+    await pi.commands.get('goal')!.handler('', ctx);
+    expect(ctx.ui.confirm).toHaveBeenCalledTimes(1);
+    expect(pi.sendUserMessage).toHaveBeenCalledWith(
+      expect.stringContaining('The login flow authenticates valid users'),
+    );
+  });
+
+  it('does not set a derived goal when the user declines confirmation', async () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx(true);
+    ctx.ui.confirm = vi.fn(async () => false);
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    await pi.eventHandlers.turn_end![0]!(
+      { type: 'turn_end', message: { role: 'user', content: 'x' } },
+      ctx,
+    );
+    deriveCondition.mockResolvedValue('some condition');
+
+    await pi.commands.get('goal')!.handler('', ctx);
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('agent_end evaluates and continues an active goal', async () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    await pi.commands.get('goal')!.handler('all tests pass', ctx);
+    pi.sendUserMessage.mockClear();
+
+    evaluateCondition.mockResolvedValue({ ok: false, impossible: false, reason: 'still failing' });
+    await pi.eventHandlers.agent_end![0]!(
+      { type: 'agent_end', messages: [{ role: 'assistant', content: 'ran tests' }] },
+      ctx,
+    );
+    expect(pi.sendUserMessage).toHaveBeenCalledWith(expect.stringContaining('still failing'));
+  });
+
+  it('agent_end is a no-op after the goal is cleared', async () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    await pi.commands.get('goal')!.handler('all tests pass', ctx);
+    await pi.commands.get('goal')!.handler('clear', ctx);
+    pi.sendUserMessage.mockClear();
+    evaluateCondition.mockResolvedValue({ ok: false, impossible: false, reason: 'x' });
+
+    await pi.eventHandlers.agent_end![0]!(
+      { type: 'agent_end', messages: [{ role: 'assistant', content: 'y' }] },
+      ctx,
+    );
+    expect(evaluateCondition).not.toHaveBeenCalled();
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows status on no-arg /goal when a goal is already active', async () => {
+    const pi = createMockPi();
+    goalExtension(pi as never, injected);
+    const ctx = createMockCtx();
+    await pi.eventHandlers.session_start![0]!({ type: 'session_start' }, ctx);
+    await pi.commands.get('goal')!.handler('build succeeds', ctx);
+
+    await pi.commands.get('goal')!.handler('', ctx);
+    expect(deriveCondition).not.toHaveBeenCalled();
+    expect(ctx.ui.notify).toHaveBeenLastCalledWith(
+      expect.stringContaining('build succeeds'),
+      'info',
+    );
+  });
+});

--- a/packages/pi-goal/src/__tests__/goal-state.test.ts
+++ b/packages/pi-goal/src/__tests__/goal-state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { GoalState, isClearKeyword, MAX_CONDITION_LENGTH } from '../goal-state.js';
+
+describe('GoalState', () => {
+  it('sets an active goal and reports it', () => {
+    const state = new GoalState();
+    const goal = state.set('all tests pass', 'explicit');
+    expect(goal.condition).toBe('all tests pass');
+    expect(goal.origin).toBe('explicit');
+    expect(goal.status).toBe('active');
+    expect(goal.iterations).toBe(0);
+    expect(state.isActive()).toBe(true);
+    expect(state.get()).toBe(goal);
+  });
+
+  it('trims the condition and rejects empty', () => {
+    const state = new GoalState();
+    expect(state.set('  spaced  ', 'derived').condition).toBe('spaced');
+    expect(() => state.set('   ', 'derived')).toThrow(/empty/i);
+  });
+
+  it('rejects conditions over the length cap', () => {
+    const state = new GoalState();
+    const tooLong = 'x'.repeat(MAX_CONDITION_LENGTH + 1);
+    expect(() => state.set(tooLong, 'explicit')).toThrow(/4000 characters/);
+  });
+
+  it('carries a token budget when provided', () => {
+    const state = new GoalState();
+    expect(state.set('c', 'explicit', { tokenBudget: 1000 }).tokenBudget).toBe(1000);
+    expect(state.set('c', 'explicit', { tokenBudget: 0 }).tokenBudget).toBeUndefined();
+  });
+
+  it('records iterations and last reason', () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    state.recordIteration('still failing', 42);
+    const goal = state.get();
+    expect(goal?.iterations).toBe(1);
+    expect(goal?.lastReason).toBe('still failing');
+    expect(goal?.tokensUsed).toBe(42);
+  });
+
+  it('transitions through terminal states', () => {
+    const state = new GoalState();
+    state.set('c', 'derived');
+    state.markAchieved('done');
+    expect(state.get()?.status).toBe('achieved');
+    expect(state.get()?.lastReason).toBe('done');
+    expect(state.isActive()).toBe(false);
+
+    state.set('c2', 'derived');
+    state.markImpossible('cannot');
+    expect(state.get()?.status).toBe('impossible');
+
+    state.set('c3', 'derived');
+    state.markBudgetLimited();
+    expect(state.get()?.status).toBe('budget_limited');
+
+    state.set('c4', 'derived');
+    state.markIterationLimited();
+    expect(state.get()?.status).toBe('iteration_limited');
+  });
+
+  it('clears the goal', () => {
+    const state = new GoalState();
+    state.set('c', 'explicit');
+    const cleared = state.clear();
+    expect(cleared?.status).toBe('cleared');
+    expect(state.get()).toBeUndefined();
+    expect(state.isActive()).toBe(false);
+  });
+
+  it('mutation methods are no-ops without an active goal', () => {
+    const state = new GoalState();
+    expect(state.recordIteration('x', 1)).toBeUndefined();
+    expect(state.markAchieved('x')).toBeUndefined();
+    expect(state.clear()).toBeUndefined();
+  });
+});
+
+describe('isClearKeyword', () => {
+  it('matches the clear keyword set case-insensitively', () => {
+    for (const kw of ['clear', 'STOP', 'Off', 'reset', 'none', 'cancel']) {
+      expect(isClearKeyword(kw)).toBe(true);
+    }
+    expect(isClearKeyword('  clear  ')).toBe(true);
+  });
+
+  it('does not match a real condition', () => {
+    expect(isClearKeyword('stop the server from crashing')).toBe(false);
+    expect(isClearKeyword('all tests pass')).toBe(false);
+  });
+});

--- a/packages/pi-goal/src/__tests__/prompts.test.ts
+++ b/packages/pi-goal/src/__tests__/prompts.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildActivationMessage,
+  buildContinueMessage,
+  buildEvaluateUserPrompt,
+  buildTruncationNote,
+  EVALUATE_SYSTEM_PROMPT,
+} from '../prompts.js';
+
+describe('EVALUATE_SYSTEM_PROMPT (aligned with Claude Code)', () => {
+  it('requires quoting transcript evidence', () => {
+    expect(EVALUATE_SYSTEM_PROMPT).toMatch(/quote evidence from the transcript/i);
+  });
+
+  it('defines the insufficient-evidence fallback', () => {
+    expect(EVALUATE_SYSTEM_PROMPT).toMatch(/insufficient evidence in transcript/i);
+  });
+
+  it('carries the impossible-judgment discipline (evidence, not proof)', () => {
+    expect(EVALUATE_SYSTEM_PROMPT).toMatch(/evidence, not proof/i);
+    expect(EVALUATE_SYSTEM_PROMPT).toMatch(/when in doubt, return \{"ok": false\}/i);
+  });
+});
+
+describe('buildEvaluateUserPrompt', () => {
+  it('omits the truncation note when nothing was dropped', () => {
+    const prompt = buildEvaluateUserPrompt('cond', 'transcript', 0);
+    expect(prompt).not.toMatch(/truncated/i);
+    expect(prompt).toContain('cond');
+    expect(prompt).toContain('transcript');
+  });
+
+  it('includes the truncation note when messages were omitted', () => {
+    const prompt = buildEvaluateUserPrompt('cond', 'transcript', 3);
+    expect(prompt).toMatch(/truncated/i);
+    expect(prompt).toContain('3 earlier message');
+  });
+});
+
+describe('buildTruncationNote', () => {
+  it('reports the omitted count and steers toward insufficient evidence', () => {
+    const note = buildTruncationNote(5);
+    expect(note).toContain('5 earlier message');
+    expect(note).toMatch(/insufficient evidence in transcript/i);
+  });
+});
+
+describe('buildActivationMessage', () => {
+  it('embeds the condition and the auto-clear guidance', () => {
+    const msg = buildActivationMessage('all tests pass');
+    expect(msg).toContain('all tests pass');
+    expect(msg).toMatch(/auto-clears/i);
+    expect(msg).toMatch(/do not tell the user to run `\/goal clear`/i);
+  });
+});
+
+describe('buildContinueMessage', () => {
+  it('embeds the condition and the remaining reason', () => {
+    const msg = buildContinueMessage('build succeeds', '2 tests failing');
+    expect(msg).toContain('build succeeds');
+    expect(msg).toContain('2 tests failing');
+    expect(msg).toMatch(/do not stop until it holds/i);
+  });
+});

--- a/packages/pi-goal/src/__tests__/transcript.test.ts
+++ b/packages/pi-goal/src/__tests__/transcript.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildTranscript, extractText } from '../transcript.js';
+
+describe('extractText', () => {
+  it('returns trimmed string content', () => {
+    expect(extractText('  hello  ')).toBe('hello');
+  });
+
+  it('joins text blocks and ignores non-text blocks', () => {
+    const content = [
+      { type: 'text', text: 'line one' },
+      { type: 'tool_use', name: 'read' },
+      { type: 'text', text: 'line two' },
+    ];
+    expect(extractText(content)).toBe('line one\nline two');
+  });
+
+  it('returns empty string for unsupported content', () => {
+    expect(extractText(undefined)).toBe('');
+    expect(extractText(42)).toBe('');
+  });
+});
+
+describe('buildTranscript', () => {
+  it('formats messages with role tags, oldest first', () => {
+    const messages = [
+      { role: 'user', content: 'do the thing' },
+      { role: 'assistant', content: 'working on it' },
+    ];
+    expect(buildTranscript(messages, 1000)).toBe(
+      '[user] do the thing\n\n[assistant] working on it',
+    );
+  });
+
+  it('skips messages with no extractable text', () => {
+    const messages = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: [{ type: 'tool_use', name: 'x' }] },
+    ];
+    expect(buildTranscript(messages, 1000)).toBe('[user] hi');
+  });
+
+  it('caps by chars, keeping the newest messages', () => {
+    const messages = [
+      { role: 'user', content: 'AAAAAAAAAA' },
+      { role: 'assistant', content: 'BBBBBBBBBB' },
+      { role: 'user', content: 'CCCCCCCCCC' },
+    ];
+    // Small cap forces dropping the oldest; newest must survive.
+    const out = buildTranscript(messages, 30);
+    expect(out).toContain('CCCCCCCCCC');
+    expect(out).not.toContain('AAAAAAAAAA');
+  });
+
+  it('always keeps at least the newest message even if over cap', () => {
+    const messages = [{ role: 'user', content: 'X'.repeat(100) }];
+    expect(buildTranscript(messages, 10)).toContain('X'.repeat(100));
+  });
+});

--- a/packages/pi-goal/src/__tests__/transcript.test.ts
+++ b/packages/pi-goal/src/__tests__/transcript.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildTranscript, extractText } from '../transcript.js';
+import { buildTranscript, buildTranscriptWithMeta, extractText } from '../transcript.js';
 
 describe('extractText', () => {
   it('returns trimmed string content', () => {
@@ -55,5 +55,38 @@ describe('buildTranscript', () => {
   it('always keeps at least the newest message even if over cap', () => {
     const messages = [{ role: 'user', content: 'X'.repeat(100) }];
     expect(buildTranscript(messages, 10)).toContain('X'.repeat(100));
+  });
+});
+
+describe('buildTranscriptWithMeta', () => {
+  it('reports zero omitted when everything fits', () => {
+    const messages = [
+      { role: 'user', content: 'a' },
+      { role: 'assistant', content: 'b' },
+    ];
+    const result = buildTranscriptWithMeta(messages, 1000);
+    expect(result.omitted).toBe(0);
+    expect(result.text).toContain('[user] a');
+  });
+
+  it('counts text-bearing messages dropped by the cap', () => {
+    const messages = [
+      { role: 'user', content: 'AAAAAAAAAA' },
+      { role: 'assistant', content: 'BBBBBBBBBB' },
+      { role: 'user', content: 'CCCCCCCCCC' },
+    ];
+    const result = buildTranscriptWithMeta(messages, 30);
+    // Newest survives; at least one older text message is dropped.
+    expect(result.text).toContain('CCCCCCCCCC');
+    expect(result.omitted).toBeGreaterThan(0);
+  });
+
+  it('does not count text-less messages as omitted', () => {
+    const messages = [
+      { role: 'assistant', content: [{ type: 'tool_use', name: 'x' }] },
+      { role: 'user', content: 'hi' },
+    ];
+    const result = buildTranscriptWithMeta(messages, 1000);
+    expect(result.omitted).toBe(0);
   });
 });

--- a/packages/pi-goal/src/config.ts
+++ b/packages/pi-goal/src/config.ts
@@ -1,0 +1,85 @@
+import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+
+const SETTINGS_KEY = 'pi-goal';
+
+/** Model used for deriving and evaluating goal conditions. */
+export type GoalModelConfig = {
+  provider: string;
+  model: string;
+};
+
+export type PiGoalConfig = {
+  /**
+   * Model for deriving conditions and evaluating whether they are met.
+   * Omit to disable the automatic engine — `/goal <condition>` still works
+   * for setting a goal, but nothing auto-derives or auto-evaluates.
+   */
+  model?: GoalModelConfig;
+  /** Max continuation rounds before the engine stops pushing. Default 10. */
+  maxIterations?: number;
+  /** Optional hard token budget; goal becomes budget_limited once exceeded. Omit for no limit. */
+  tokenBudget?: number;
+  /** Max chars of transcript fed to derive/evaluate. Default 8000. */
+  transcriptMaxChars?: number;
+  /** Ask the user to confirm a derived condition in TUI mode. Default true. */
+  requireConfirmForDerived?: boolean;
+};
+
+export type ResolvedGoalConfig = {
+  model?: GoalModelConfig;
+  maxIterations: number;
+  tokenBudget?: number;
+  transcriptMaxChars: number;
+  requireConfirmForDerived: boolean;
+};
+
+export const DEFAULTS = {
+  maxIterations: 10,
+  transcriptMaxChars: 8000,
+  requireConfirmForDerived: true,
+} as const;
+
+export function resolveConfig(raw?: PiGoalConfig): ResolvedGoalConfig {
+  const resolved: ResolvedGoalConfig = {
+    maxIterations: sanitizePositiveInt(raw?.maxIterations, DEFAULTS.maxIterations),
+    transcriptMaxChars: sanitizePositiveInt(raw?.transcriptMaxChars, DEFAULTS.transcriptMaxChars),
+    requireConfirmForDerived: raw?.requireConfirmForDerived ?? DEFAULTS.requireConfirmForDerived,
+  };
+  if (isValidModel(raw?.model)) {
+    resolved.model = { provider: raw.model.provider, model: raw.model.model };
+  }
+  if (
+    typeof raw?.tokenBudget === 'number' &&
+    Number.isFinite(raw.tokenBudget) &&
+    raw.tokenBudget > 0
+  ) {
+    resolved.tokenBudget = Math.floor(raw.tokenBudget);
+  }
+  return resolved;
+}
+
+export function loadSettings(cwd: string): PiGoalConfig | undefined {
+  try {
+    const config = loadPiSettings<Partial<PiGoalConfig>>(SETTINGS_KEY, { cwd });
+    return Object.keys(config).length > 0 ? (config as PiGoalConfig) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isValidModel(model: GoalModelConfig | undefined): model is GoalModelConfig {
+  return (
+    !!model &&
+    typeof model.provider === 'string' &&
+    model.provider.trim().length > 0 &&
+    typeof model.model === 'string' &&
+    model.model.trim().length > 0
+  );
+}
+
+function sanitizePositiveInt(value: number | undefined, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return fallback;
+}

--- a/packages/pi-goal/src/derive.ts
+++ b/packages/pi-goal/src/derive.ts
@@ -19,7 +19,10 @@ export interface DeriveOptions {
  */
 export async function deriveCondition(opts: DeriveOptions): Promise<string | null> {
   const { registry, modelConfig, transcript, signal } = opts;
-  if (!transcript.trim()) return null;
+  if (!transcript.trim()) {
+    console.error('[pi-goal] derive: empty transcript, nothing to derive from');
+    return null;
+  }
 
   const raw = await completeOnce(
     registry,
@@ -28,10 +31,17 @@ export async function deriveCondition(opts: DeriveOptions): Promise<string | nul
     buildDeriveUserPrompt(transcript),
     signal,
   );
-  if (raw === null) return null;
+  if (raw === null) {
+    console.error('[pi-goal] derive: model unavailable or call failed');
+    return null;
+  }
 
   const condition = normalizeCondition(raw);
-  if (!condition || condition.toUpperCase() === 'NONE') return null;
+  if (!condition || condition.toUpperCase() === 'NONE') {
+    console.error('[pi-goal] derive: no actionable objective inferred (NONE)');
+    return null;
+  }
+  console.error(`[pi-goal] derived condition: ${condition}`);
   return condition;
 }
 

--- a/packages/pi-goal/src/derive.ts
+++ b/packages/pi-goal/src/derive.ts
@@ -1,0 +1,46 @@
+/**
+ * Derive a measurable completion condition from recent conversation.
+ */
+
+import type { GoalModelConfig } from './config.js';
+import { completeOnce, type GoalModelRegistry } from './llm.js';
+import { buildDeriveUserPrompt, DERIVE_SYSTEM_PROMPT } from './prompts.js';
+
+export interface DeriveOptions {
+  registry: GoalModelRegistry;
+  modelConfig: GoalModelConfig;
+  transcript: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Returns a one-line condition, or null if the model is unavailable, the call
+ * fails, or no actionable objective could be inferred (model returned NONE).
+ */
+export async function deriveCondition(opts: DeriveOptions): Promise<string | null> {
+  const { registry, modelConfig, transcript, signal } = opts;
+  if (!transcript.trim()) return null;
+
+  const raw = await completeOnce(
+    registry,
+    modelConfig,
+    DERIVE_SYSTEM_PROMPT,
+    buildDeriveUserPrompt(transcript),
+    signal,
+  );
+  if (raw === null) return null;
+
+  const condition = normalizeCondition(raw);
+  if (!condition || condition.toUpperCase() === 'NONE') return null;
+  return condition;
+}
+
+function normalizeCondition(raw: string): string {
+  // Take the first non-empty line, strip stray wrapping quotes/backticks.
+  const firstLine = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return '';
+  return firstLine.replace(/^["'`]+|["'`]+$/g, '').trim();
+}

--- a/packages/pi-goal/src/evaluate.ts
+++ b/packages/pi-goal/src/evaluate.ts
@@ -37,9 +37,16 @@ export async function evaluateCondition(opts: EvaluateOptions): Promise<GoalVerd
     buildEvaluateUserPrompt(condition, transcript, omittedCount ?? 0),
     signal,
   );
-  if (raw === null) return null;
+  if (raw === null) {
+    console.error('[pi-goal] evaluate: model unavailable or call failed');
+    return null;
+  }
 
-  return parseVerdict(raw);
+  const verdict = parseVerdict(raw);
+  console.error(
+    `[pi-goal] evaluation: ok=${verdict.ok} impossible=${verdict.impossible} reason=${verdict.reason}`,
+  );
+  return verdict;
 }
 
 /** Parse the JSON verdict leniently; unparseable output → conservative "not yet". */

--- a/packages/pi-goal/src/evaluate.ts
+++ b/packages/pi-goal/src/evaluate.ts
@@ -1,0 +1,81 @@
+/**
+ * Evaluate whether a goal condition is satisfied, given the conversation so far.
+ */
+
+import type { GoalModelConfig } from './config.js';
+import { completeOnce, type GoalModelRegistry } from './llm.js';
+import { buildEvaluateUserPrompt, EVALUATE_SYSTEM_PROMPT } from './prompts.js';
+
+export interface GoalVerdict {
+  ok: boolean;
+  impossible: boolean;
+  reason: string;
+}
+
+export interface EvaluateOptions {
+  registry: GoalModelRegistry;
+  modelConfig: GoalModelConfig;
+  condition: string;
+  transcript: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Returns a verdict, or null if the model is unavailable / the call failed.
+ * A malformed model response is treated conservatively as "not yet met" rather
+ * than null, so the engine keeps working instead of silently giving up.
+ */
+export async function evaluateCondition(opts: EvaluateOptions): Promise<GoalVerdict | null> {
+  const { registry, modelConfig, condition, transcript, signal } = opts;
+
+  const raw = await completeOnce(
+    registry,
+    modelConfig,
+    EVALUATE_SYSTEM_PROMPT,
+    buildEvaluateUserPrompt(condition, transcript),
+    signal,
+  );
+  if (raw === null) return null;
+
+  return parseVerdict(raw);
+}
+
+/** Parse the JSON verdict leniently; unparseable output → conservative "not yet". */
+export function parseVerdict(raw: string): GoalVerdict {
+  const parsed = extractJsonObject(raw);
+  if (!parsed) {
+    return { ok: false, impossible: false, reason: 'Could not parse evaluation; continuing.' };
+  }
+  const ok = parsed.ok === true;
+  const impossible = parsed.impossible === true && !ok;
+  const reason =
+    typeof parsed.reason === 'string' && parsed.reason.trim()
+      ? parsed.reason.trim()
+      : ok
+        ? 'Condition satisfied.'
+        : 'Condition not yet satisfied.';
+  return { ok, impossible, reason };
+}
+
+function extractJsonObject(raw: string): Record<string, unknown> | null {
+  const text = raw.trim();
+  // Fast path: whole string is JSON.
+  const direct = tryParse(text);
+  if (direct) return direct;
+  // Fallback: first {...} block (handles code fences / surrounding prose).
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start >= 0 && end > start) {
+    return tryParse(text.slice(start, end + 1));
+  }
+  return null;
+}
+
+function tryParse(text: string): Record<string, unknown> | null {
+  try {
+    const value = JSON.parse(text);
+    return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/pi-goal/src/evaluate.ts
+++ b/packages/pi-goal/src/evaluate.ts
@@ -17,6 +17,8 @@ export interface EvaluateOptions {
   modelConfig: GoalModelConfig;
   condition: string;
   transcript: string;
+  /** Text-bearing messages dropped to fit the cap; surfaced to the evaluator. */
+  omittedCount?: number;
   signal?: AbortSignal;
 }
 
@@ -26,13 +28,13 @@ export interface EvaluateOptions {
  * than null, so the engine keeps working instead of silently giving up.
  */
 export async function evaluateCondition(opts: EvaluateOptions): Promise<GoalVerdict | null> {
-  const { registry, modelConfig, condition, transcript, signal } = opts;
+  const { registry, modelConfig, condition, transcript, omittedCount, signal } = opts;
 
   const raw = await completeOnce(
     registry,
     modelConfig,
     EVALUATE_SYSTEM_PROMPT,
-    buildEvaluateUserPrompt(condition, transcript),
+    buildEvaluateUserPrompt(condition, transcript, omittedCount ?? 0),
     signal,
   );
   if (raw === null) return null;
@@ -44,7 +46,11 @@ export async function evaluateCondition(opts: EvaluateOptions): Promise<GoalVerd
 export function parseVerdict(raw: string): GoalVerdict {
   const parsed = extractJsonObject(raw);
   if (!parsed) {
-    return { ok: false, impossible: false, reason: 'Could not parse evaluation; continuing.' };
+    return {
+      ok: false,
+      impossible: false,
+      reason: 'insufficient evidence in transcript (unparseable evaluation)',
+    };
   }
   const ok = parsed.ok === true;
   const impossible = parsed.impossible === true && !ok;

--- a/packages/pi-goal/src/extension.ts
+++ b/packages/pi-goal/src/extension.ts
@@ -151,7 +151,10 @@ export default function goalExtension(
     pendingDerive = false;
     const evt = event as unknown as { prompt?: unknown };
     const prompt = typeof evt.prompt === 'string' ? evt.prompt : '';
-    await deriveAndSet(ctx, prompt);
+    // activate=false: the agent is about to run this prompt, so don't inject an
+    // activation message (it would throw "already processing"). The run reaches
+    // agent_end on its own, where the engine evaluates the goal.
+    await deriveAndSet(ctx, prompt, false);
   });
 
   // Keep the freshest full message list for the engine; agent_end also carries it.
@@ -258,7 +261,11 @@ export default function goalExtension(
     }
   }
 
-  async function deriveAndSet(ctx: ExtensionContext, extraContext = ''): Promise<void> {
+  async function deriveAndSet(
+    ctx: ExtensionContext,
+    extraContext = '',
+    activate = true,
+  ): Promise<void> {
     if (!config.model || !registry) {
       ctx.ui.notify(
         'No evaluator model configured. Set `pi-goal.model` in settings, or use `/goal <condition>`.',
@@ -301,7 +308,14 @@ export default function goalExtension(
     try {
       const goal = state.set(condition, 'derived', tokenBudgetOpts());
       ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
-      pi.sendUserMessage(buildActivationMessage(goal.condition));
+      // Only inject the activation nudge when the agent is idle (interactive
+      // /goal). When deriving at before_agent_start, the agent is already about
+      // to run the user's prompt — injecting here throws "Agent is already
+      // processing a prompt". That run naturally reaches agent_end, where the
+      // engine evaluates the goal.
+      if (activate) {
+        pi.sendUserMessage(buildActivationMessage(goal.condition));
+      }
     } catch (err) {
       ctx.ui.notify(err instanceof Error ? err.message : 'Failed to set goal.', 'error');
     }

--- a/packages/pi-goal/src/extension.ts
+++ b/packages/pi-goal/src/extension.ts
@@ -1,4 +1,8 @@
-import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import {
+  buildSessionContext,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from '@earendil-works/pi-coding-agent';
 import {
   loadSettings,
   type PiGoalConfig,
@@ -115,7 +119,6 @@ export default function goalExtension(
   const state = new GoalState();
   let config: ResolvedGoalConfig = resolveConfig(injectedConfig);
   let registry: GoalModelRegistry | undefined;
-  let latestMessages: unknown[] = [];
   let engineRunning = false;
   // Set when `--goal` was passed with an empty value: derivation is deferred to
   // the first before_agent_start, where the user's prompt is available. At
@@ -157,18 +160,11 @@ export default function goalExtension(
     await deriveAndSet(ctx, prompt, false);
   });
 
-  // Keep the freshest full message list for the engine; agent_end also carries it.
-  pi.on('turn_end', async (event) => {
-    const evt = event as unknown as { message?: unknown };
-    if (evt.message) latestMessages.push(evt.message);
-  });
-
   pi.on('agent_end', async (event, ctx) => {
     if (!state.isActive() || !config.model || !registry) return;
     if (engineRunning) return; // re-entrancy guard: our own sendUserMessage re-triggers agent_end
     const evt = event as unknown as { messages?: unknown[] };
-    const messages =
-      Array.isArray(evt.messages) && evt.messages.length > 0 ? evt.messages : latestMessages;
+    const messages = Array.isArray(evt.messages) ? evt.messages : [];
 
     engineRunning = true;
     try {
@@ -193,7 +189,6 @@ export default function goalExtension(
 
   pi.on('session_shutdown', async () => {
     state.clear();
-    latestMessages = [];
     registry = undefined;
     pendingDerive = false;
   });
@@ -236,9 +231,23 @@ export default function goalExtension(
         return;
       }
 
-      await deriveAndSet(ctx);
+      // Interactive /goal with no arg: derive from the session's conversation
+      // history (read from the session manager, the authoritative source).
+      await deriveAndSet(ctx, '', true, readSessionMessages(ctx));
     },
   });
+
+  /** Resolved conversation messages from the session, or [] if unavailable. */
+  function readSessionMessages(ctx: ExtensionContext): unknown[] {
+    try {
+      const sm = ctx.sessionManager;
+      if (!sm) return [];
+      const context = buildSessionContext(sm.getEntries(), sm.getLeafId());
+      return context.messages ?? [];
+    } catch {
+      return [];
+    }
+  }
 
   function setExplicitGoal(condition: string, ctx: ExtensionContext): void {
     if (condition.length > MAX_CONDITION_LENGTH) {
@@ -265,6 +274,7 @@ export default function goalExtension(
     ctx: ExtensionContext,
     extraContext = '',
     activate = true,
+    history: unknown[] = [],
   ): Promise<void> {
     if (!config.model || !registry) {
       ctx.ui.notify(
@@ -275,9 +285,9 @@ export default function goalExtension(
     }
     ctx.ui.notify('Deriving a goal from the conversation…', 'info');
     // Fold the current turn's prompt (when derivation was triggered by --goal
-    // before any turn has run) into the buffered transcript, so there is always
-    // something to derive from even on a fresh session.
-    const buffered = buildTranscript(latestMessages, config.transcriptMaxChars);
+    // before any turn has run) into the conversation history, so there is
+    // always something to derive from even on a fresh session.
+    const buffered = buildTranscript(history, config.transcriptMaxChars);
     const extra = extraContext.trim() ? `[user] ${extraContext.trim()}` : '';
     const transcript = [buffered, extra].filter(Boolean).join('\n\n');
     const condition = await deriveCondition({

--- a/packages/pi-goal/src/extension.ts
+++ b/packages/pi-goal/src/extension.ts
@@ -117,6 +117,10 @@ export default function goalExtension(
   let registry: GoalModelRegistry | undefined;
   let latestMessages: unknown[] = [];
   let engineRunning = false;
+  // Set when `--goal` was passed with an empty value: derivation is deferred to
+  // the first before_agent_start, where the user's prompt is available. At
+  // session_start there is no transcript yet, so deriving there yields nothing.
+  let pendingDerive = false;
 
   pi.on('session_start', async (_event, ctx) => {
     const fileConfig = loadSettings(ctx.cwd);
@@ -126,16 +130,28 @@ export default function goalExtension(
 
     // --goal <condition> flag: set the goal at startup (print mode can't dispatch
     // the /goal slash command, so the flag is the CLI entry point). An empty
-    // string (bare --goal) triggers derivation, mirroring no-arg /goal.
+    // string (bare --goal) defers derivation to before_agent_start, where the
+    // user's prompt for the turn is available to derive from.
     const flagValue = pi.getFlag('goal');
     if (typeof flagValue === 'string') {
       const condition = flagValue.trim();
       if (condition && !isClearKeyword(condition)) {
         setExplicitGoal(condition, ctx);
       } else if (!condition) {
-        await deriveAndSet(ctx);
+        pendingDerive = true;
       }
     }
+  });
+
+  // First user prompt: if a --goal derivation is pending, derive the condition
+  // now — event.prompt carries what the user wants this turn, which is the
+  // signal to derive from. Fires once per prompt; we clear the flag after.
+  pi.on('before_agent_start', async (event, ctx) => {
+    if (!pendingDerive) return;
+    pendingDerive = false;
+    const evt = event as unknown as { prompt?: unknown };
+    const prompt = typeof evt.prompt === 'string' ? evt.prompt : '';
+    await deriveAndSet(ctx, prompt);
   });
 
   // Keep the freshest full message list for the engine; agent_end also carries it.
@@ -176,6 +192,7 @@ export default function goalExtension(
     state.clear();
     latestMessages = [];
     registry = undefined;
+    pendingDerive = false;
   });
 
   pi.registerFlag('goal', {
@@ -241,7 +258,7 @@ export default function goalExtension(
     }
   }
 
-  async function deriveAndSet(ctx: ExtensionContext): Promise<void> {
+  async function deriveAndSet(ctx: ExtensionContext, extraContext = ''): Promise<void> {
     if (!config.model || !registry) {
       ctx.ui.notify(
         'No evaluator model configured. Set `pi-goal.model` in settings, or use `/goal <condition>`.',
@@ -250,10 +267,16 @@ export default function goalExtension(
       return;
     }
     ctx.ui.notify('Deriving a goal from the conversation…', 'info');
+    // Fold the current turn's prompt (when derivation was triggered by --goal
+    // before any turn has run) into the buffered transcript, so there is always
+    // something to derive from even on a fresh session.
+    const buffered = buildTranscript(latestMessages, config.transcriptMaxChars);
+    const extra = extraContext.trim() ? `[user] ${extraContext.trim()}` : '';
+    const transcript = [buffered, extra].filter(Boolean).join('\n\n');
     const condition = await deriveCondition({
       registry,
       modelConfig: config.model,
-      transcript: buildTranscript(latestMessages, config.transcriptMaxChars),
+      transcript,
       ...(ctx.signal ? { signal: ctx.signal } : {}),
     });
     if (!condition) {

--- a/packages/pi-goal/src/extension.ts
+++ b/packages/pi-goal/src/extension.ts
@@ -1,0 +1,304 @@
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import {
+  loadSettings,
+  type PiGoalConfig,
+  type ResolvedGoalConfig,
+  resolveConfig,
+} from './config.js';
+import { deriveCondition } from './derive.js';
+import { evaluateCondition } from './evaluate.js';
+import { type ActiveGoal, GoalState, isClearKeyword, MAX_CONDITION_LENGTH } from './goal-state.js';
+import type { GoalModelRegistry } from './llm.js';
+import { buildActivationMessage, buildContinueMessage } from './prompts.js';
+import { buildTranscript } from './transcript.js';
+
+const STATUS_KEY = 'pi-goal';
+
+export type PiGoalExtensionConfig = PiGoalConfig;
+
+/**
+ * Dependencies for the goal engine — extracted so the engine is unit-testable
+ * without a live ExtensionAPI.
+ */
+export interface GoalEngineDeps {
+  state: GoalState;
+  config: ResolvedGoalConfig;
+  registry: GoalModelRegistry;
+  sendUserMessage: (content: string) => void;
+  notify: (message: string, level: 'info' | 'warning' | 'error') => void;
+  setStatus: (text: string) => void;
+  signal?: AbortSignal;
+  /** Rough token accounting; defaults to a char-based estimate of the transcript. */
+  estimateTokens?: (transcript: string) => number;
+}
+
+/**
+ * Evaluate the active goal against the transcript and either stop (achieved /
+ * impossible / limited) or inject a continuation message. Idempotent guard: the
+ * caller must ensure only one invocation runs at a time (see extension wiring).
+ */
+export async function runGoalEngine(
+  deps: GoalEngineDeps,
+  messages: unknown[],
+): Promise<
+  'achieved' | 'impossible' | 'continued' | 'budget_limited' | 'iteration_limited' | 'skipped'
+> {
+  const { state, config, registry } = deps;
+  const goal = state.get();
+  if (!goal || goal.status !== 'active') return 'skipped';
+  if (!config.model) return 'skipped'; // engine disabled without a model
+
+  const transcript = buildTranscript(messages, config.transcriptMaxChars);
+  if (!transcript) return 'skipped';
+
+  const verdict = await evaluateCondition({
+    registry,
+    modelConfig: config.model,
+    condition: goal.condition,
+    transcript,
+    ...(deps.signal ? { signal: deps.signal } : {}),
+  });
+  // Model unavailable / call failed: do nothing this round (degrade quietly).
+  if (verdict === null) return 'skipped';
+
+  if (verdict.impossible) {
+    state.markImpossible(verdict.reason);
+    deps.notify(`Goal deemed unreachable: ${verdict.reason}`, 'warning');
+    deps.setStatus(formatStatus(state.get()));
+    return 'impossible';
+  }
+
+  if (verdict.ok) {
+    state.markAchieved(verdict.reason);
+    deps.notify(`Goal achieved: ${verdict.reason}`, 'info');
+    deps.setStatus(formatStatus(state.get()));
+    return 'achieved';
+  }
+
+  // Not yet met — apply guards before continuing.
+  const estimate = deps.estimateTokens ?? ((t: string) => Math.ceil(t.length / 4));
+  const tokensUsed = goal.tokensUsed + estimate(transcript);
+  state.recordIteration(verdict.reason, tokensUsed);
+  const current = state.get();
+  if (!current) return 'skipped';
+
+  if (current.iterations >= config.maxIterations) {
+    state.markIterationLimited(verdict.reason);
+    deps.notify(
+      `Goal paused after ${current.iterations} rounds (max reached). Last check: ${verdict.reason}`,
+      'warning',
+    );
+    deps.setStatus(formatStatus(state.get()));
+    return 'iteration_limited';
+  }
+
+  if (config.tokenBudget && tokensUsed >= config.tokenBudget) {
+    state.markBudgetLimited(verdict.reason);
+    deps.notify(`Goal paused: token budget reached. Last check: ${verdict.reason}`, 'warning');
+    deps.setStatus(formatStatus(state.get()));
+    return 'budget_limited';
+  }
+
+  deps.setStatus(formatStatus(current));
+  deps.sendUserMessage(buildContinueMessage(current.condition, verdict.reason));
+  return 'continued';
+}
+
+export default function goalExtension(
+  pi: ExtensionAPI,
+  injectedConfig?: PiGoalExtensionConfig,
+): void {
+  const state = new GoalState();
+  let config: ResolvedGoalConfig = resolveConfig(injectedConfig);
+  let registry: GoalModelRegistry | undefined;
+  let latestMessages: unknown[] = [];
+  let engineRunning = false;
+
+  pi.on('session_start', async (_event, ctx) => {
+    const fileConfig = loadSettings(ctx.cwd);
+    config = resolveConfig({ ...fileConfig, ...injectedConfig });
+    registry = ctx.modelRegistry as unknown as GoalModelRegistry;
+    ctx.ui.setStatus(STATUS_KEY, config.model ? 'goal: none' : 'goal: disabled (no model)');
+
+    // --goal <condition> flag: set the goal at startup (print mode can't dispatch
+    // the /goal slash command, so the flag is the CLI entry point). An empty
+    // string (bare --goal) triggers derivation, mirroring no-arg /goal.
+    const flagValue = pi.getFlag('goal');
+    if (typeof flagValue === 'string') {
+      const condition = flagValue.trim();
+      if (condition && !isClearKeyword(condition)) {
+        setExplicitGoal(condition, ctx);
+      } else if (!condition) {
+        await deriveAndSet(ctx);
+      }
+    }
+  });
+
+  // Keep the freshest full message list for the engine; agent_end also carries it.
+  pi.on('turn_end', async (event) => {
+    const evt = event as unknown as { message?: unknown };
+    if (evt.message) latestMessages.push(evt.message);
+  });
+
+  pi.on('agent_end', async (event, ctx) => {
+    if (!state.isActive() || !config.model || !registry) return;
+    if (engineRunning) return; // re-entrancy guard: our own sendUserMessage re-triggers agent_end
+    const evt = event as unknown as { messages?: unknown[] };
+    const messages =
+      Array.isArray(evt.messages) && evt.messages.length > 0 ? evt.messages : latestMessages;
+
+    engineRunning = true;
+    try {
+      await runGoalEngine(
+        {
+          state,
+          config,
+          registry,
+          sendUserMessage: (content) => pi.sendUserMessage(content),
+          notify: (message, level) => ctx.ui.notify(message, level),
+          setStatus: (text) => ctx.ui.setStatus(STATUS_KEY, text),
+          ...(ctx.signal ? { signal: ctx.signal } : {}),
+        },
+        messages,
+      );
+    } catch (err) {
+      console.error(`[pi-goal] engine error: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      engineRunning = false;
+    }
+  });
+
+  pi.on('session_shutdown', async () => {
+    state.clear();
+    latestMessages = [];
+    registry = undefined;
+  });
+
+  pi.registerFlag('goal', {
+    description:
+      'Set a goal at startup — Pi keeps working until the condition is met. Pass a condition, or an empty string to derive one from context.',
+    type: 'string',
+  });
+
+  pi.registerCommand('goal', {
+    description:
+      'Set a goal — Pi keeps working until the condition is met. Usage: /goal [<condition> | clear]. With no argument, derives a goal from the conversation.',
+    getArgumentCompletions: (prefix: string) => {
+      const options = ['clear'];
+      const matches = options.filter((o) => o.startsWith(prefix.trim().toLowerCase()));
+      return matches.map((o) => ({ label: o, value: o }));
+    },
+    handler: async (args: string, ctx: ExtensionContext) => {
+      const arg = args.trim();
+
+      // Clear
+      if (isClearKeyword(arg)) {
+        const cleared = state.clear();
+        ctx.ui.setStatus(STATUS_KEY, config.model ? 'goal: none' : 'goal: disabled (no model)');
+        ctx.ui.notify(cleared ? `Goal cleared: ${cleared.condition}` : 'No goal was set.', 'info');
+        return;
+      }
+
+      // Explicit condition
+      if (arg) {
+        setExplicitGoal(arg, ctx);
+        return;
+      }
+
+      // No argument: show status if a goal exists, else derive
+      const existing = state.get();
+      if (existing && existing.status === 'active') {
+        ctx.ui.notify(formatDetail(existing), 'info');
+        return;
+      }
+
+      await deriveAndSet(ctx);
+    },
+  });
+
+  function setExplicitGoal(condition: string, ctx: ExtensionContext): void {
+    if (condition.length > MAX_CONDITION_LENGTH) {
+      ctx.ui.notify(`Goal condition is limited to ${MAX_CONDITION_LENGTH} characters.`, 'error');
+      return;
+    }
+    try {
+      const goal = state.set(condition, 'explicit', tokenBudgetOpts());
+      ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
+      if (config.model) {
+        pi.sendUserMessage(buildActivationMessage(goal.condition));
+      } else {
+        ctx.ui.notify(
+          'Goal set, but no evaluator model is configured — auto-continuation is disabled.',
+          'warning',
+        );
+      }
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : 'Failed to set goal.', 'error');
+    }
+  }
+
+  async function deriveAndSet(ctx: ExtensionContext): Promise<void> {
+    if (!config.model || !registry) {
+      ctx.ui.notify(
+        'No evaluator model configured. Set `pi-goal.model` in settings, or use `/goal <condition>`.',
+        'warning',
+      );
+      return;
+    }
+    ctx.ui.notify('Deriving a goal from the conversation…', 'info');
+    const condition = await deriveCondition({
+      registry,
+      modelConfig: config.model,
+      transcript: buildTranscript(latestMessages, config.transcriptMaxChars),
+      ...(ctx.signal ? { signal: ctx.signal } : {}),
+    });
+    if (!condition) {
+      ctx.ui.notify(
+        'Could not derive a clear goal from the conversation. Try `/goal <condition>`.',
+        'warning',
+      );
+      return;
+    }
+
+    if (config.requireConfirmForDerived && ctx.hasUI) {
+      const approved = await ctx.ui.confirm(
+        'Set this goal?',
+        `Pi will keep working until:\n\n${condition}`,
+      );
+      if (!approved) {
+        ctx.ui.notify('Goal not set.', 'info');
+        return;
+      }
+    }
+
+    try {
+      const goal = state.set(condition, 'derived', tokenBudgetOpts());
+      ctx.ui.setStatus(STATUS_KEY, formatStatus(goal));
+      pi.sendUserMessage(buildActivationMessage(goal.condition));
+    } catch (err) {
+      ctx.ui.notify(err instanceof Error ? err.message : 'Failed to set goal.', 'error');
+    }
+  }
+
+  function tokenBudgetOpts(): { tokenBudget?: number } {
+    return config.tokenBudget ? { tokenBudget: config.tokenBudget } : {};
+  }
+}
+
+function formatStatus(goal: ActiveGoal | undefined): string {
+  if (!goal) return 'goal: none';
+  if (goal.status === 'active') return `goal: active (${goal.iterations})`;
+  return `goal: ${goal.status}`;
+}
+
+function formatDetail(goal: ActiveGoal): string {
+  const lines = [
+    `Goal (${goal.origin}): ${goal.condition}`,
+    `Status: ${goal.status}`,
+    `Rounds: ${goal.iterations}`,
+  ];
+  if (goal.tokenBudget) lines.push(`Tokens: ~${goal.tokensUsed} / ${goal.tokenBudget}`);
+  if (goal.lastReason) lines.push(`Last check: ${goal.lastReason}`);
+  lines.push('/goal clear to stop early');
+  return lines.join('\n');
+}

--- a/packages/pi-goal/src/extension.ts
+++ b/packages/pi-goal/src/extension.ts
@@ -10,7 +10,7 @@ import { evaluateCondition } from './evaluate.js';
 import { type ActiveGoal, GoalState, isClearKeyword, MAX_CONDITION_LENGTH } from './goal-state.js';
 import type { GoalModelRegistry } from './llm.js';
 import { buildActivationMessage, buildContinueMessage } from './prompts.js';
-import { buildTranscript } from './transcript.js';
+import { buildTranscript, buildTranscriptWithMeta } from './transcript.js';
 
 const STATUS_KEY = 'pi-goal';
 
@@ -48,7 +48,10 @@ export async function runGoalEngine(
   if (!goal || goal.status !== 'active') return 'skipped';
   if (!config.model) return 'skipped'; // engine disabled without a model
 
-  const transcript = buildTranscript(messages, config.transcriptMaxChars);
+  const { text: transcript, omitted } = buildTranscriptWithMeta(
+    messages,
+    config.transcriptMaxChars,
+  );
   if (!transcript) return 'skipped';
 
   const verdict = await evaluateCondition({
@@ -56,6 +59,7 @@ export async function runGoalEngine(
     modelConfig: config.model,
     condition: goal.condition,
     transcript,
+    omittedCount: omitted,
     ...(deps.signal ? { signal: deps.signal } : {}),
   });
   // Model unavailable / call failed: do nothing this round (degrade quietly).

--- a/packages/pi-goal/src/goal-state.ts
+++ b/packages/pi-goal/src/goal-state.ts
@@ -1,0 +1,121 @@
+/**
+ * Session-scoped goal state. A single active goal per session, held in memory
+ * (mirrors Claude Code's session-level activeGoal — no cross-session persistence).
+ */
+
+export type GoalStatus =
+  | 'active'
+  | 'achieved'
+  | 'impossible'
+  | 'budget_limited'
+  | 'iteration_limited'
+  | 'cleared';
+
+export type GoalOrigin = 'derived' | 'explicit';
+
+export interface ActiveGoal {
+  condition: string;
+  origin: GoalOrigin;
+  status: GoalStatus;
+  iterations: number;
+  setAt: number;
+  lastReason?: string;
+  tokenBudget?: number;
+  tokensUsed: number;
+}
+
+/** Max length of a goal condition, matching Claude Code's 4000-char cap. */
+export const MAX_CONDITION_LENGTH = 4000;
+
+/** Keywords that clear an active goal (matches Claude Code's clear-keyword set). */
+export const CLEAR_KEYWORDS = new Set(['clear', 'stop', 'off', 'reset', 'none', 'cancel']);
+
+export function isClearKeyword(arg: string): boolean {
+  return CLEAR_KEYWORDS.has(arg.trim().toLowerCase());
+}
+
+/**
+ * Holds the single active goal for a session. Instantiated per-session in the
+ * extension; not shared across sessions.
+ */
+export class GoalState {
+  private goal: ActiveGoal | undefined;
+
+  get(): ActiveGoal | undefined {
+    return this.goal;
+  }
+
+  isActive(): boolean {
+    return this.goal?.status === 'active';
+  }
+
+  /**
+   * Set (or replace) the active goal. Throws on an empty or over-long condition
+   * so callers can surface a sanitized error to the user.
+   */
+  set(condition: string, origin: GoalOrigin, options: { tokenBudget?: number } = {}): ActiveGoal {
+    const trimmed = condition.trim();
+    if (!trimmed) {
+      throw new Error('Goal condition cannot be empty');
+    }
+    if (trimmed.length > MAX_CONDITION_LENGTH) {
+      throw new Error(`Goal condition is limited to ${MAX_CONDITION_LENGTH} characters`);
+    }
+    const goal: ActiveGoal = {
+      condition: trimmed,
+      origin,
+      status: 'active',
+      iterations: 0,
+      setAt: Date.now(),
+      tokensUsed: 0,
+    };
+    if (typeof options.tokenBudget === 'number' && options.tokenBudget > 0) {
+      goal.tokenBudget = options.tokenBudget;
+    }
+    this.goal = goal;
+    return goal;
+  }
+
+  clear(): ActiveGoal | undefined {
+    const previous = this.goal;
+    if (previous) {
+      previous.status = 'cleared';
+    }
+    this.goal = undefined;
+    return previous;
+  }
+
+  /** Record a not-yet-met round: bump iterations, store the evaluator's reason. */
+  recordIteration(reason: string, tokensUsed: number): ActiveGoal | undefined {
+    if (!this.goal) return undefined;
+    this.goal.iterations += 1;
+    this.goal.lastReason = reason;
+    this.goal.tokensUsed = tokensUsed;
+    return this.goal;
+  }
+
+  markAchieved(reason: string): ActiveGoal | undefined {
+    return this.transition('achieved', reason);
+  }
+
+  markImpossible(reason: string): ActiveGoal | undefined {
+    return this.transition('impossible', reason);
+  }
+
+  markBudgetLimited(reason?: string): ActiveGoal | undefined {
+    return this.transition('budget_limited', reason);
+  }
+
+  markIterationLimited(reason?: string): ActiveGoal | undefined {
+    return this.transition('iteration_limited', reason);
+  }
+
+  private transition(status: GoalStatus, reason?: string): ActiveGoal | undefined {
+    if (!this.goal) return undefined;
+    this.goal.status = status;
+    if (reason !== undefined) {
+      this.goal.lastReason = reason;
+    }
+    return this.goal;
+  }
+}

--- a/packages/pi-goal/src/index.ts
+++ b/packages/pi-goal/src/index.ts
@@ -1,0 +1,40 @@
+export {
+  DEFAULTS,
+  type GoalModelConfig,
+  loadSettings,
+  type PiGoalConfig,
+  type ResolvedGoalConfig,
+  resolveConfig,
+} from './config.js';
+export { type DeriveOptions, deriveCondition } from './derive.js';
+export {
+  type EvaluateOptions,
+  evaluateCondition,
+  type GoalVerdict,
+  parseVerdict,
+} from './evaluate.js';
+export {
+  default,
+  type GoalEngineDeps,
+  type PiGoalExtensionConfig,
+  runGoalEngine,
+} from './extension.js';
+export {
+  type ActiveGoal,
+  CLEAR_KEYWORDS,
+  type GoalOrigin,
+  GoalState,
+  type GoalStatus,
+  isClearKeyword,
+  MAX_CONDITION_LENGTH,
+} from './goal-state.js';
+export { completeOnce, type GoalModelRegistry } from './llm.js';
+export {
+  buildActivationMessage,
+  buildContinueMessage,
+  buildDeriveUserPrompt,
+  buildEvaluateUserPrompt,
+  DERIVE_SYSTEM_PROMPT,
+  EVALUATE_SYSTEM_PROMPT,
+} from './prompts.js';
+export { buildTranscript, extractText } from './transcript.js';

--- a/packages/pi-goal/src/index.ts
+++ b/packages/pi-goal/src/index.ts
@@ -34,7 +34,13 @@ export {
   buildContinueMessage,
   buildDeriveUserPrompt,
   buildEvaluateUserPrompt,
+  buildTruncationNote,
   DERIVE_SYSTEM_PROMPT,
   EVALUATE_SYSTEM_PROMPT,
 } from './prompts.js';
-export { buildTranscript, extractText } from './transcript.js';
+export {
+  buildTranscript,
+  buildTranscriptWithMeta,
+  extractText,
+  type TranscriptResult,
+} from './transcript.js';

--- a/packages/pi-goal/src/llm.ts
+++ b/packages/pi-goal/src/llm.ts
@@ -1,0 +1,101 @@
+/**
+ * Single-turn, tool-less LLM completion helper shared by the derive and
+ * evaluate steps. Wraps pi-agent-core's Agent + pi-ai's streamSimple, the same
+ * primitives pi-memory uses for background work.
+ */
+
+import { Agent } from '@earendil-works/pi-agent-core';
+import { streamSimple } from '@earendil-works/pi-ai/compat';
+import type { GoalModelConfig } from './config.js';
+
+/** Minimal slice of ctx.modelRegistry we depend on (kept narrow for testability). */
+export interface GoalModelRegistry {
+  find(provider: string, model: string): unknown;
+  getApiKeyAndHeaders(
+    model: unknown,
+  ): Promise<{ ok: boolean; apiKey?: string; headers?: Record<string, string>; error?: string }>;
+}
+
+interface AgentMessageLike {
+  role: string;
+  content: unknown;
+}
+
+/**
+ * Run one system+user prompt through the model and return the assistant's text.
+ * Returns null on any resolution/auth failure so callers can degrade gracefully
+ * (never throws for expected failures).
+ */
+export async function completeOnce(
+  registry: GoalModelRegistry,
+  modelConfig: GoalModelConfig,
+  systemPrompt: string,
+  userPrompt: string,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  const model = registry.find(modelConfig.provider, modelConfig.model);
+  if (!model) return null;
+
+  const auth = await registry.getApiKeyAndHeaders(model);
+  if (!auth.ok) return null;
+
+  const agent = new Agent({
+    initialState: {
+      systemPrompt,
+      model: model as never,
+      tools: [] as never[],
+    },
+    streamFn: (m: unknown, c: unknown, streamOpts?: unknown) => {
+      const merged = { ...((streamOpts as Record<string, unknown>) ?? {}) };
+      if (auth.apiKey) merged.apiKey = auth.apiKey;
+      if (auth.headers) merged.headers = auth.headers;
+      const existingSignal = (streamOpts as { signal?: AbortSignal } | undefined)?.signal;
+      if (!existingSignal && signal) merged.signal = signal;
+      return streamSimple(m as never, c as never, merged as never);
+    },
+    convertToLlm: (msgs: unknown) => msgs as never[],
+  });
+
+  // Tool-less: a single assistant turn ends the run. Guard against runaway anyway.
+  agent.subscribe((event: unknown) => {
+    if ((event as { type?: string }).type === 'turn_end') {
+      void agent.abort();
+    }
+  });
+
+  try {
+    await agent.prompt(userPrompt);
+  } catch {
+    return null;
+  }
+
+  return lastAssistantText(agent.state.messages as AgentMessageLike[]);
+}
+
+function lastAssistantText(messages: AgentMessageLike[]): string | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role !== 'assistant') continue;
+    const text = extractText(msg.content);
+    if (text) return text;
+  }
+  return null;
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (c): c is { type: string; text: string } =>
+          !!c &&
+          typeof c === 'object' &&
+          (c as { type?: unknown }).type === 'text' &&
+          typeof (c as { text?: unknown }).text === 'string',
+      )
+      .map((c) => c.text)
+      .join('\n')
+      .trim();
+  }
+  return '';
+}

--- a/packages/pi-goal/src/prompts.ts
+++ b/packages/pi-goal/src/prompts.ts
@@ -1,10 +1,11 @@
 /**
  * Prompt templates for the goal engine.
  *
- * - Derive: turn recent conversation into one measurable completion condition.
- * - Evaluate: judge whether a condition is met (JSON verdict), modeled on
- *   Claude Code's stop-condition evaluator.
- * - Activation / continue: messages injected into the main agent to drive it.
+ * The evaluator and activation prompts are adapted almost verbatim from Claude
+ * Code's own stop-hook prompts (agent-prompt-hook-condition-evaluator-stop,
+ * system-reminder-session-stop-hook-active), tuned only where pi's mechanics
+ * differ (a `/goal` command instead of CC's). The derive prompt has no CC
+ * analogue — CC always takes an explicit condition — so it is ours.
  */
 
 export const DERIVE_SYSTEM_PROMPT = `You infer a single, concrete completion condition from a coding conversation.
@@ -22,37 +23,52 @@ export function buildDeriveUserPrompt(transcript: string): string {
   return `## Recent conversation\n\n${transcript}\n\n---\nInfer the single measurable completion condition, or output NONE.`;
 }
 
-export const EVALUATE_SYSTEM_PROMPT = `You are evaluating a stop condition for a coding agent. Based on the conversation transcript, judge whether the user-provided condition is now satisfied.
+/**
+ * Stop-condition evaluator. Adapted from Claude Code's
+ * `agent-prompt-hook-condition-evaluator-stop` — the quote-evidence
+ * requirement, the "insufficient evidence in transcript" fallback, and the
+ * impossible-judgment discipline all come from CC's original wording.
+ */
+export const EVALUATE_SYSTEM_PROMPT = `You are evaluating a stop-condition hook. Read the conversation transcript carefully, then judge whether the user-provided condition is satisfied.
 
-Respond with a JSON object and NOTHING else. Shapes:
-- Met:        {"ok": true, "reason": "<why it is satisfied>"}
-- Not yet:    {"ok": false, "reason": "<what still remains>"}
-- Impossible: {"ok": false, "impossible": true, "reason": "<why it cannot be achieved>"}
+Your response must be a JSON object with one of these shapes:
+- {"ok": true, "reason": "<quote evidence from the transcript that satisfies the condition>"}
+- {"ok": false, "reason": "<quote what is missing or what blocks the condition>"}
+- {"ok": false, "impossible": true, "reason": "<explain why the condition can never be satisfied>"}
 
-Guidance:
-- Only report ok:true when the condition is genuinely and verifiably met by the work shown.
-- Use impossible sparingly — only when the condition can never be satisfied (contradictory, blocked by an external hard limit), not merely because it is unfinished.
-- Keep "reason" to one sentence.`;
+Always include a "reason" field, quoting specific text from the transcript whenever possible. If the transcript does not contain clear evidence that the condition is satisfied, return {"ok": false, "reason": "insufficient evidence in transcript"}.
 
-export function buildEvaluateUserPrompt(condition: string, transcript: string): string {
-  return `## Conversation transcript\n\n${transcript}\n\n## Condition\n\n${condition}\n\n---\nHas the condition been satisfied? Reply with the JSON verdict only.`;
+Only use {"ok": false, "impossible": true} when the condition is genuinely unachievable in this session — for example: the condition is self-contradictory, it depends on a resource or capability that is unavailable, or the assistant has explicitly tried, exhausted reasonable approaches, and stated it cannot be done. Apply your own judgment when deciding this — the assistant claiming the goal is impossible is evidence, not proof; independently confirm the condition is genuinely unachievable rather than deferring to the assistant's self-assessment. Do not use it just because the goal has not been reached yet or because progress is slow. When in doubt, return {"ok": false} without "impossible".`;
+
+/**
+ * Note prepended to the transcript when older messages were dropped to fit the
+ * evaluator's char cap. Adapted from CC's
+ * `system-prompt-hook-evaluator-truncated-transcript-note`: if the evidence
+ * might be in the omitted prefix, the evaluator should return insufficient
+ * evidence rather than guess.
+ */
+export function buildTruncationNote(omittedCount: number): string {
+  return `[Earlier conversation truncated to fit the evaluator's context window — ${omittedCount} earlier message(s) omitted. Evaluate the condition against the recent transcript below; if the required evidence may be in the omitted prefix, return {"ok": false, "reason": "insufficient evidence in transcript"}.]`;
 }
 
-/** Injected once when a goal is set, so the main agent starts working toward it. */
+export function buildEvaluateUserPrompt(
+  condition: string,
+  transcript: string,
+  omittedCount = 0,
+): string {
+  const note = omittedCount > 0 ? `${buildTruncationNote(omittedCount)}\n\n` : '';
+  return `## Conversation transcript\n\n${note}${transcript}\n\n## Condition\n\n${condition}\n\n---\nHas the condition been satisfied? Reply with the JSON verdict only.`;
+}
+
+/**
+ * Injected once when a goal is set, so the main agent starts working toward it.
+ * Adapted from CC's `system-reminder-session-stop-hook-active`.
+ */
 export function buildActivationMessage(condition: string): string {
-  return [
-    `A goal is now active with condition: "${condition}".`,
-    'Briefly acknowledge it, then immediately start (or continue) working toward it — treat the condition itself as your directive and do not pause to ask what to do.',
-    'You will be checked against this condition when you finish; work will resume automatically until it holds.',
-    'It clears automatically once the condition is met — do not tell the user to clear it after success.',
-  ].join(' ');
+  return `A goal is now active with condition: "${condition}". Briefly acknowledge the goal, then immediately start (or continue) working toward it — treat the condition itself as your directive and do not pause to ask the user what to do. Work will be blocked from stopping until the condition holds. It auto-clears once the condition is met — do not tell the user to run \`/goal clear\` after success; that's only for clearing a goal early.`;
 }
 
 /** Injected after a not-yet-met evaluation to drive the next round of work. */
 export function buildContinueMessage(condition: string, reason: string): string {
-  return [
-    `The goal is not yet met. Goal condition: "${condition}".`,
-    `What still remains: ${reason}`,
-    'Continue working toward the condition now.',
-  ].join(' ');
+  return `The goal condition is not yet met: "${condition}". ${reason} Continue working toward the condition now — do not stop until it holds.`;
 }

--- a/packages/pi-goal/src/prompts.ts
+++ b/packages/pi-goal/src/prompts.ts
@@ -1,0 +1,58 @@
+/**
+ * Prompt templates for the goal engine.
+ *
+ * - Derive: turn recent conversation into one measurable completion condition.
+ * - Evaluate: judge whether a condition is met (JSON verdict), modeled on
+ *   Claude Code's stop-condition evaluator.
+ * - Activation / continue: messages injected into the main agent to drive it.
+ */
+
+export const DERIVE_SYSTEM_PROMPT = `You infer a single, concrete completion condition from a coding conversation.
+
+Given the recent transcript, output ONE line describing the measurable outcome that would mean the user's current objective is fully handled. This condition will later be used to judge whether the agent may stop working.
+
+Rules:
+- Output ONLY the condition text — no preamble, no quotes, no markdown, no trailing explanation.
+- Make it measurable and verifiable (e.g. "All tests pass and \`pnpm lint\` reports no errors", "The /login endpoint returns 200 for valid credentials and 401 otherwise").
+- Base it on the user's most recent intent, not incidental side-quests.
+- Keep it under 300 characters.
+- If the conversation has no actionable objective, output exactly: NONE`;
+
+export function buildDeriveUserPrompt(transcript: string): string {
+  return `## Recent conversation\n\n${transcript}\n\n---\nInfer the single measurable completion condition, or output NONE.`;
+}
+
+export const EVALUATE_SYSTEM_PROMPT = `You are evaluating a stop condition for a coding agent. Based on the conversation transcript, judge whether the user-provided condition is now satisfied.
+
+Respond with a JSON object and NOTHING else. Shapes:
+- Met:        {"ok": true, "reason": "<why it is satisfied>"}
+- Not yet:    {"ok": false, "reason": "<what still remains>"}
+- Impossible: {"ok": false, "impossible": true, "reason": "<why it cannot be achieved>"}
+
+Guidance:
+- Only report ok:true when the condition is genuinely and verifiably met by the work shown.
+- Use impossible sparingly — only when the condition can never be satisfied (contradictory, blocked by an external hard limit), not merely because it is unfinished.
+- Keep "reason" to one sentence.`;
+
+export function buildEvaluateUserPrompt(condition: string, transcript: string): string {
+  return `## Conversation transcript\n\n${transcript}\n\n## Condition\n\n${condition}\n\n---\nHas the condition been satisfied? Reply with the JSON verdict only.`;
+}
+
+/** Injected once when a goal is set, so the main agent starts working toward it. */
+export function buildActivationMessage(condition: string): string {
+  return [
+    `A goal is now active with condition: "${condition}".`,
+    'Briefly acknowledge it, then immediately start (or continue) working toward it — treat the condition itself as your directive and do not pause to ask what to do.',
+    'You will be checked against this condition when you finish; work will resume automatically until it holds.',
+    'It clears automatically once the condition is met — do not tell the user to clear it after success.',
+  ].join(' ');
+}
+
+/** Injected after a not-yet-met evaluation to drive the next round of work. */
+export function buildContinueMessage(condition: string, reason: string): string {
+  return [
+    `The goal is not yet met. Goal condition: "${condition}".`,
+    `What still remains: ${reason}`,
+    'Continue working toward the condition now.',
+  ].join(' ');
+}

--- a/packages/pi-goal/src/transcript.ts
+++ b/packages/pi-goal/src/transcript.ts
@@ -9,22 +9,45 @@ interface MessageLike {
   content: unknown;
 }
 
-export function buildTranscript(messages: unknown[], maxChars: number): string {
+export interface TranscriptResult {
+  /** Formatted transcript, oldest included message first. */
+  text: string;
+  /** Count of text-bearing messages dropped because of the char cap. */
+  omitted: number;
+}
+
+/**
+ * Build the transcript and report how many text-bearing messages were dropped
+ * to fit the cap. The evaluator uses `omitted` to decide whether to warn that
+ * evidence may live in the truncated prefix (see buildTruncationNote).
+ */
+export function buildTranscriptWithMeta(messages: unknown[], maxChars: number): TranscriptResult {
   const lines: string[] = [];
   let total = 0;
+  let included = 0;
+  let textMessages = 0;
 
   for (let i = messages.length - 1; i >= 0; i--) {
     const msg = messages[i] as MessageLike | undefined;
     if (!msg || typeof msg.role !== 'string') continue;
     const text = extractText(msg.content);
     if (!text) continue;
+    textMessages += 1;
     const line = `[${msg.role}] ${text}`;
-    if (total + line.length > maxChars && lines.length > 0) break;
+    if (total + line.length > maxChars && lines.length > 0) {
+      // Cap hit: this and every older text message is omitted.
+      continue;
+    }
     lines.unshift(line);
     total += line.length;
+    included += 1;
   }
 
-  return lines.join('\n\n');
+  return { text: lines.join('\n\n'), omitted: Math.max(0, textMessages - included) };
+}
+
+export function buildTranscript(messages: unknown[], maxChars: number): string {
+  return buildTranscriptWithMeta(messages, maxChars).text;
 }
 
 export function extractText(content: unknown): string {

--- a/packages/pi-goal/src/transcript.ts
+++ b/packages/pi-goal/src/transcript.ts
@@ -1,0 +1,46 @@
+/**
+ * Build a compact text transcript from agent messages for derive/evaluate.
+ * Works backwards from the newest message so the most recent context survives
+ * the char cap (same approach as pi-memory's serializer).
+ */
+
+interface MessageLike {
+  role: string;
+  content: unknown;
+}
+
+export function buildTranscript(messages: unknown[], maxChars: number): string {
+  const lines: string[] = [];
+  let total = 0;
+
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i] as MessageLike | undefined;
+    if (!msg || typeof msg.role !== 'string') continue;
+    const text = extractText(msg.content);
+    if (!text) continue;
+    const line = `[${msg.role}] ${text}`;
+    if (total + line.length > maxChars && lines.length > 0) break;
+    lines.unshift(line);
+    total += line.length;
+  }
+
+  return lines.join('\n\n');
+}
+
+export function extractText(content: unknown): string {
+  if (typeof content === 'string') return content.trim();
+  if (Array.isArray(content)) {
+    return content
+      .filter(
+        (c): c is { type: string; text: string } =>
+          !!c &&
+          typeof c === 'object' &&
+          (c as { type?: unknown }).type === 'text' &&
+          typeof (c as { text?: unknown }).text === 'string',
+      )
+      .map((c) => c.text)
+      .join('\n')
+      .trim();
+  }
+  return '';
+}

--- a/packages/pi-goal/tsconfig.json
+++ b/packages/pi-goal/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "references": [
+    { "path": "../shared" }
+  ],
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,28 @@ importers:
         specifier: ^4.0.0
         version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/pi-goal:
+    dependencies:
+      '@amaster.ai/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: 0.80.3
+        version: 0.80.3(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: 0.80.3
+        version: 0.80.3(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 0.80.3
+        version: 0.80.3(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+      typebox:
+        specifier: '*'
+        version: 1.1.38
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(vite@8.0.13(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/pi-image-gen:
     dependencies:
       '@amaster.ai/pi-shared':

--- a/tests/eval/.gitignore
+++ b/tests/eval/.gitignore
@@ -1,2 +1,4 @@
 datasets/
 results/
+# chrome-devtools-mcp / take_snapshot can dump a snapshot file into cwd during a run
+snapshot.txt

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -17,9 +17,16 @@ tests/eval/
   src/
     loaders/locomo.ts   # forgiving JSON adapter
     judge.ts            # token-F1 helper (fast in-runner baseline)
+    pi-harness.ts       # shared driver: real `pi` CLI + isolated config + event-stream parse
   memory/
     run-mem0.ts         # pi-memory-mem0 runner (passive extraction)
     run-memory.ts       # pi-memory runner (real memory_add/replace/remove loop)
+  browser/
+    run-browser.ts      # pi-browser-use L3 runner (real Chrome via pi CLI)
+    tasks.ts            # browser task set + deterministic success predicates
+  computer/
+    run-computer.ts     # pi-computer-use L3 runner (real cua-driver via pi CLI; macOS-only)
+    tasks.ts            # desktop task set + deterministic success predicates
 ```
 
 ## Quick start
@@ -45,6 +52,127 @@ pnpm --filter @amaster.ai/pi-eval judge:llm -- \
 ```
 
 Platform mode for mem0 (`--mode platform`) reads `MEM0_API_KEY` instead.
+
+## Browser (pi-browser-use L3 — task-completion rate)
+
+Answers the "does it actually work" question: a **real** tool-calling LLM must
+complete a task using only the `browser_*` tools, driving a **real Chrome**. It
+drives the extension through the **real `pi` CLI** — the same way
+`.github/workflows/integration.yml` does: install the extension with `pi install`
+into an isolated config dir, then `pi --mode json -p '<task>' --tools <allowlist>`
+and parse the event stream. The extension runs exactly as shipped (built dist,
+pi's own dependency resolution), so the success rate reflects the real wrapper
+(snapshot handling, tool descriptions, overlay/stale hints) plus the model — no
+importing package internals, no hand-rolled tool loop.
+
+Nothing is hardcoded. Provider, model, endpoint, and key are all parameterized:
+
+```bash
+# endpoint + key from env (repo convention: PI_INTEGRATION_*). The generated
+# models.json references the key by env-var NAME, so the secret never lands on disk.
+export PI_INTEGRATION_BASE_URL="https://your-gateway/v1"
+export PI_INTEGRATION_API_KEY="sk-..."
+
+pnpm --filter @amaster.ai/pi-eval eval:browser -- \
+  --provider deepseek-integration --model deepseek-v4-flash
+
+# single task:
+pnpm --filter @amaster.ai/pi-eval eval:browser -- --task example-title
+
+# LLM-judge the run (only needed for tasks without a deterministic `check`):
+pnpm --filter @amaster.ai/pi-eval judge:llm -- \
+  --input results/browser-tasks.json --llm-model deepseek-v4-pro --models "$MODELS"
+```
+
+Flags (all optional, with env fallbacks): `--models <path>` (use a ready-made
+models.json verbatim — what CI does; `PI_MODELS_PATH`), or generate one from
+`--provider` (`PI_EVAL_PROVIDER`, default `deepseek-integration`), `--model`
+(`PI_EVAL_MODEL`), `--base-url` (`PI_INTEGRATION_BASE_URL`), `--api`
+(`PI_EVAL_API`, default `openai-completions`), `--api-key-env`
+(`PI_EVAL_API_KEY_ENV`, default `PI_INTEGRATION_API_KEY` — names the env var
+holding the key). Plus `--thinking` (default `high`), `--timeout` (per-task ms),
+`--tasks N`, `--task <id>`. Chrome is found via `CHROME_BIN` or common
+macOS/Linux paths; if none, install one with
+`npx -y @puppeteer/browsers install chrome@stable` and set `CHROME_BIN` (the
+Linux-CI step from integration.yml).
+
+**Scoring.** Each task in `browser/tasks.ts` carries a deterministic
+`check(answer, observed)` predicate — success is a string/regex match over the
+model's final answer plus the tool outputs it saw. No LLM in the scoring path, so
+numbers are stable and free. Tasks that genuinely can't be reduced to a match
+omit `check` and defer to `judge-llm.ts` (every task still sets `gold`). The
+summary reports `successRate` (over checked, non-crashed tasks), `avgTurns`
+(model round-trips to reach a passing answer — **fewer is better**; a sharper
+wrapper/prompt lets the model finish in fewer turns), `avgToolCalls`, and a
+`failureMix` bucketing each task as `ok` / `check-failed` / `tool-error` /
+`crash` — a regression in, say, snapshot stripping shows up as a shift in the mix.
+
+Task coverage aims at the failure modes the wrapper is responsible for, not just
+happy-path reads: single reads (`example-*`, pinned Wikipedia), form fill+submit
+(`login-form-submit` — two fields + submit on the-internet.herokuapp.com), and
+**multi-step navigation** (`multi-step-navigate` — click a link, re-snapshot
+after uids invalidate), which exercises the extension's stale-element handling.
+Seeds are chosen for stability: IANA-reserved `example.com`/`example.org`, pinned
+Wikipedia `oldid`s, and the SeleniumHQ demo site — httpbin.org was dropped after
+it flaked repeatedly (503s / timeouts) in trial runs.
+
+**CI.** Runs as the manual **Agentic Eval** workflow
+(`.github/workflows/agentic-eval.yml`, `workflow_dispatch`) — kept separate from
+integration.yml, which is a pass/fail smoke test; this one is effect evaluation.
+The workflow installs a real Chrome and writes models.json from the
+`PI_INTEGRATION_*` secrets, then runs this runner and publishes a scored summary.
+
+Known variance:
+- **Site availability.** Seed sites can be down — a seed 503 shows up (correctly)
+  as `check-failed`/`tool-error`. Prefer static seeds; re-run before reading a
+  single-run failure as a regression.
+- **Model drift.** Temperature aside, tool-calling models still vary run-to-run
+  in tool-call count and page-reading accuracy. Treat `successRate` as ±.
+- **Wikipedia** tasks pin an `oldid` so article text can't drift; other seeds are
+  chosen for stability but are not pinned.
+
+## Computer (pi-computer-use L3 — desktop task-completion rate)
+
+Same shape and same `pi`-CLI harness as the browser eval, one level lower: a real
+tool-calling LLM drives **real macOS desktop apps** via `computer_use_*` tools.
+The extension (with its own `formatToolError` / bundled `cua-driver`) runs as
+shipped. Most seed apps are built-in system apps (Calculator, TextEdit, Notes) so
+results are deterministic and offline. One task (`netease-daily-recommend`)
+drives a real third-party app (NetEase Cloud Music) to its 每日推荐 entry — a
+genuine agentic-interaction case; its `check` only verifies the agent reached the
+recommendation view (content is login-gated and changes daily), and it is skipped
+implicitly if the app isn't installed (the launch tool errors → `tool-error`).
+
+```bash
+export PI_INTEGRATION_BASE_URL="https://your-gateway/v1"
+export PI_INTEGRATION_API_KEY="sk-..."
+
+pnpm --filter @amaster.ai/pi-eval eval:computer -- \
+  --provider amaster --model deepseek-v4-flash
+
+pnpm --filter @amaster.ai/pi-eval judge:llm -- \
+  --input results/computer-tasks.json --llm-model deepseek-v4-pro --models "$MODELS"
+```
+
+Flags are identical to the browser runner. Result file:
+`results/computer-tasks.json`, same summary shape.
+
+**macOS-only, and skips gracefully elsewhere.** On any non-macOS platform (e.g. a
+Linux CI runner) the runner writes a `{skipped: true}` result and exits 0 — it
+never fails a cross-platform pipeline. On macOS it requires:
+- The bundled `cua-driver` binary for your platform
+  (`packages/pi-computer-use/bin/<platform>/`).
+- **Accessibility** *and* **Screen Recording** granted to the process running the
+  eval (System Settings → Privacy & Security). Without them cua-driver returns
+  `ax_not_granted` / `sc_not_granted`; the extension's own permission hint then
+  surfaces in the tool output and tasks fail as `tool-error`.
+- Apps launch **visibly** and receive synthetic clicks/keystrokes — don't run
+  this while doing other work on the same machine.
+
+The **Agentic Eval** workflow includes a `computer-eval` job (run it via the
+`target` input), but there is no hosted macOS runner wired to it yet — on the
+Linux runner it no-ops via the graceful skip above. Point the job's `runs-on` at
+a macOS runner with the TCC grants to get real numbers.
 
 ## Datasets
 

--- a/tests/eval/browser/run-browser.ts
+++ b/tests/eval/browser/run-browser.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * pi-browser-use L3 eval: task-completion rate, driven through the REAL `pi` CLI.
+ *
+ * Sets up an isolated pi config dir, installs pi-browser-use, then runs each task
+ * in browser/tasks.ts via `pi --mode json -p '<task>' --tools <allowlist>` and
+ * scores the result with the task's deterministic `check`. Because the extension
+ * is installed and run exactly as shipped, the success rate reflects the real
+ * wrapper (snapshot handling, tool descriptions, overlay/stale hints) plus the
+ * model — no importing package internals.
+ *
+ * REQUIRES: `pi` on PATH, a real Chrome (found via CHROME_BIN or common paths),
+ * and a working provider — either --models <models.json> or --base-url +
+ * PI_INTEGRATION_API_KEY. Runs on Linux/macOS. See README.
+ *
+ * Usage:
+ *   PI_INTEGRATION_BASE_URL=... PI_INTEGRATION_API_KEY=... \
+ *     pnpm --filter @amaster.ai/pi-eval eval:browser -- --model deepseek-v4-flash
+ *   # or with a ready models.json (what CI does):
+ *   pnpm --filter @amaster.ai/pi-eval eval:browser -- --models /path/to/models.json
+ */
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  type DriveResult,
+  drivePrompt,
+  type FailureMode,
+  parseCommonArgs,
+  setupHarness,
+  toHarnessConfig,
+} from '../src/pi-harness.js';
+import { type BrowserTask, BROWSER_TASKS, DEFAULT_BROWSER_TOOLS } from './tasks.js';
+
+interface Row {
+  task: string;
+  question: string;
+  gold: string;
+  success: number;
+  hasCheck: boolean;
+  turns: number;
+  toolCalls: number;
+  failureMode: FailureMode;
+  answer: string;
+  blob: string;
+  error?: string;
+}
+
+/**
+ * Locate a Chrome/Chromium binary for chrome-devtools-mcp, cross-platform.
+ * Override via CHROME_BIN. Checks common macOS + Linux locations; returns
+ * undefined if none found (caller prints the npx-install hint).
+ */
+function resolveChrome(): string | undefined {
+  if (process.env.CHROME_BIN && existsSync(process.env.CHROME_BIN)) return process.env.CHROME_BIN;
+  const candidates = [
+    // macOS
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    // Linux
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/snap/bin/chromium',
+  ];
+  return candidates.find((c) => existsSync(c));
+}
+
+function buildPrompt(task: BrowserTask): string {
+  return `Start URL: ${task.startUrl}\n\nTask: ${task.instruction}\n\nNavigate to the start URL first (take a snapshot after each navigation/action to see the page), then complete the task and reply with a final plain-text answer stating the requested value.`;
+}
+
+function scoreTask(task: BrowserTask, drive: DriveResult): Row {
+  const observed = drive.observed.toLowerCase();
+  const answer = drive.answer.toLowerCase();
+  let failureMode = drive.failureMode;
+  let success = 0;
+
+  if (failureMode === 'ok') {
+    if (task.check) {
+      const passed = task.check({ answer, observed });
+      success = passed ? 1 : 0;
+      if (!passed) failureMode = drive.sawToolError ? 'tool-error' : 'check-failed';
+    } else if (drive.sawToolError) {
+      failureMode = 'tool-error';
+    }
+  }
+
+  return {
+    task: task.id,
+    question: task.instruction,
+    gold: task.gold,
+    success,
+    hasCheck: Boolean(task.check),
+    turns: drive.turns,
+    toolCalls: drive.toolCalls,
+    failureMode,
+    answer: drive.answer,
+    blob: `FINAL ANSWER: ${drive.answer}\n\nOBSERVED:\n${drive.observed}`,
+    ...(drive.error ? { error: drive.error } : {}),
+  };
+}
+
+async function main() {
+  const args = parseCommonArgs({ model: 'deepseek-v4-flash', timeoutMs: 180_000 });
+  const hcfg = toHarnessConfig(args);
+
+  const chrome = resolveChrome();
+  if (!chrome) {
+    throw new Error(
+      'No Chrome binary found. Set CHROME_BIN, or install one: ' +
+        '`npx -y @puppeteer/browsers install chrome@stable --path <dir>` then point CHROME_BIN at it. ' +
+        '(On Linux CI this is the same step integration.yml uses.)',
+    );
+  }
+
+  let selected = args.taskId
+    ? BROWSER_TASKS.filter((t) => t.id === args.taskId)
+    : BROWSER_TASKS;
+  if (args.tasks > 0) selected = selected.slice(0, args.tasks);
+  if (selected.length === 0) throw new Error('no tasks selected');
+
+  process.stderr.write(
+    `[eval:browser] tasks=${selected.length} model=${args.provider}/${args.model} chrome=${chrome}\n`,
+  );
+
+  const harness = await setupHarness(hcfg, {
+    pkg: 'pi-browser-use',
+    settings: {
+      'pi-browser-use': {
+        headless: true,
+        sessionMode: 'isolated',
+        viewport: '1280x720',
+        executablePath: chrome,
+      },
+    },
+  });
+
+  const rows: Row[] = [];
+  try {
+    // Sequential: chrome-devtools-mcp is stateful per session, and each `pi`
+    // invocation spins up its own isolated browser anyway.
+    for (const task of selected) {
+      process.stderr.write(`[eval:browser] start ${task.id}\n`);
+      const drive = await drivePrompt(
+        harness,
+        hcfg,
+        buildPrompt(task),
+        task.tools ?? DEFAULT_BROWSER_TOOLS,
+      );
+      const row = scoreTask(task, drive);
+      rows.push(row);
+      process.stderr.write(
+        `[eval:browser] done ${task.id}: success=${row.success} mode=${row.failureMode} turns=${row.turns} tools=${row.toolCalls}${row.error ? ` err=${row.error.slice(0, 80)}` : ''}\n`,
+      );
+    }
+  } finally {
+    harness.cleanup();
+  }
+
+  const checked = rows.filter((r) => r.hasCheck && r.failureMode !== 'crash');
+  const successRate = checked.reduce((a, r) => a + r.success, 0) / Math.max(1, checked.length);
+  const avgToolCalls = rows.reduce((a, r) => a + r.toolCalls, 0) / Math.max(1, rows.length);
+  // Turns-to-success: efficiency of the runs that actually completed. Averaging
+  // over failures would conflate "slow" with "gave up", so restrict to passes.
+  const passed = rows.filter((r) => r.success === 1);
+  const avgTurns = passed.reduce((a, r) => a + r.turns, 0) / Math.max(1, passed.length);
+  const failureMix: Record<string, number> = {};
+  for (const r of rows) failureMix[r.failureMode] = (failureMix[r.failureMode] ?? 0) + 1;
+
+  const summary = {
+    model: `${args.provider}/${args.model}`,
+    n: rows.length,
+    nChecked: checked.length,
+    successRate,
+    avgTurns,
+    avgToolCalls,
+    failureMix,
+  };
+  process.stderr.write(`[eval:browser] ${JSON.stringify(summary)}\n`);
+
+  const outDir = path.resolve(import.meta.dirname, '..', 'results');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, 'browser-tasks.json'), JSON.stringify({ summary, rows }, null, 2));
+}
+
+main().catch((err) => {
+  process.stderr.write(`[eval:browser] error: ${err.stack ?? err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/browser/tasks.ts
+++ b/tests/eval/browser/tasks.ts
@@ -1,0 +1,120 @@
+/**
+ * Browser task set for the pi-browser-use L3 (task-completion) eval.
+ *
+ * Each task is a self-contained agentic goal driven through the real `pi` CLI:
+ * the model is given the start URL in the prompt and must reach `instruction`
+ * using only the whitelisted `browser_*` tools. Sites are chosen to be as stable
+ * as possible (static pages, httpbin, a pinned Wikipedia revision) so day-to-day
+ * flakiness reflects the browser/model stack, not content churn.
+ *
+ * Success is decided by `check` — a deterministic predicate over the run's
+ * transcript (the model's final answer plus the concatenated tool outputs it
+ * saw). Keep predicates tolerant of formatting: lowercase-compare, accept
+ * restatements. When a task's success signal genuinely can't be reduced to a
+ * string match, leave `check` undefined and the runner defers to the shared LLM
+ * judge (judge-llm.ts).
+ */
+
+/** Default browser tool allowlist covering navigation + read + basic interaction. */
+export const DEFAULT_BROWSER_TOOLS =
+  'browser_navigate_page,browser_take_snapshot,browser_click,browser_fill,browser_fill_form,browser_press_key';
+
+export interface BrowserTask {
+  id: string;
+  /** Page the agent starts on (embedded into the prompt). */
+  startUrl: string;
+  /** Natural-language goal handed to the model. */
+  instruction: string;
+  /** Comma-separated `--tools` allowlist. Defaults to DEFAULT_BROWSER_TOOLS. */
+  tools?: string;
+  /**
+   * Deterministic success predicate. Receives the lowercased final answer and
+   * the lowercased concatenation of all tool outputs the agent observed.
+   * Return true iff the task is complete. Omit to defer to the LLM judge.
+   */
+  check?: (ctx: { answer: string; observed: string }) => boolean;
+  /**
+   * Gold string used only by the LLM-judge fallback (judge-llm.ts reads `gold`).
+   * Always set it so a judge pass has ground truth even when `check` exists.
+   */
+  gold: string;
+}
+
+const includes = (needle: string) => (ctx: { answer: string; observed: string }) =>
+  ctx.answer.includes(needle.toLowerCase()) || ctx.observed.includes(needle.toLowerCase());
+
+export const BROWSER_TASKS: BrowserTask[] = [
+  {
+    id: 'example-title',
+    startUrl: 'https://example.com/',
+    instruction:
+      'Navigate to the page and report the main heading (the large <h1> text) exactly as it appears.',
+    gold: 'Example Domain',
+    check: includes('example domain'),
+  },
+  {
+    id: 'example-link-text',
+    startUrl: 'https://example.com/',
+    instruction:
+      'On this page there is a single link in the body. Report the visible text of that link.',
+    gold: 'Learn more',
+    // example.com's body link text is "Learn more" (verified live). Accept the
+    // older "More information" wording too in case the page reverts.
+    check: ({ answer, observed }) =>
+      /learn more|more information/.test(`${answer}\n${observed}`),
+  },
+  {
+    // example.org is the same IANA-reserved static page as example.com (never
+    // changes, tiny). A second read seed that does NOT depend on httpbin.
+    id: 'example-org-title',
+    startUrl: 'https://example.org/',
+    instruction:
+      'Navigate to the page and report its main heading (the large <h1> text).',
+    gold: 'Example Domain',
+    check: includes('example domain'),
+  },
+  {
+    // Form fill + submit on a stable automation test site (the-internet is the
+    // standard SeleniumHQ demo site — content is fixed, unlike httpbin which was
+    // observed flaking with 503s). Fills two fields and clicks Login; the known
+    // valid credentials land on a "Secure Area" page.
+    id: 'login-form-submit',
+    startUrl: 'https://the-internet.herokuapp.com/login',
+    instruction:
+      'This is a login form. Enter the username "tomsmith" and the password "SuperSecretPassword!", then click the Login button. After logging in, report the heading or confirmation message shown on the resulting page.',
+    gold: 'Secure Area',
+    tools:
+      'browser_navigate_page,browser_take_snapshot,browser_click,browser_fill,browser_fill_form,browser_wait_for',
+    check: ({ answer, observed }) =>
+      /secure area|logged into/i.test(`${answer}\n${observed}`),
+  },
+  {
+    id: 'wikipedia-pinned-first-sentence',
+    // Pinned oldid so the article text cannot drift between runs.
+    startUrl:
+      'https://en.wikipedia.org/w/index.php?title=Web_browser&oldid=1230000000',
+    instruction:
+      'Read the first sentence of this article and report what kind of software application a "web browser" is described as.',
+    gold: 'application for accessing websites',
+    // Tolerant: the lead defines it as an application for accessing the World
+    // Wide Web / websites. Accept either phrasing.
+    check: ({ answer, observed }) => {
+      const hay = `${answer}\n${observed}`;
+      return /web browser/.test(hay) && /(access|accessing).*(web|website|internet)/.test(hay);
+    },
+  },
+  {
+    // Multi-step navigation: click a link on the index, land on a new page,
+    // re-snapshot (uids invalidate after the click) and read it — exercising the
+    // extension's stale-element handling. the-internet's index is a fixed list of
+    // named example links, so the target text is deterministic.
+    id: 'multi-step-navigate',
+    startUrl: 'https://the-internet.herokuapp.com/',
+    instruction:
+      'This page is an index of example links. Click the link titled "A/B Testing". After the new page loads, take a fresh snapshot and report the main heading shown on that page.',
+    gold: 'A/B Test',
+    tools:
+      'browser_navigate_page,browser_take_snapshot,browser_click,browser_wait_for',
+    check: ({ answer, observed }) => /a\/b test/i.test(`${answer}\n${observed}`),
+  },
+];

--- a/tests/eval/computer/run-computer.ts
+++ b/tests/eval/computer/run-computer.ts
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * pi-computer-use L3 eval: desktop task-completion rate, driven through the REAL
+ * `pi` CLI. Same shape as the browser eval, one level lower: installs
+ * pi-computer-use into an isolated pi config dir and runs each task in
+ * computer/tasks.ts via `pi --mode json -p '<task>' --tools <allowlist>`, driving
+ * real macOS apps through the cua-driver the extension bundles. Scoring is the
+ * task's deterministic `check`.
+ *
+ * REQUIRES: macOS, `pi` on PATH, the bundled cua-driver binary, a working
+ * provider (--models <models.json> or --base-url + PI_INTEGRATION_API_KEY), and
+ * Accessibility + Screen Recording granted to the process. Apps launch visibly
+ * and receive synthetic input. Skips gracefully on non-macOS. See README.
+ *
+ * Usage:
+ *   PI_INTEGRATION_BASE_URL=... PI_INTEGRATION_API_KEY=... \
+ *     pnpm --filter @amaster.ai/pi-eval eval:computer -- --model deepseek-v4-flash
+ *   # or with a ready models.json (what CI does):
+ *   pnpm --filter @amaster.ai/pi-eval eval:computer -- --models /path/to/models.json
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  type DriveResult,
+  drivePrompt,
+  type FailureMode,
+  parseCommonArgs,
+  setupHarness,
+  toHarnessConfig,
+} from '../src/pi-harness.js';
+import { DEFAULT_COMPUTER_TOOLS, type DesktopTask, DESKTOP_TASKS } from './tasks.js';
+
+interface Row {
+  task: string;
+  question: string;
+  gold: string;
+  success: number;
+  hasCheck: boolean;
+  turns: number;
+  toolCalls: number;
+  failureMode: FailureMode;
+  answer: string;
+  blob: string;
+  error?: string;
+}
+
+function buildPrompt(task: DesktopTask): string {
+  return `Target app: ${task.appName} (bundle id: ${task.bundleId})\n\nTask: ${task.instruction}\n\nLaunch the target app first (computer_use_launch_app), then use list_windows + get_window_state to inspect it, act, and reply with a final plain-text answer stating the requested value.`;
+}
+
+function scoreTask(task: DesktopTask, drive: DriveResult): Row {
+  const observed = drive.observed.toLowerCase();
+  const answer = drive.answer.toLowerCase();
+  let failureMode = drive.failureMode;
+  let success = 0;
+
+  if (failureMode === 'ok') {
+    if (task.check) {
+      const passed = task.check({ answer, observed });
+      success = passed ? 1 : 0;
+      if (!passed) failureMode = drive.sawToolError ? 'tool-error' : 'check-failed';
+    } else if (drive.sawToolError) {
+      failureMode = 'tool-error';
+    }
+  }
+
+  return {
+    task: task.id,
+    question: task.instruction,
+    gold: task.gold,
+    success,
+    hasCheck: Boolean(task.check),
+    turns: drive.turns,
+    toolCalls: drive.toolCalls,
+    failureMode,
+    answer: drive.answer,
+    blob: `FINAL ANSWER: ${drive.answer}\n\nOBSERVED:\n${drive.observed}`,
+    ...(drive.error ? { error: drive.error } : {}),
+  };
+}
+
+async function main() {
+  // Desktop automation needs a real macOS session + TCC grants. On any other
+  // platform (e.g. Linux CI) skip GRACEFULLY — write an empty skipped result and
+  // exit 0 so this never fails a cross-platform pipeline.
+  if (process.platform !== 'darwin') {
+    process.stderr.write(
+      `[eval:computer] skipped: requires macOS desktop (got ${process.platform}). ` +
+        'cua-driver drives real apps and needs Accessibility + Screen Recording.\n',
+    );
+    const outDir = path.resolve(import.meta.dirname, '..', 'results');
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(
+      path.join(outDir, 'computer-tasks.json'),
+      JSON.stringify(
+        { summary: { skipped: true, reason: `platform ${process.platform} is not macOS` }, rows: [] },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const args = parseCommonArgs({ model: 'deepseek-v4-flash', timeoutMs: 240_000 });
+  const hcfg = toHarnessConfig(args);
+
+  let selected = args.taskId
+    ? DESKTOP_TASKS.filter((t) => t.id === args.taskId)
+    : DESKTOP_TASKS;
+  if (args.tasks > 0) selected = selected.slice(0, args.tasks);
+  if (selected.length === 0) throw new Error('no tasks selected');
+
+  process.stderr.write(
+    `[eval:computer] tasks=${selected.length} model=${args.provider}/${args.model}\n`,
+  );
+  process.stderr.write(
+    '[eval:computer] NOTE: needs Accessibility + Screen Recording granted to this process; apps will visibly launch.\n',
+  );
+
+  const harness = await setupHarness(hcfg, {
+    pkg: 'pi-computer-use',
+    settings: { 'pi-computer-use': { mode: 'bundled' } },
+  });
+
+  const rows: Row[] = [];
+  try {
+    for (const task of selected) {
+      process.stderr.write(`[eval:computer] start ${task.id}\n`);
+      const drive = await drivePrompt(
+        harness,
+        hcfg,
+        buildPrompt(task),
+        task.tools ?? DEFAULT_COMPUTER_TOOLS,
+      );
+      const row = scoreTask(task, drive);
+      rows.push(row);
+      process.stderr.write(
+        `[eval:computer] done ${task.id}: success=${row.success} mode=${row.failureMode} turns=${row.turns} tools=${row.toolCalls}${row.error ? ` err=${row.error.slice(0, 80)}` : ''}\n`,
+      );
+    }
+  } finally {
+    harness.cleanup();
+  }
+
+  const checked = rows.filter((r) => r.hasCheck && r.failureMode !== 'crash');
+  const successRate = checked.reduce((a, r) => a + r.success, 0) / Math.max(1, checked.length);
+  const avgToolCalls = rows.reduce((a, r) => a + r.toolCalls, 0) / Math.max(1, rows.length);
+  // Turns-to-success only (see browser runner rationale).
+  const passed = rows.filter((r) => r.success === 1);
+  const avgTurns = passed.reduce((a, r) => a + r.turns, 0) / Math.max(1, passed.length);
+  const failureMix: Record<string, number> = {};
+  for (const r of rows) failureMix[r.failureMode] = (failureMix[r.failureMode] ?? 0) + 1;
+
+  const summary = {
+    model: `${args.provider}/${args.model}`,
+    n: rows.length,
+    nChecked: checked.length,
+    successRate,
+    avgTurns,
+    avgToolCalls,
+    failureMix,
+  };
+  process.stderr.write(`[eval:computer] ${JSON.stringify(summary)}\n`);
+
+  const outDir = path.resolve(import.meta.dirname, '..', 'results');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, 'computer-tasks.json'), JSON.stringify({ summary, rows }, null, 2));
+}
+
+main().catch((err) => {
+  process.stderr.write(`[eval:computer] error: ${err.stack ?? err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/computer/tasks.ts
+++ b/tests/eval/computer/tasks.ts
@@ -1,0 +1,113 @@
+/**
+ * Desktop task set for the pi-computer-use L3 (task-completion) eval.
+ *
+ * Driven through the real `pi` CLI. Unlike browser tasks (URL-driven), desktop
+ * tasks are app-driven: the agent must launch/target a real macOS app by
+ * pid + window_id and drive its AX tree. Seeds are built-in system apps so
+ * results are deterministic and offline — the default is Calculator
+ * (com.apple.calculator): launch → read/click buttons → read the display.
+ *
+ * Success is decided by `check(answer, observed)` over the run transcript (the
+ * model's final answer plus the concatenated tool outputs it saw). Tasks that
+ * can't be reduced to a match omit `check` and defer to judge-llm.ts; every task
+ * still sets `gold` for that fallback.
+ *
+ * REQUIRES a real macOS desktop session with Accessibility + Screen Recording
+ * granted to the process running the eval. Cannot run headless / in CI.
+ */
+
+/** Default computer_use tool allowlist covering launch → inspect → act → read. */
+export const DEFAULT_COMPUTER_TOOLS =
+  'computer_use_launch_app,computer_use_list_windows,computer_use_get_window_state,computer_use_click,computer_use_type_text,computer_use_press_key,computer_use_get_accessibility_tree';
+
+export interface DesktopTask {
+  id: string;
+  /** Bundle id the agent should launch/target first. */
+  bundleId: string;
+  /** Human-readable app name (used in the instruction). */
+  appName: string;
+  /** Natural-language goal handed to the model. */
+  instruction: string;
+  /** Comma-separated `--tools` allowlist. Defaults to DEFAULT_COMPUTER_TOOLS. */
+  tools?: string;
+  /**
+   * Deterministic success predicate over the lowercased final answer and the
+   * lowercased concatenation of all tool outputs observed. Omit to defer to the
+   * LLM judge.
+   */
+  check?: (ctx: { answer: string; observed: string }) => boolean;
+  /** Gold string for the judge-llm.ts fallback. Always set. */
+  gold: string;
+}
+
+const includes = (needle: string) => (ctx: { answer: string; observed: string }) =>
+  ctx.answer.includes(needle.toLowerCase()) || ctx.observed.includes(needle.toLowerCase());
+
+export const DESKTOP_TASKS: DesktopTask[] = [
+  {
+    id: 'calc-add',
+    bundleId: 'com.apple.calculator',
+    appName: 'Calculator',
+    instruction:
+      'Using the Calculator app, compute 7 + 8 by clicking the buttons (7, then +, then 8, then =). Then report the number shown on the calculator display.',
+    gold: '15',
+    check: includes('15'),
+  },
+  {
+    id: 'calc-multiply',
+    bundleId: 'com.apple.calculator',
+    appName: 'Calculator',
+    instruction:
+      'Using the Calculator app, compute 6 × 9 (click 6, then the multiply button ×, then 9, then =). Report the number shown on the display.',
+    gold: '54',
+    check: includes('54'),
+  },
+  {
+    id: 'calc-read-window-title',
+    bundleId: 'com.apple.calculator',
+    appName: 'Calculator',
+    instruction:
+      'Launch the Calculator app and inspect its window. Report the title of the Calculator window as it appears in the accessibility tree.',
+    gold: 'Calculator',
+    check: includes('calculator'),
+  },
+  {
+    id: 'textedit-type',
+    bundleId: 'com.apple.TextEdit',
+    appName: 'TextEdit',
+    instruction:
+      'Open TextEdit (it will show a new blank document), then type the exact text PiEvalOK into the document. Confirm by reporting the text that now appears in the document body.',
+    gold: 'PiEvalOK',
+    check: includes('pievalok'),
+  },
+  {
+    id: 'notes-read-list',
+    bundleId: 'com.apple.Notes',
+    appName: 'Notes',
+    instruction:
+      'Launch the Notes app and inspect its window with get_window_state. Report the title of one note visible in the notes list, or state clearly that the list is empty.',
+    gold: 'a note title or empty',
+    // Content is user-specific, so accept any plausible completion signal: the app
+    // opened and its AX tree was read (a note title, or an explicit "empty"/"no notes").
+    check: ({ observed, answer }) =>
+      /notes|note|empty|no notes/.test(`${answer}\n${observed}`),
+  },
+  {
+    // Real-world agentic interaction: launch NetEase Cloud Music and navigate to
+    // its "每日推荐" (Daily Recommendation) entry. Content requires login and
+    // changes daily, so we only verify the agent reached a recommendation-related
+    // view — not specific songs. Exercises launch → inspect AX tree → click.
+    id: 'netease-daily-recommend',
+    bundleId: 'com.netease.163music',
+    appName: '网易云音乐 (NetEase Cloud Music)',
+    instruction:
+      'Launch NetEase Cloud Music. In its window, find and click the "每日推荐" (Daily Recommendation) navigation entry in the left sidebar. After clicking, report what section or page title is now shown.',
+    gold: '每日推荐 / Daily Recommendation view',
+    // Tolerant: success = the agent found and acted on the 每日推荐 entry (its label
+    // appears in the AX tree it read, or the answer references reaching it).
+    check: ({ observed, answer }) => {
+      const hay = `${answer}\n${observed}`;
+      return /每日推荐|daily recommend|recommendation/i.test(hay);
+    },
+  },
+];

--- a/tests/eval/package.json
+++ b/tests/eval/package.json
@@ -8,6 +8,8 @@
     "fetch:locomo": "tsx scripts/fetch-locomo.ts",
     "eval:memory:mem0": "tsx memory/run-mem0.ts",
     "eval:memory:curated": "tsx memory/run-memory.ts",
+    "eval:browser": "tsx browser/run-browser.ts",
+    "eval:computer": "tsx computer/run-computer.ts",
     "judge:llm": "tsx scripts/judge-llm.ts"
   },
   "dependencies": {

--- a/tests/eval/src/pi-harness.ts
+++ b/tests/eval/src/pi-harness.ts
@@ -1,0 +1,432 @@
+/**
+ * Shared harness for the agentic L3 evals (browser, computer, …).
+ *
+ * Instead of hand-rolling a tool-calling loop, we drive the REAL `pi` CLI the
+ * same way tests/.github/workflows/integration.yml does:
+ *   1. Build an isolated PI_CODING_AGENT_DIR (never touches the user's ~/.pi).
+ *   2. GENERATE a models.json in it from parameterized provider/baseUrl/api +
+ *      an env-var name for the key (exactly like the CI heredoc) — no hardcoded
+ *      endpoint, model, or key, and no copying a machine-specific file.
+ *   3. Write the extension settings.json.
+ *   4. `pi install ./packages/<ext>` into that dir.
+ *   5. Per task: `pi --mode json -p '<task>' --tools <allowlist>` and parse the
+ *      JSON event stream (tool_execution_start/end, message_end, agent_end).
+ *
+ * This runs the extension exactly as shipped (built dist, pi's own dependency
+ * resolution), so the eval measures production behavior — no importing package
+ * internals under tsx, no duplicated wrapper logic.
+ *
+ * Nothing here hardcodes a provider, model, endpoint, or key. All come from CLI
+ * flags / env: --models <path> (a ready models.json, e.g. one CI wrote from
+ * secrets), or --provider / --model / --base-url (or PI_INTEGRATION_BASE_URL) /
+ * --api / --api-key-env (default PI_INTEGRATION_API_KEY — the repo-wide
+ * convention). See README.
+ */
+import { spawn } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export type FailureMode = 'ok' | 'max-steps' | 'tool-error' | 'check-failed' | 'crash';
+
+export interface DriveResult {
+  /** Final assistant free-text (joined across message_end events). */
+  answer: string;
+  /** Concatenated tool outputs + names the agent produced (scorer haystack + judge blob). */
+  observed: string;
+  /**
+   * Number of agent turns (turn_start events) taken to reach the answer. Fewer
+   * turns = the agent got there in fewer model round-trips — a primary efficiency
+   * metric: a better wrapper / prompt should let the model finish in fewer turns.
+   */
+  turns: number;
+  /** Number of tool_execution_end events. */
+  toolCalls: number;
+  /** Whether any tool result was isError. */
+  sawToolError: boolean;
+  /** Non-'ok' when the run itself failed (pi crash / non-zero exit). */
+  failureMode: FailureMode;
+  error?: string;
+}
+
+export interface HarnessConfig {
+  /** Provider id to pass to `pi --provider` and used as the models.json key. */
+  provider: string;
+  /** Model id to pass to `pi --model` and register in the generated models.json. */
+  model: string;
+  /**
+   * Local mode: reuse the caller's default pi config (~/.pi/agent) verbatim
+   * instead of isolating a temp dir. No models.json is generated, and provider
+   * override env vars (ANTHROPIC_ etc.) are still stripped, so pi uses whatever
+   * provider the user has authed (e.g. a built-in deepseek via auth.json).
+   * --provider/--model still select within it. Use for local runs; CI uses
+   * modelsPath.
+   */
+  useDefaultPi?: boolean;
+  /**
+   * Path to a ready-made models.json to use verbatim (CI writes one from secrets,
+   * same as memory-eval.yml). When set, baseUrl/api/apiKeyEnv are ignored.
+   */
+  modelsPath?: string;
+  /** Provider baseUrl (OpenAI-compatible endpoint). Used only when modelsPath is unset. */
+  baseUrl: string;
+  /** pi provider `api` shape (default 'openai-completions'). */
+  api: string;
+  /**
+   * Name of the env var that holds the API key. Written verbatim into models.json
+   * as the apiKey value so pi resolves it at runtime — the secret never touches
+   * disk or logs. Default 'PI_INTEGRATION_API_KEY'. Used only when modelsPath is unset.
+   */
+  apiKeyEnv: string;
+  /** Thinking level (default 'high'; xhigh can hang some gateways). */
+  thinking: string;
+  /** Per-tool wall-clock timeout in ms. */
+  timeoutMs: number;
+}
+
+/**
+ * models.json contents when generating in-place (no --models given). Mirrors the
+ * memory-eval.yml heredoc but keeps the key as an env-var NAME so nothing secret
+ * lands on disk. CI paths pass a ready file via modelsPath instead.
+ */
+function buildModelsJson(hcfg: HarnessConfig): string {
+  return JSON.stringify(
+    {
+      providers: {
+        [hcfg.provider]: {
+          baseUrl: hcfg.baseUrl,
+          api: hcfg.api,
+          // Literal env-var name → pi resolves it at runtime. Not the secret.
+          apiKey: hcfg.apiKeyEnv,
+          authHeader: true,
+          models: [{ id: hcfg.model, name: hcfg.model, input: ['text'] }],
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+export interface ExtensionSetup {
+  /** Package dir name under packages/, e.g. 'pi-browser-use'. */
+  pkg: string;
+  /** settings.json contents (the extension's config block(s)). */
+  settings: Record<string, unknown>;
+  /** Extra packages to also install (e.g. companion extensions). */
+  alsoInstall?: string[];
+}
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
+
+export interface Harness {
+  cfgDir: string;
+  cleanup: () => void;
+}
+
+/**
+ * Prepare pi for a run. Two modes:
+ *   • default (CI): create an isolated PI_CODING_AGENT_DIR, seed models.json +
+ *     settings.json, install the extension there. cfgDir is the temp path.
+ *   • useDefaultPi (local): reuse the caller's ~/.pi/agent verbatim — no temp
+ *     dir, no config writes. cfgDir is '' (runPi then leaves PI_CODING_AGENT_DIR
+ *     alone). The extension is still installed (idempotent) so the tool exists.
+ * Returns cfgDir (to set as PI_CODING_AGENT_DIR, or '' for default) and cleanup.
+ */
+export async function setupHarness(hcfg: HarnessConfig, ext: ExtensionSetup): Promise<Harness> {
+  if (hcfg.useDefaultPi) {
+    // Reuse the user's default pi config. Only ensure the extension is installed.
+    const pkgs = [ext.pkg, ...(ext.alsoInstall ?? [])];
+    for (const p of pkgs) {
+      const pkgPath = path.join(REPO_ROOT, 'packages', p);
+      await runPi('', ['install', pkgPath], 120_000);
+    }
+    return { cfgDir: '', cleanup: () => {} };
+  }
+
+  const cfgDir = mkdtempSync(path.join(os.tmpdir(), 'pi-eval-cfg-'));
+  const cleanup = () => rmSync(cfgDir, { recursive: true, force: true });
+  try {
+    mkdirSync(cfgDir, { recursive: true });
+    if (hcfg.modelsPath) {
+      copyFileSync(hcfg.modelsPath, path.join(cfgDir, 'models.json'));
+    } else {
+      writeFileSync(path.join(cfgDir, 'models.json'), buildModelsJson(hcfg));
+    }
+    writeFileSync(path.join(cfgDir, 'settings.json'), JSON.stringify(ext.settings, null, 2));
+
+    const pkgs = [ext.pkg, ...(ext.alsoInstall ?? [])];
+    for (const p of pkgs) {
+      const pkgPath = path.join(REPO_ROOT, 'packages', p);
+      await runPi(cfgDir, ['install', pkgPath], 120_000);
+    }
+    return { cfgDir, cleanup };
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+}
+
+/** Spawn `pi` with the isolated config dir. Resolves with {stdout, code}. */
+function runPi(
+  cfgDir: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ stdout: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    // Strip env vars that would hijack pi's provider selection. Claude Code (and
+    // some shells) inject ANTHROPIC_*/OPENAI_* etc.; pi picks those up over its
+    // own models.json and then 401s against the wrong endpoint. We want pi to use
+    // ONLY the config in our isolated dir. Also strip proxies (mirrors CI).
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const k of Object.keys(env)) {
+      if (
+        /^(ANTHROPIC|OPENAI|GEMINI|GOOGLE|DEEPSEEK|GROQ|MISTRAL|XAI|OPENROUTER)_/.test(k) ||
+        /^(HTTP_PROXY|HTTPS_PROXY|ALL_PROXY|NO_PROXY)$/i.test(k)
+      ) {
+        delete env[k];
+      }
+    }
+    // Isolated mode: pin PI_CODING_AGENT_DIR to our temp dir. Default mode
+    // (cfgDir === ''): leave it as-is so pi uses the user's ~/.pi/agent.
+    if (cfgDir) env.PI_CODING_AGENT_DIR = cfgDir;
+
+    // stdin MUST be 'ignore': with an open stdin pipe, pi blocks waiting for
+    // interactive input and never streams (0 bytes out). Ignoring it makes pi
+    // run headless and flush the --mode json event stream.
+    const child = spawn('pi', args, { env, cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`pi timed out after ${timeoutMs}ms (args: ${args.join(' ')})`));
+    }, timeoutMs);
+    child.stdout.on('data', (d) => {
+      stdout += d;
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code !== 0 && args[0] === 'install') {
+        reject(new Error(`pi install failed (code ${code}): ${stderr.slice(0, 300)}`));
+        return;
+      }
+      resolve({ stdout: `${stdout}${stderr}`, code: code ?? 0 });
+    });
+  });
+}
+
+interface PiEvent {
+  type: string;
+  toolName?: string;
+  isError?: boolean;
+  result?: { content?: Array<{ type: string; text?: string }> };
+  message?: { role?: string; content?: Array<{ type: string; text?: string }>; errorMessage?: string };
+  errorMessage?: string;
+}
+
+function parseEvents(stream: string): PiEvent[] {
+  const events: PiEvent[] = [];
+  for (const line of stream.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    try {
+      events.push(JSON.parse(trimmed) as PiEvent);
+    } catch {
+      // Non-JSON diagnostic line — skip.
+    }
+  }
+  return events;
+}
+
+const MAX_OBSERVED = 40_000;
+const MAX_ANSWER = 4_000;
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max)}\n…[${s.length - max} chars truncated]` : s;
+}
+
+/**
+ * Run one task prompt through `pi --mode json` and distill the event stream into
+ * a DriveResult. `tools` is the comma-separated allowlist passed to --tools.
+ */
+export async function drivePrompt(
+  harness: Harness,
+  hcfg: HarnessConfig,
+  prompt: string,
+  tools: string,
+): Promise<DriveResult> {
+  let out: { stdout: string; code: number };
+  try {
+    out = await runPi(
+      harness.cfgDir,
+      [
+        '--provider',
+        hcfg.provider,
+        '--model',
+        hcfg.model,
+        '--thinking',
+        hcfg.thinking,
+        '--no-session',
+        '--no-context-files',
+        '--tools',
+        tools,
+        '--mode',
+        'json',
+        '-p',
+        prompt,
+      ],
+      hcfg.timeoutMs,
+    );
+  } catch (err) {
+    return {
+      answer: '',
+      observed: '',
+      turns: 0,
+      toolCalls: 0,
+      sawToolError: false,
+      failureMode: 'crash',
+      error: err instanceof Error ? err.message.slice(0, 300) : String(err),
+    };
+  }
+
+  const events = parseEvents(out.stdout);
+  const answerParts: string[] = [];
+  const observedParts: string[] = [];
+  let turns = 0;
+  let toolCalls = 0;
+  let sawToolError = false;
+  let providerError: string | undefined;
+
+  for (const ev of events) {
+    if (ev.type === 'turn_start') {
+      turns++;
+    } else if (ev.type === 'tool_execution_end') {
+      toolCalls++;
+      const text = (ev.result?.content ?? [])
+        .filter((c) => c.type === 'text' && c.text)
+        .map((c) => c.text as string)
+        .join('\n');
+      if (ev.isError || text.startsWith('Error:')) sawToolError = true;
+      observedParts.push(`# ${ev.toolName ?? 'tool'}${ev.isError ? ' [error]' : ''}\n${text}`);
+    } else if (ev.type === 'message_end' && ev.message?.role === 'assistant') {
+      const text = (ev.message.content ?? [])
+        .filter((c) => c.type === 'text' && c.text)
+        .map((c) => c.text as string)
+        .join('\n');
+      if (text) answerParts.push(text);
+      if (ev.message.errorMessage) providerError = ev.message.errorMessage;
+    }
+  }
+
+  // A provider-level error (e.g. 401, overload) with no tool activity is a crash,
+  // not a task failure — surface it so it isn't miscounted as check-failed.
+  if (providerError && toolCalls === 0 && answerParts.length === 0) {
+    return {
+      answer: '',
+      observed: observedParts.join('\n'),
+      turns,
+      toolCalls,
+      sawToolError,
+      failureMode: 'crash',
+      error: providerError.slice(0, 300),
+    };
+  }
+
+  return {
+    answer: truncate(answerParts.join('\n'), MAX_ANSWER),
+    observed: truncate(observedParts.join('\n'), MAX_OBSERVED),
+    turns,
+    toolCalls,
+    sawToolError,
+    failureMode: 'ok',
+  };
+}
+
+// ─── Shared arg parsing + provider resolution ────────────────────────────────
+
+export interface CommonArgs {
+  provider: string;
+  model: string;
+  useDefaultPi: boolean;
+  modelsPath: string;
+  baseUrl: string;
+  api: string;
+  apiKeyEnv: string;
+  thinking: string;
+  timeoutMs: number;
+  taskId: string;
+  tasks: number;
+}
+
+/**
+ * Parse the flags shared by every pi-CLI eval. Provider-config modes:
+ *   • --use-default-pi: reuse ~/.pi/agent verbatim (local; uses whatever provider
+ *     you've authed, e.g. a built-in deepseek). provider/model still select.
+ *   • --models <path>: use a ready-made models.json verbatim (CI writes one from
+ *     secrets, same as memory-eval.yml).
+ *   • otherwise: generate models.json from --base-url (or PI_INTEGRATION_BASE_URL)
+ *     + the env var named by --api-key-env (default PI_INTEGRATION_API_KEY).
+ * Env fallbacks use the repo-wide PI_INTEGRATION_* convention. Nothing is
+ * hardcoded to a machine.
+ */
+export function parseCommonArgs(defaults: { model: string; timeoutMs: number }): CommonArgs {
+  const argv = process.argv.slice(2);
+  const get = (flag: string, dflt: string) => {
+    const i = argv.indexOf(flag);
+    return i >= 0 ? argv[i + 1]! : dflt;
+  };
+  return {
+    provider: get('--provider', process.env.PI_EVAL_PROVIDER || 'deepseek-integration'),
+    model: get('--model', process.env.PI_EVAL_MODEL || defaults.model),
+    useDefaultPi: argv.includes('--use-default-pi'),
+    modelsPath: get('--models', process.env.PI_MODELS_PATH || ''),
+    baseUrl: get('--base-url', process.env.PI_INTEGRATION_BASE_URL || ''),
+    api: get('--api', process.env.PI_EVAL_API || 'openai-completions'),
+    apiKeyEnv: get('--api-key-env', process.env.PI_EVAL_API_KEY_ENV || 'PI_INTEGRATION_API_KEY'),
+    thinking: get('--thinking', 'high'),
+    timeoutMs: Number(get('--timeout', String(defaults.timeoutMs))),
+    taskId: get('--task', ''),
+    tasks: Number(get('--tasks', '0')),
+  };
+}
+
+/**
+ * Convert parsed args → HarnessConfig. --use-default-pi reuses ~/.pi/agent;
+ * --models trusts the file; otherwise we require --base-url + the key env var so
+ * the generated models.json is usable.
+ */
+export function toHarnessConfig(args: CommonArgs): HarnessConfig {
+  const base = {
+    provider: args.provider,
+    model: args.model,
+    api: args.api,
+    apiKeyEnv: args.apiKeyEnv,
+    thinking: args.thinking,
+    timeoutMs: args.timeoutMs,
+  };
+  if (args.useDefaultPi) {
+    return { ...base, useDefaultPi: true, baseUrl: args.baseUrl };
+  }
+  if (args.modelsPath) {
+    return { ...base, modelsPath: args.modelsPath, baseUrl: args.baseUrl };
+  }
+  if (!args.baseUrl) {
+    throw new Error(
+      'No provider config. Pass --use-default-pi (reuse ~/.pi/agent), --models <models.json>, ' +
+        'or --base-url <url> (or set PI_INTEGRATION_BASE_URL) to generate one.',
+    );
+  }
+  if (!process.env[args.apiKeyEnv]) {
+    throw new Error(
+      `API key env var "${args.apiKeyEnv}" is not set. Export it (or pass --api-key-env <NAME>).`,
+    );
+  }
+  return { ...base, baseUrl: args.baseUrl };
+}


### PR DESCRIPTION
## Summary

Adds `@amaster.ai/pi-goal`, an extension that keeps the agent working until a goal condition is met. You don't have to phrase the condition yourself — it can be derived from the conversation, confirmed, then re-checked after each agent run by a small evaluator model.

Design:
- **Engine** modeled on Claude Code's stop-condition mechanism (passive, driven off `agent_end`), with an iteration/token-budget backstop borrowed from Codex's goal mode. Goal state is session-scoped and in-memory.
- **Entry points:** `/goal` command (TUI) and `--goal <condition>` flag (CLI). Print mode does not dispatch slash commands, so the flag is the CLI entry point.
- **Auto-derivation** with a confirm step in TUI; degrades to a no-op when no evaluator model is configured (`/goal <condition>` still sets a goal, nothing auto-continues).

## Contents

- New package `packages/pi-goal/` — config, goal-state machine, LLM wrapper (`streamSimple`), derive/evaluate steps, transcript builder, engine + `/goal` command + `--goal` flag.
- 54 unit tests (config, goal-state, derive, evaluate, transcript, engine, wiring).
- `integration.yml`: Stage A already covers install/registration via `packages/pi-*` auto-discovery; added a Stage C matrix entry that drives the extension via `--goal`, plus a `pi-goal` settings block with `maxIterations=1` to bound continuation.
- Root README extension list entry.

## Also included

This branch also carries a pre-existing local commit (`ef2ef7b`) adding pi-browser-use / pi-computer-use L3 task-completion evals.

## Verification

`pnpm build && pnpm test && pnpm typecheck && pnpm lint` all pass (1102 tests, 77 files). Verified locally that `pi --goal '...'` is accepted and enters the session without error.