### PR TITLE
Harden pi-browser-use CDP sessions and screenshot handling

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -271,13 +271,14 @@ jobs:
             prompt: "Use image_generate to generate a test image with prompt 'a solid red square'. Report the generated file path."
             assert_pattern: "(image|generated|.png|.jpg|.webp|pi-images)"
           - extension: pi-browser-use
-            tools: browser_navigate_page,browser_take_snapshot
-            prompt: "Use browser_navigate_page to go to https://example.com then use browser_take_snapshot to get page content. Tell me the page title."
-            assert_pattern: "(Example Domain|example.com)"
+            tools: browser_list_pages,browser_navigate_page,browser_take_snapshot
+            prompt: "Use browser_list_pages first to get the current pageId. Pass that pageId to browser_navigate_page to go to https://example.com, then pass it to browser_take_snapshot and tell me the page title."
+            assert_pattern: "Example Domain"
+            assert_tool: browser_take_snapshot
           - extension: pi-browser-use
             scenario: screenshot
-            tools: browser_navigate_page,browser_analyze_screenshot
-            prompt: "Use browser_navigate_page to go to http://127.0.0.1:8765/. Then use browser_analyze_screenshot exactly once and ask it to report the exact large heading plus the dominant background color. Return its visual findings. Do not infer the answer from the URL."
+            tools: browser_list_pages,browser_navigate_page,browser_analyze_screenshot
+            prompt: "Use browser_list_pages first to get the current pageId. Pass that pageId to browser_navigate_page to go to http://127.0.0.1:8765/. Then pass it to browser_analyze_screenshot exactly once and ask it to report the exact large heading plus the dominant background color. Return its visual findings. Do not infer the answer from the URL."
             assert_pattern: "(VISUAL CHECK 7391.*(blue|#1457d9)|(blue|#1457d9).*VISUAL CHECK 7391)"
             assert_visual_analysis: true
     env:
@@ -531,7 +532,8 @@ jobs:
         run: |
           set -euo pipefail
           # Use npmmirror CDN to avoid slow Google CDN on domestic runners.
-          npx -y @puppeteer/browsers install chrome@stable \
+          sudo env "PATH=$PATH" npx -y @puppeteer/browsers install chrome@stable \
+            --install-deps \
             --path "$RUNNER_TEMP/chrome-install" \
             --base-url https://cdn.npmmirror.com/binaries/chrome-for-testing
           CHROME_BIN=$(find "$RUNNER_TEMP/chrome-install" -name "chrome" -type f | head -1)
@@ -540,7 +542,7 @@ jobs:
             exit 1
           fi
           echo "Chrome: $CHROME_BIN"
-          "$CHROME_BIN" --version --no-sandbox || true
+          "$CHROME_BIN" --version
           echo "CHROMIUM_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
 
       - name: Start browser screenshot fixture (pi-browser-use screenshot only)
@@ -663,7 +665,7 @@ jobs:
             ' <<<"$output" || true
             echo "--- final assistant text ---"
             ASSISTANT_TEXT=$(jq -rs '
-              map(select(.type == "message_end") | .message.content[]?
+              map(select(.type == "message_end" and .message.role == "assistant") | .message.content[]?
                 | select(.type == "text") | .text)
               | join("\n")
             ' <<<"$output" 2>/dev/null || echo "")
@@ -684,6 +686,32 @@ jobs:
           if [ "${{ matrix.extension }}" != "pi-goal" ]; then
             if ! grep -qiE '${{ matrix.assert_pattern }}' <<<"$HAYSTACK"; then
               echo "::error::Expected pattern '${{ matrix.assert_pattern }}' not found in ${{ matrix.extension }} output"
+              exit 1
+            fi
+          fi
+
+          # Cases with assert_tool must prove that the expected text came from
+          # a successful tool result, not from the prompt or model commentary.
+          if [ -n "${{ matrix.assert_tool }}" ]; then
+            if ! command -v jq >/dev/null 2>&1; then
+              echo "::error::jq is required for the tool result assertion"
+              exit 1
+            fi
+            if ! jq -e -s \
+              --arg tool '${{ matrix.assert_tool }}' \
+              --arg pattern '${{ matrix.assert_pattern }}' '
+                any(.[];
+                  .type == "tool_execution_end"
+                  and .toolName == $tool
+                  and .isError != true
+                  and .result.isError != true
+                  and any((.result.content // [])[]?;
+                    .type == "text"
+                    and ((.text // "") | test($pattern; "i"))
+                  )
+                )
+              ' <<<"$output" >/dev/null; then
+              echo "::error::${{ matrix.assert_tool }} did not return '${{ matrix.assert_pattern }}' successfully"
               exit 1
             fi
           fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -198,7 +198,7 @@ jobs:
   # setup because self-hosted matrix jobs don't share workspace state.
   # ──────────────────────────────────────────────────────────────────────
   extension-tool-matrix:
-    name: Extension E2E (${{ matrix.extension }}${{ matrix.provider && format('-{0}', matrix.provider) || '' }})
+    name: Extension E2E (${{ matrix.extension }}${{ matrix.provider && format('-{0}', matrix.provider) || '' }}${{ matrix.scenario && format('-{0}', matrix.scenario) || '' }})
     needs: pi-runtime
     if: >
       (github.event_name != 'pull_request' ||
@@ -274,6 +274,12 @@ jobs:
             tools: browser_navigate_page,browser_take_snapshot
             prompt: "Use browser_navigate_page to go to https://example.com then use browser_take_snapshot to get page content. Tell me the page title."
             assert_pattern: "(Example Domain|example.com)"
+          - extension: pi-browser-use
+            scenario: screenshot
+            tools: browser_navigate_page,browser_analyze_screenshot
+            prompt: "Use browser_navigate_page to go to http://127.0.0.1:8765/. Then use browser_analyze_screenshot exactly once and ask it to report the exact large heading plus the dominant background color. Return its visual findings. Do not infer the answer from the URL."
+            assert_pattern: "(VISUAL CHECK 7391.*(blue|#1457d9)|(blue|#1457d9).*VISUAL CHECK 7391)"
+            assert_visual_analysis: true
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
       PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
@@ -349,7 +355,6 @@ jobs:
             IMAGE_GEN_MODEL="qwen-image-2.0"
           fi
 
-
           # NOTE on ordering: this step writes settings.json BEFORE the
           # `pi install` step below. `pi install` appends to settings.json's
           # `packages` array; if we wrote settings.json after install, the
@@ -357,8 +362,9 @@ jobs:
           # run against zero registered extensions while still constraining
           # tools to a name that no longer exists — pi hangs in that state.
 
-          # 1. models.json — the deepseek-integration custom provider used by
-          #    every matrix entry.
+          # 1. models.json — the integration gateway custom provider used by
+          #    every matrix entry. DeepSeek remains the main model; the browser
+          #    vision tool uses Kimi K2.6 because DeepSeek cannot accept images.
           cat > "$PI_CODING_AGENT_DIR/models.json" <<EOF
           {
             "providers": {
@@ -386,6 +392,22 @@ jobs:
                       "thinkingFormat": "deepseek",
                       "requiresReasoningContentOnAssistantMessages": true,
                       "supportsDeveloperRole": false
+                    }
+                  },
+                  {
+                    "id": "kimi-k2.6",
+                    "name": "Kimi K2.6",
+                    "reasoning": true,
+                    "input": ["text", "image"],
+                    "contextWindow": 262144,
+                    "maxTokens": 262144,
+                    "compat": {
+                      "supportsStore": false,
+                      "supportsDeveloperRole": false,
+                      "supportsReasoningEffort": false,
+                      "maxTokensField": "max_tokens",
+                      "supportsStrictMode": false,
+                      "thinkingFormat": "deepseek"
                     }
                   }
                 ]
@@ -453,7 +475,11 @@ jobs:
               "headless": true,
               "sessionMode": "isolated",
               "viewport": "1280x720",
-              "executablePath": "\${CHROMIUM_BIN}"
+              "executablePath": "\${CHROMIUM_BIN}",
+              "visionModel": {
+                "provider": "deepseek-integration",
+                "model": "kimi-k2.6"
+              }
             }
           }
           EOF
@@ -517,6 +543,45 @@ jobs:
           "$CHROME_BIN" --version --no-sandbox || true
           echo "CHROMIUM_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
 
+      - name: Start browser screenshot fixture (pi-browser-use screenshot only)
+        if: matrix.extension == 'pi-browser-use' && matrix.scenario == 'screenshot'
+        run: |
+          set -euo pipefail
+          fixture_dir="$RUNNER_TEMP/pi-browser-screenshot-fixture"
+          mkdir -p "$fixture_dir"
+          cat > "$fixture_dir/index.html" <<'EOF'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <title>Screenshot fixture</title>
+              <style>
+                html, body { height: 100%; margin: 0; }
+                body {
+                  display: grid;
+                  place-items: center;
+                  background: #1457d9;
+                  color: white;
+                  font-family: sans-serif;
+                }
+                h1 { font-size: 64px; letter-spacing: 0.08em; }
+              </style>
+            </head>
+            <body><h1>VISUAL CHECK 7391</h1></body>
+          </html>
+          EOF
+          python3 -m http.server 8765 --bind 127.0.0.1 --directory "$fixture_dir" \
+            > "$RUNNER_TEMP/pi-browser-screenshot-fixture.log" 2>&1 &
+          echo "BROWSER_FIXTURE_PID=$!" >> "$GITHUB_ENV"
+          for attempt in $(seq 1 20); do
+            if curl -fsS http://127.0.0.1:8765/ >/dev/null; then
+              exit 0
+            fi
+            sleep 0.25
+          done
+          echo "::error::Browser screenshot fixture failed to start"
+          exit 1
+
       - name: Run extension prompt (Stage C)
         if: env.PI_INTEGRATION_BASE_URL != '' && env.PI_INTEGRATION_API_KEY != ''
         run: |
@@ -536,7 +601,7 @@ jobs:
           # what args, and what each call returned — including any tool-side
           # errors that text-mode silently summarizes into prose.
           #
-          # --thinking high (not xhigh): xhigh maps to deepseek
+          # --thinking high (not xhigh): for DeepSeek, xhigh maps to
           # `reasoning_effort: max`, which on the amaster gateway has been
           # observed to occasionally hang >5min on tool-call prompts. Stage B
           # smoke keeps xhigh per the original spec.
@@ -623,6 +688,31 @@ jobs:
             fi
           fi
 
+          # Screenshot scenario: browser_analyze_screenshot captures the image
+          # internally, sends it to the configured Kimi vision model, and returns
+          # text to the DeepSeek main model. Assert the vision tool itself found
+          # both deterministic markers before checking the final answer above.
+          if [ "${{ matrix.assert_visual_analysis }}" = "true" ]; then
+            if ! command -v jq >/dev/null 2>&1; then
+              echo "::error::jq is required for the visual analysis assertion"
+              exit 1
+            fi
+            if ! jq -e -s '
+              any(.[];
+                .type == "tool_execution_end"
+                and .toolName == "browser_analyze_screenshot"
+                and any((.result.content // [])[]?;
+                  .type == "text"
+                  and ((.text // "") | test("VISUAL CHECK 7391"; "i"))
+                  and ((.text // "") | test("blue|#1457d9"; "i"))
+                )
+              )
+            ' <<<"$output" >/dev/null; then
+              echo "::error::browser_analyze_screenshot did not identify the fixture heading and color"
+              exit 1
+            fi
+          fi
+
           # pi-goal: prove the goal engine actually ran and the task completed.
           #   1. [pi-goal] derived condition:  — derivation ran (hard gate;
           #      happens at before_agent_start, always before the run ends).
@@ -649,6 +739,13 @@ jobs:
             fi
             echo "✓ pi-goal wrote $GOAL_FILE and the goal engine derived+evaluated a condition."
             rm -f "$GOAL_FILE"
+          fi
+
+      - name: Stop browser screenshot fixture
+        if: always() && matrix.extension == 'pi-browser-use' && matrix.scenario == 'screenshot'
+        run: |
+          if [ -n "${BROWSER_FIXTURE_PID:-}" ]; then
+            kill "$BROWSER_FIXTURE_PID" 2>/dev/null || true
           fi
 
       - name: Verify pi-memory-mem0 captured turn (memory job only)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -277,8 +277,9 @@ jobs:
             assert_tool: browser_take_snapshot
           - extension: pi-browser-use
             scenario: screenshot
-            tools: browser_list_pages,browser_navigate_page,browser_analyze_screenshot
-            prompt: "Use browser_list_pages first to get the current pageId. Pass that pageId to browser_navigate_page to go to http://127.0.0.1:8765/. Then pass it to browser_analyze_screenshot exactly once and ask it to report the exact large heading plus the dominant background color. Return its visual findings. Do not infer the answer from the URL."
+            tools: browser_list_pages,browser_evaluate_script,browser_analyze_screenshot
+            prompt: >-
+              Use browser_list_pages first to get the current pageId. Pass that pageId to browser_evaluate_script with this function parameter exactly: () => { document.title = "Screenshot fixture"; document.documentElement.style.cssText = "height:100%;margin:0"; document.body.style.cssText = "height:100%;margin:0;display:grid;place-items:center;background:#1457d9;color:white;font-family:sans-serif"; const heading = document.createElement("h1"); heading.textContent = "VISUAL CHECK 7391"; heading.style.cssText = "font-size:64px;letter-spacing:.08em"; document.body.replaceChildren(heading); return document.title; }. Then pass the same pageId to browser_analyze_screenshot exactly once and ask it to report the exact large heading plus the dominant background color. Return its visual findings.
             assert_pattern: "(VISUAL CHECK 7391.*(blue|#1457d9)|(blue|#1457d9).*VISUAL CHECK 7391)"
             assert_visual_analysis: true
     env:
@@ -286,6 +287,7 @@ jobs:
       PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
       PI_INTEGRATION_MULTICA_TOKEN: ${{ secrets.PI_INTEGRATION_MULTICA_TOKEN }}
       FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+      BROWSERLESS_TOKEN: ${{ secrets.BROWSERLESS_TOKEN }}
       PI_OFFLINE: '0'
 
     steps:
@@ -473,10 +475,8 @@ jobs:
               }
             },
             "pi-browser-use": {
-              "headless": true,
-              "sessionMode": "isolated",
-              "viewport": "1280x720",
-              "executablePath": "\${CHROMIUM_BIN}",
+              "sessionMode": "existing",
+              "wsEndpoint": "wss://production-sfo.browserless.io/chrome?token=\${BROWSERLESS_TOKEN}",
               "visionModel": {
                 "provider": "deepseek-integration",
                 "model": "kimi-k2.6"
@@ -527,62 +527,14 @@ jobs:
           # Smoke-test the auth before handing off to pi-teamwork.
           multica workspace list --output json
 
-      - name: Install Chromium (pi-browser-use only)
+      - name: Verify Browserless credentials (pi-browser-use only)
         if: matrix.extension == 'pi-browser-use'
         run: |
           set -euo pipefail
-          # Use npmmirror CDN to avoid slow Google CDN on domestic runners.
-          sudo env "PATH=$PATH" npx -y @puppeteer/browsers install chrome@stable \
-            --install-deps \
-            --path "$RUNNER_TEMP/chrome-install" \
-            --base-url https://cdn.npmmirror.com/binaries/chrome-for-testing
-          CHROME_BIN=$(find "$RUNNER_TEMP/chrome-install" -name "chrome" -type f | head -1)
-          if [ -z "$CHROME_BIN" ]; then
-            echo "::error::Could not find chrome binary after install"
+          if [ -z "${BROWSERLESS_TOKEN:-}" ]; then
+            echo "::error::BROWSERLESS_TOKEN secret is required for pi-browser-use E2E"
             exit 1
           fi
-          echo "Chrome: $CHROME_BIN"
-          "$CHROME_BIN" --version
-          echo "CHROMIUM_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
-
-      - name: Start browser screenshot fixture (pi-browser-use screenshot only)
-        if: matrix.extension == 'pi-browser-use' && matrix.scenario == 'screenshot'
-        run: |
-          set -euo pipefail
-          fixture_dir="$RUNNER_TEMP/pi-browser-screenshot-fixture"
-          mkdir -p "$fixture_dir"
-          cat > "$fixture_dir/index.html" <<'EOF'
-          <!doctype html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8">
-              <title>Screenshot fixture</title>
-              <style>
-                html, body { height: 100%; margin: 0; }
-                body {
-                  display: grid;
-                  place-items: center;
-                  background: #1457d9;
-                  color: white;
-                  font-family: sans-serif;
-                }
-                h1 { font-size: 64px; letter-spacing: 0.08em; }
-              </style>
-            </head>
-            <body><h1>VISUAL CHECK 7391</h1></body>
-          </html>
-          EOF
-          python3 -m http.server 8765 --bind 127.0.0.1 --directory "$fixture_dir" \
-            > "$RUNNER_TEMP/pi-browser-screenshot-fixture.log" 2>&1 &
-          echo "BROWSER_FIXTURE_PID=$!" >> "$GITHUB_ENV"
-          for attempt in $(seq 1 20); do
-            if curl -fsS http://127.0.0.1:8765/ >/dev/null; then
-              exit 0
-            fi
-            sleep 0.25
-          done
-          echo "::error::Browser screenshot fixture failed to start"
-          exit 1
 
       - name: Run extension prompt (Stage C)
         if: env.PI_INTEGRATION_BASE_URL != '' && env.PI_INTEGRATION_API_KEY != ''
@@ -767,13 +719,6 @@ jobs:
             fi
             echo "✓ pi-goal wrote $GOAL_FILE and the goal engine derived+evaluated a condition."
             rm -f "$GOAL_FILE"
-          fi
-
-      - name: Stop browser screenshot fixture
-        if: always() && matrix.extension == 'pi-browser-use' && matrix.scenario == 'screenshot'
-        run: |
-          if [ -n "${BROWSER_FIXTURE_PID:-}" ]; then
-            kill "$BROWSER_FIXTURE_PID" 2>/dev/null || true
           fi
 
       - name: Verify pi-memory-mem0 captured turn (memory job only)

--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -8,6 +8,9 @@ pi-coding-agent extension that wraps [chrome-devtools-mcp](https://github.com/Ch
 
 - **pi-coding-agent extension** — registers tools via `pi.registerTool()`, managed by the agent lifecycle
 - **Dynamic tool discovery** — automatically proxies all upstream chrome-devtools-mcp tools with `browser_` prefix
+- **Page-scoped routing** — routes page tools by explicit `pageId` instead of shared selected-page state
+- **Connection recovery** — detects closed or unhealthy MCP transports and reconnects before the next call
+- **Navigation safety** — supports URL allow/block patterns and redacts sensitive network headers by default
 - **Tool description augmentation** — adds usage hints for key tools (click, fill, press_key, etc.)
 - **Result post-processing** — strips embedded snapshots, detects overlay/stale element issues
 - **Optional visual analysis** — `browser_analyze_screenshot` via configurable vision model
@@ -39,7 +42,8 @@ Configure via `.pi/settings.json` (project-level) or `~/.pi/agent/settings.json`
     "headless": true,
     "channel": "stable",
     "viewport": "1280x720",
-    "experimentalVision": true
+    "experimentalVision": true,
+    "blockedUrlPattern": ["https://ads.example/*"]
   }
 }
 ```
@@ -87,6 +91,7 @@ npx @amaster.ai/pi-browser-use --config path/to/config.json
 | `isolated` | `boolean` | `false` | Use isolated browser profile |
 | `userDataDir` | `string` | — | Custom user data directory |
 | `autoConnect` | `boolean` | `false` | Auto-connect to running browser |
+| `acceptInsecureCerts` | `boolean` | `false` | Ignore invalid or self-signed certificate errors; use with caution |
 
 ### Categories
 
@@ -104,6 +109,7 @@ npx @amaster.ai/pi-browser-use --config path/to/config.json
 | `experimentalVision` | `boolean` | `true` | Enable vision tools (click_at) |
 | `experimentalScreencast` | `boolean` | `false` | Enable screencast |
 | `experimentalMemory` | `boolean` | `false` | Enable memory snapshots |
+| `experimentalPageIdRouting` | `boolean` | `true` | Add a required `pageId` to page-scoped tools and route directly to that page |
 
 ### Privacy
 
@@ -111,6 +117,24 @@ npx @amaster.ai/pi-browser-use --config path/to/config.json
 |--------|------|---------|-------------|
 | `usageStatistics` | `boolean` | `false` | Send usage statistics |
 | `performanceCrux` | `boolean` | `false` | Enable CrUX performance data |
+| `redactNetworkHeaders` | `boolean` | `true` | Redact sensitive headers in network tool results |
+| `allowedUrlPattern` | `string[]` | — | Allow only matching URLPattern values; requires Chrome 149+ |
+| `blockedUrlPattern` | `string[]` | — | Block matching navigation and subresource URLPattern values |
+
+`allowedUrlPattern` and `blockedUrlPattern` are mutually exclusive. Page ID routing is disabled automatically in `slim` mode because upstream slim tools do not expose `pageId`.
+
+### Page-scoped Tool Calls
+
+With the default page ID routing enabled, call `browser_list_pages` first and pass the returned numeric page ID to subsequent page-scoped tools:
+
+```text
+browser_list_pages({})
+browser_take_snapshot({ "pageId": 2 })
+browser_click({ "pageId": 2, "uid": "12_4" })
+browser_take_screenshot({ "pageId": 2 })
+```
+
+This avoids relying on `browser_select_page` when multiple browser calls or tabs are active. A single chrome-devtools-mcp process still serializes tool execution; page ID routing provides isolation rather than parallel throughput.
 
 ### Vision Model (Optional)
 
@@ -128,6 +152,12 @@ Enable `browser_analyze_screenshot` by referencing a model already configured in
 ```
 
 The extension resolves API key, base URL, and headers from the model registry automatically — no need to duplicate credentials here.
+
+With the default page ID routing enabled, visual analysis also targets a page explicitly:
+
+```text
+browser_analyze_screenshot({ "pageId": 2, "instruction": "Find the blue submit button" })
+```
 
 ## Tool Augmentation
 

--- a/packages/pi-browser-use/src/__tests__/analyze-screenshot.test.ts
+++ b/packages/pi-browser-use/src/__tests__/analyze-screenshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it, test, vi } from 'vitest';
 import {
   createFetchVisionCaller,
   handleAnalyzeScreenshot,
@@ -62,13 +62,19 @@ describe('handleAnalyzeScreenshot', () => {
     const client = createMockClient();
     const caller = mockVisionCaller('Blue button at (150, 300)');
     const result = await handleAnalyzeScreenshot(client, caller, {
+      pageId: 7,
       instruction: 'Find the blue button',
     });
 
     expect(result.isError).toBeUndefined();
     expect(result.content[0]!.text).toContain('Blue button at (150, 300)');
-    expect(client.callTool).toHaveBeenCalledWith('take_screenshot', {});
-    expect(caller).toHaveBeenCalledWith('Find the blue button', 'aW1hZ2VkYXRh', 'image/png');
+    expect(client.callTool).toHaveBeenCalledWith('take_screenshot', { pageId: 7 }, undefined);
+    expect(caller).toHaveBeenCalledWith(
+      'Find the blue button',
+      'aW1hZ2VkYXRh',
+      'image/png',
+      undefined,
+    );
   });
 
   test('no screenshot data returns error', async () => {
@@ -131,10 +137,56 @@ describe('handleAnalyzeScreenshot', () => {
   test('defaults instruction to empty string', async () => {
     const client = createMockClient();
     const caller = mockVisionCaller('Full page analysis');
-    const result = await handleAnalyzeScreenshot(client, caller, {});
+    const result = await handleAnalyzeScreenshot(client, caller, { pageId: 7 });
 
     expect(result.isError).toBeUndefined();
-    expect(caller).toHaveBeenCalledWith('', 'aW1hZ2VkYXRh', 'image/png');
+    expect(caller).toHaveBeenCalledWith('', 'aW1hZ2VkYXRh', 'image/png', undefined);
+  });
+
+  it('omits pageId when page ID routing is disabled', async () => {
+    const client = createMockClient();
+    const caller = mockVisionCaller('Full page analysis');
+
+    await handleAnalyzeScreenshot(client, caller, {});
+
+    expect(client.callTool).toHaveBeenCalledWith('take_screenshot', {}, undefined);
+  });
+
+  it('forwards the abort signal to screenshot capture and vision analysis', async () => {
+    const client = createMockClient();
+    const caller = mockVisionCaller('Full page analysis');
+    const controller = new AbortController();
+
+    await handleAnalyzeScreenshot(
+      client,
+      caller,
+      { pageId: 7, instruction: 'Find the button' },
+      controller.signal,
+    );
+
+    expect(client.callTool).toHaveBeenCalledWith(
+      'take_screenshot',
+      { pageId: 7 },
+      controller.signal,
+    );
+    expect(caller).toHaveBeenCalledWith(
+      'Find the button',
+      'aW1hZ2VkYXRh',
+      'image/png',
+      controller.signal,
+    );
+  });
+
+  it('does not convert cancellation into a visual analysis error', async () => {
+    const client = createMockClient();
+    const caller = mockVisionCaller('should not be called');
+    const controller = new AbortController();
+    controller.abort();
+    client.callTool.mockRejectedValueOnce(controller.signal.reason);
+
+    await expect(
+      handleAnalyzeScreenshot(client, caller, { pageId: 7 }, controller.signal),
+    ).rejects.toBe(controller.signal.reason);
   });
 
   test('uses correct mimeType from screenshot response', async () => {
@@ -142,7 +194,7 @@ describe('handleAnalyzeScreenshot', () => {
     const caller = mockVisionCaller('result');
     await handleAnalyzeScreenshot(client, caller, { instruction: 'test' });
 
-    expect(caller).toHaveBeenCalledWith('test', 'jpegdata', 'image/jpeg');
+    expect(caller).toHaveBeenCalledWith('test', 'jpegdata', 'image/jpeg', undefined);
   });
 
   test('permission error returns model-not-available', async () => {
@@ -200,9 +252,10 @@ describe('createFetchVisionCaller', () => {
   test('passes image data and mimeType to complete()', async () => {
     const piAi = await import('@earendil-works/pi-ai/compat');
     (piAi.complete as any).mockClear();
+    const controller = new AbortController();
 
     const caller = createFetchVisionCaller({ provider: 'openai', model: 'gpt-4o' });
-    await caller('Describe this', 'aW1hZ2U=', 'image/jpeg');
+    await caller('Describe this', 'aW1hZ2U=', 'image/jpeg', controller.signal);
 
     const callArgs = (piAi.complete as any).mock.calls[0];
     const messages = callArgs[1].messages;
@@ -210,5 +263,6 @@ describe('createFetchVisionCaller', () => {
     expect(imageContent.type).toBe('image');
     expect(imageContent.data).toBe('aW1hZ2U=');
     expect(imageContent.mimeType).toBe('image/jpeg');
+    expect(callArgs[2].signal).toBe(controller.signal);
   });
 });

--- a/packages/pi-browser-use/src/__tests__/analyze-screenshot.test.ts
+++ b/packages/pi-browser-use/src/__tests__/analyze-screenshot.test.ts
@@ -272,9 +272,10 @@ describe('createFetchVisionCaller', () => {
     expect(imageContent.data).toBe('aW1hZ2U=');
     expect(imageContent.mimeType).toBe('image/jpeg');
     expect(callArgs[2].signal).toBe(controller.signal);
+    expect(callArgs[2]).not.toHaveProperty('temperature');
   });
 
-  it('omits temperature for reasoning vision models', async () => {
+  it('omits temperature for reasoning vision models too', async () => {
     const piAi = await import('@earendil-works/pi-ai/compat');
     (piAi.complete as any).mockClear();
 

--- a/packages/pi-browser-use/src/__tests__/analyze-screenshot.test.ts
+++ b/packages/pi-browser-use/src/__tests__/analyze-screenshot.test.ts
@@ -6,10 +6,18 @@ import {
 } from '../analyze-screenshot.js';
 
 vi.mock('@earendil-works/pi-coding-agent', () => {
-  const mockModel = { id: 'gpt-4o', provider: 'openai' };
+  const mockModel = { id: 'gpt-4o', provider: 'openai', reasoning: false };
+  const mockReasoningModel = {
+    id: 'kimi-k2.6',
+    provider: 'deepseek-integration',
+    reasoning: true,
+  };
   const mockRegistry = {
     find: vi.fn((provider: string, model: string) => {
       if (provider === 'openai' && model === 'gpt-4o') return mockModel;
+      if (provider === 'deepseek-integration' && model === 'kimi-k2.6') {
+        return mockReasoningModel;
+      }
       return undefined;
     }),
     getApiKeyAndHeaders: vi.fn(() =>
@@ -264,5 +272,35 @@ describe('createFetchVisionCaller', () => {
     expect(imageContent.data).toBe('aW1hZ2U=');
     expect(imageContent.mimeType).toBe('image/jpeg');
     expect(callArgs[2].signal).toBe(controller.signal);
+  });
+
+  it('omits temperature for reasoning vision models', async () => {
+    const piAi = await import('@earendil-works/pi-ai/compat');
+    (piAi.complete as any).mockClear();
+
+    const caller = createFetchVisionCaller({
+      provider: 'deepseek-integration',
+      model: 'kimi-k2.6',
+    });
+    await caller('Describe this', 'aW1hZ2U=', 'image/png');
+
+    const options = (piAi.complete as any).mock.calls[0][2];
+    expect(options).toMatchObject({ maxTokens: 2048 });
+    expect(options).not.toHaveProperty('temperature');
+  });
+
+  it('surfaces model error results instead of treating them as empty analysis', async () => {
+    const piAi = await import('@earendil-works/pi-ai/compat');
+    (piAi.complete as any).mockResolvedValueOnce({
+      content: [],
+      stopReason: 'error',
+      errorMessage: 'invalid temperature',
+    });
+
+    const caller = createFetchVisionCaller({ provider: 'openai', model: 'gpt-4o' });
+
+    await expect(caller('Describe this', 'aW1hZ2U=', 'image/png')).rejects.toThrow(
+      'invalid temperature',
+    );
   });
 });

--- a/packages/pi-browser-use/src/__tests__/cli.test.ts
+++ b/packages/pi-browser-use/src/__tests__/cli.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, it, test, vi } from 'vitest';
 
 vi.mock('../index.js', () => ({
   DevToolsClient: class {
@@ -27,6 +27,15 @@ vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
 const { parseArgs } = await import('../cli.js');
 
 describe('parseArgs', () => {
+  it('collects repeated URL pattern flags into arrays', () => {
+    const config = parseArgs([
+      '--allowed-url-pattern=https://one.example/*',
+      '--allowed-url-pattern=https://two.example/*',
+    ]);
+
+    expect(config.allowedUrlPattern).toEqual(['https://one.example/*', 'https://two.example/*']);
+  });
+
   test('--headless produces boolean true', () => {
     const config = parseArgs(['--headless']);
     expect(config.headless).toBe(true);

--- a/packages/pi-browser-use/src/__tests__/config.test.ts
+++ b/packages/pi-browser-use/src/__tests__/config.test.ts
@@ -1,7 +1,15 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 import { configToArgs, resolveConfig } from '../config.js';
 
 describe('resolveConfig', () => {
+  it('enables page ID routing and network header redaction by default', () => {
+    const config = resolveConfig();
+
+    expect(config.experimentalPageIdRouting).toBe(true);
+    expect(config.redactNetworkHeaders).toBe(true);
+    expect(config.acceptInsecureCerts).toBe(false);
+  });
+
   test('returns defaults when called with no args', () => {
     const config = resolveConfig();
     expect(config.categoryPerformance).toBe(false);
@@ -39,6 +47,54 @@ describe('resolveConfig', () => {
 });
 
 describe('configToArgs', () => {
+  it('enables page ID routing and network header redaction by default', () => {
+    const args = configToArgs({});
+
+    expect(args).toContain('--experimental-page-id-routing');
+    expect(args).toContain('--redact-network-headers');
+    expect(args).not.toContain('--accept-insecure-certs');
+  });
+
+  it('maps URL patterns and insecure certificate configuration', () => {
+    const args = configToArgs({
+      blockedUrlPattern: ['https://example.com/*', 'https://*.internal/*'],
+      acceptInsecureCerts: true,
+    });
+
+    expect(args).toContain('--blocked-url-pattern=https://example.com/*');
+    expect(args).toContain('--blocked-url-pattern=https://*.internal/*');
+    expect(args).toContain('--accept-insecure-certs');
+  });
+
+  it('allows page routing and header redaction to be disabled explicitly', () => {
+    const args = configToArgs({
+      experimentalPageIdRouting: false,
+      redactNetworkHeaders: false,
+    });
+
+    expect(args).not.toContain('--experimental-page-id-routing');
+    expect(args).not.toContain('--redact-network-headers');
+  });
+
+  it('rejects simultaneous URL allow and block lists', () => {
+    expect(() =>
+      configToArgs({
+        allowedUrlPattern: ['https://allowed.example/*'],
+        blockedUrlPattern: ['https://blocked.example/*'],
+      }),
+    ).toThrow('allowedUrlPattern and blockedUrlPattern cannot be used together');
+  });
+
+  it('disables page ID routing automatically in slim mode', () => {
+    expect(configToArgs({ slim: true })).not.toContain('--experimental-page-id-routing');
+  });
+
+  it('rejects explicitly enabled page ID routing in slim mode', () => {
+    expect(() => configToArgs({ slim: true, experimentalPageIdRouting: true })).toThrow(
+      'experimentalPageIdRouting cannot be used with slim mode',
+    );
+  });
+
   test('empty config produces default flags', () => {
     const args = configToArgs({});
     expect(args).toContain('--category-performance=false');

--- a/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
+++ b/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
@@ -1,7 +1,12 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 const mockClientConnect = vi.fn(() => Promise.resolve());
 const mockClientClose = vi.fn(() => Promise.resolve());
+const mockClientPing = vi.fn(() => Promise.resolve({}));
+const mockTransports: Array<{
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+}> = [];
 let _listToolsCalls = 0;
 const mockListTools = vi.fn((opts?: { cursor?: string }) => {
   _listToolsCalls++;
@@ -23,6 +28,7 @@ const mockCallTool = vi.fn((_req: { name: string; arguments: Record<string, unkn
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: class {
     connect = mockClientConnect;
+    ping = mockClientPing;
     listTools = mockListTools;
     callTool = mockCallTool;
     close = mockClientClose;
@@ -31,8 +37,11 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
 
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   StdioClientTransport: class {
-    onerror: unknown;
-    constructor(public opts: unknown) {}
+    onclose?: () => void;
+    onerror?: (error: Error) => void;
+    constructor(public opts: unknown) {
+      mockTransports.push(this);
+    }
   },
 }));
 
@@ -42,12 +51,22 @@ describe('DevToolsClient', () => {
   beforeEach(() => {
     mockClientConnect.mockClear();
     mockClientClose.mockClear();
+    mockClientPing.mockClear();
     mockListTools.mockClear();
     mockCallTool.mockClear();
     _listToolsCalls = 0;
+    mockTransports.length = 0;
   });
 
   describe('connect()', () => {
+    it('shares one connection attempt across concurrent callers', async () => {
+      const client = new DevToolsClient();
+
+      await Promise.all([client.connect(), client.connect()]);
+
+      expect(mockClientConnect).toHaveBeenCalledTimes(1);
+    });
+
     test('creates transport and connects client', async () => {
       const client = new DevToolsClient();
       await client.connect();
@@ -80,13 +99,27 @@ describe('DevToolsClient', () => {
       expect(mockListTools).toHaveBeenCalledTimes(2);
     });
 
-    test('throws when not connected', async () => {
+    it('connects on demand when listing tools', async () => {
       const client = new DevToolsClient();
-      await expect(client.listAllTools()).rejects.toThrow('Client not connected');
+
+      await client.listAllTools();
+
+      expect(mockClientConnect).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('callTool()', () => {
+    it('reconnects before the next tool call after the transport closes', async () => {
+      const client = new DevToolsClient();
+      await client.connect();
+      mockTransports[0]!.onclose?.();
+
+      await client.callTool('click', { uid: '1_2' });
+
+      expect(mockClientConnect).toHaveBeenCalledTimes(2);
+      expect(mockCallTool).toHaveBeenCalledTimes(1);
+    });
+
     test('calls upstream tool with name and args', async () => {
       const client = new DevToolsClient();
       await client.connect();
@@ -101,9 +134,179 @@ describe('DevToolsClient', () => {
       expect(result.content).toEqual([{ type: 'text', text: 'done' }]);
     });
 
-    test('throws when not connected', async () => {
+    it('connects on demand before the first tool call', async () => {
       const client = new DevToolsClient();
-      await expect(client.callTool('click', {})).rejects.toThrow('Client not connected');
+
+      await client.callTool('click', {});
+
+      expect(mockClientConnect).toHaveBeenCalledTimes(1);
+      expect(mockCallTool).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks connection health after the health interval', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-07-16T00:00:00Z'));
+        const client = new DevToolsClient();
+        await client.connect();
+        vi.advanceTimersByTime(10_001);
+
+        await client.callTool('click', {});
+
+        expect(mockClientPing).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reconnects when a health check fails before dispatch', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-07-16T00:00:00Z'));
+        const client = new DevToolsClient();
+        await client.connect();
+        vi.advanceTimersByTime(10_001);
+        mockClientPing.mockRejectedValueOnce(new Error('transport closed'));
+
+        await client.callTool('click', {});
+
+        expect(mockClientConnect).toHaveBeenCalledTimes(2);
+        expect(mockCallTool).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reconnects when concurrent health checks disagree', async () => {
+      let now = 0;
+      const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => now);
+      let rejectFirstPing!: (reason: Error) => void;
+      let resolveSecondPing!: (value: object) => void;
+      mockClientPing
+        .mockImplementationOnce(
+          () =>
+            new Promise((_resolve, reject) => {
+              rejectFirstPing = reject;
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveSecondPing = resolve;
+            }),
+        );
+
+      try {
+        const client = new DevToolsClient();
+        await client.connect();
+        now = 10_001;
+
+        const firstCall = client.callTool('click', { uid: '1_1' });
+        const secondCall = client.callTool('click', { uid: '1_2' });
+        await vi.waitFor(() => expect(mockClientPing).toHaveBeenCalledTimes(2));
+
+        rejectFirstPing(new Error('transport closed'));
+        resolveSecondPing({});
+
+        await expect(Promise.all([firstCall, secondCall])).resolves.toHaveLength(2);
+        expect(mockClientConnect).toHaveBeenCalledTimes(2);
+        expect(mockCallTool).toHaveBeenCalledTimes(2);
+      } finally {
+        dateNow.mockRestore();
+      }
+    });
+
+    it('passes the abort signal to the upstream request', async () => {
+      const client = new DevToolsClient();
+      const controller = new AbortController();
+
+      await client.callTool('click', {}, controller.signal);
+
+      expect(mockCallTool).toHaveBeenCalledWith({ name: 'click', arguments: {} }, undefined, {
+        signal: controller.signal,
+        timeout: 60_000,
+      });
+    });
+
+    it('does not replay a tool that loses its connection during dispatch', async () => {
+      const client = new DevToolsClient();
+      await client.connect();
+      mockCallTool.mockImplementationOnce(async () => {
+        mockTransports[0]!.onclose?.();
+        throw new Error('internal transport detail');
+      });
+
+      await expect(client.callTool('click', {})).rejects.toThrow(
+        'Browser connection lost; retry the tool',
+      );
+
+      expect(mockCallTool).toHaveBeenCalledTimes(1);
+      expect(client.getState()).toBe('disconnected');
+    });
+
+    it('sanitizes unexpected upstream request failures', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      try {
+        const client = new DevToolsClient();
+        mockCallTool.mockRejectedValueOnce(new Error('secret response body'));
+
+        await expect(client.callTool('click', {})).rejects.toThrow('Browser tool call failed.');
+
+        expect(consoleError).toHaveBeenCalledWith(
+          '[pi-browser-use] upstream tool call failed (Error)',
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  });
+
+  describe('connection state', () => {
+    it('tracks ready and disconnected transport states', async () => {
+      const client = new DevToolsClient();
+      expect(client.getState()).toBe('disconnected');
+
+      await client.connect();
+      expect(client.getState()).toBe('ready');
+
+      mockTransports[0]!.onclose?.();
+      expect(client.getState()).toBe('disconnected');
+    });
+
+    it('ignores a late close event from an old transport', async () => {
+      const client = new DevToolsClient();
+      await client.connect();
+      const oldTransport = mockTransports[0]!;
+      oldTransport.onclose?.();
+      await client.callTool('click', {});
+
+      oldTransport.onclose?.();
+
+      expect(client.getState()).toBe('ready');
+    });
+
+    it('ignores a late error event from an old transport', async () => {
+      const client = new DevToolsClient();
+      await client.connect();
+      const oldTransport = mockTransports[0]!;
+      oldTransport.onclose?.();
+      await client.callTool('click', {});
+
+      oldTransport.onerror?.(new Error('late transport error'));
+
+      expect(client.getState()).toBe('ready');
+      expect(mockClientClose).not.toHaveBeenCalled();
+    });
+
+    it('can retry after an initial connection failure', async () => {
+      mockClientConnect.mockRejectedValueOnce(new Error('startup failed'));
+      const client = new DevToolsClient();
+
+      await expect(client.connect()).rejects.toThrow('Browser connection failed.');
+      expect(client.getState()).toBe('failed');
+
+      await client.connect();
+      expect(client.getState()).toBe('ready');
     });
   });
 

--- a/packages/pi-browser-use/src/__tests__/index.test.ts
+++ b/packages/pi-browser-use/src/__tests__/index.test.ts
@@ -44,6 +44,11 @@ const mockCallTool = vi.fn((_name: string, _args: Record<string, unknown>, _sign
 
 const mockConnect = vi.fn(() => Promise.resolve());
 const mockClose = vi.fn(() => Promise.resolve());
+const mockComplete = vi.fn((..._args: any[]) =>
+  Promise.resolve({ content: [{ type: 'text', text: 'Visual result' }] }),
+);
+
+vi.mock('@earendil-works/pi-ai/compat', () => ({ complete: mockComplete }));
 
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: class {
@@ -148,6 +153,7 @@ describe('browserUseExtension', () => {
     mockConnect.mockClear();
     mockCallTool.mockClear();
     mockClose.mockClear();
+    mockComplete.mockClear();
     mockListAllTools.mockClear();
   });
 
@@ -237,6 +243,32 @@ describe('browserUseExtension', () => {
         required: ['pageId'],
       });
       expect(tool!.promptSnippet).toContain('browser_list_pages');
+    });
+
+    it('omits temperature when the configured vision model uses reasoning', async () => {
+      await startExtension({
+        visionModel: { provider: 'deepseek-integration', model: 'kimi-k2.6' },
+      });
+      mockCallTool.mockResolvedValueOnce({
+        content: [{ type: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' }],
+      } as any);
+      const tool = registeredTools.get('browser_analyze_screenshot')!;
+      const ctx = {
+        modelRegistry: {
+          find: vi.fn(() => ({
+            id: 'kimi-k2.6',
+            provider: 'deepseek-integration',
+            reasoning: true,
+          })),
+          getApiKeyAndHeaders: vi.fn(() => Promise.resolve({ ok: true, apiKey: 'key' })),
+        },
+      };
+
+      await tool.execute('call-1', { pageId: 7 }, undefined, undefined, ctx);
+
+      const options = mockComplete.mock.calls[0]![2] as Record<string, unknown>;
+      expect(options).toMatchObject({ maxTokens: 2048 });
+      expect(options).not.toHaveProperty('temperature');
     });
 
     test('does not register analyze_screenshot without visionModel', async () => {

--- a/packages/pi-browser-use/src/__tests__/index.test.ts
+++ b/packages/pi-browser-use/src/__tests__/index.test.ts
@@ -7,7 +7,11 @@ const mockListAllTools = vi.fn(() =>
     {
       name: 'click',
       description: 'Click an element.',
-      inputSchema: { type: 'object' as const },
+      inputSchema: {
+        type: 'object' as const,
+        properties: { pageId: { type: 'number' as const } },
+        required: ['pageId'],
+      },
     },
     {
       name: 'take_snapshot',
@@ -32,7 +36,7 @@ const mockListAllTools = vi.fn(() =>
   ]),
 );
 
-const mockCallTool = vi.fn((_name: string, _args: Record<string, unknown>) =>
+const mockCallTool = vi.fn((_name: string, _args: Record<string, unknown>, _signal?: AbortSignal) =>
   Promise.resolve({
     content: [{ type: 'text', text: 'Tool result' }],
   }),
@@ -45,9 +49,14 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: class {
     connect = mockConnect;
     listTools = vi.fn(() => mockListAllTools().then((tools) => ({ tools, nextCursor: undefined })));
-    callTool = vi.fn((req: { name: string; arguments: Record<string, unknown> }) =>
-      mockCallTool(req.name, req.arguments),
+    callTool = vi.fn(
+      (
+        req: { name: string; arguments: Record<string, unknown> },
+        _schema: unknown,
+        options?: { signal?: AbortSignal },
+      ) => mockCallTool(req.name, req.arguments, options?.signal),
     );
+    ping = vi.fn(() => Promise.resolve({}));
     close = mockClose;
   },
 }));
@@ -74,11 +83,13 @@ interface RegisteredTool {
   name: string;
   label: string;
   description: string;
+  promptSnippet?: string;
+  promptGuidelines?: string[];
   parameters: unknown;
   execute: (
     id: string,
     params: Record<string, unknown>,
-    signal: undefined,
+    signal: AbortSignal | undefined,
     onUpdate: undefined,
     ctx: unknown,
   ) => Promise<unknown>;
@@ -183,6 +194,20 @@ describe('browserUseExtension', () => {
       expect(names).toContain('browser_navigate_page');
     });
 
+    it('preserves required pageId parameters from page-scoped upstream tools', async () => {
+      await startExtension();
+
+      const tool = registeredTools.get('browser_click')!;
+      expect(tool.parameters).toMatchObject({
+        properties: { pageId: { type: 'number' } },
+        required: ['pageId'],
+      });
+      expect(tool.promptSnippet).toContain('browser_list_pages');
+      expect(tool.promptGuidelines).toEqual(
+        expect.arrayContaining([expect.stringContaining('pageId')]),
+      );
+    });
+
     test('excludes lighthouse_audit', async () => {
       await startExtension();
 
@@ -205,13 +230,48 @@ describe('browserUseExtension', () => {
         visionModel: { provider: 'openai', model: 'gpt-4o' },
       });
 
-      expect(registeredTools.has('browser_analyze_screenshot')).toBe(true);
+      const tool = registeredTools.get('browser_analyze_screenshot');
+      expect(tool).toBeDefined();
+      expect(tool!.parameters).toMatchObject({
+        properties: { pageId: { type: 'number' } },
+        required: ['pageId'],
+      });
+      expect(tool!.promptSnippet).toContain('browser_list_pages');
     });
 
     test('does not register analyze_screenshot without visionModel', async () => {
       await startExtension();
 
       expect(registeredTools.has('browser_analyze_screenshot')).toBe(false);
+    });
+
+    it('returns visual analysis failures as tool errors', async () => {
+      await startExtension({
+        visionModel: { provider: 'openai', model: 'gpt-4o' },
+      });
+      const tool = registeredTools.get('browser_analyze_screenshot')!;
+
+      const result = (await tool.execute('call-1', { pageId: 7 }, undefined, undefined, {})) as {
+        isError?: boolean;
+      };
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('forwards the Pi abort signal during visual screenshot capture', async () => {
+      await startExtension({
+        visionModel: { provider: 'openai', model: 'gpt-4o' },
+      });
+      const tool = registeredTools.get('browser_analyze_screenshot')!;
+      const controller = new AbortController();
+
+      await tool.execute('call-1', { pageId: 7 }, controller.signal, undefined, {});
+
+      expect(mockCallTool).toHaveBeenCalledWith(
+        'take_screenshot',
+        { pageId: 7 },
+        controller.signal,
+      );
     });
   });
 
@@ -220,9 +280,19 @@ describe('browserUseExtension', () => {
       await startExtension();
       const clickTool = registeredTools.get('browser_click')!;
 
-      await clickTool.execute('call-1', { uid: '1_2' }, undefined, undefined, {});
+      await clickTool.execute('call-1', { pageId: 7, uid: '1_2' }, undefined, undefined, {});
 
-      expect(mockCallTool).toHaveBeenCalledWith('click', { uid: '1_2' });
+      expect(mockCallTool).toHaveBeenCalledWith('click', { pageId: 7, uid: '1_2' }, undefined);
+    });
+
+    it('forwards the Pi abort signal to the browser client', async () => {
+      await startExtension();
+      const clickTool = registeredTools.get('browser_click')!;
+      const controller = new AbortController();
+
+      await clickTool.execute('call-1', {}, controller.signal, undefined, {});
+
+      expect(mockCallTool).toHaveBeenCalledWith('click', {}, controller.signal);
     });
 
     test('returns upstream text content', async () => {
@@ -288,6 +358,7 @@ describe('browserUseExtension', () => {
       };
 
       expect(result.content[0]!.text).toContain('element not found');
+      expect(result.isError).toBe(true);
     });
 
     test('appends overlay hint for click action blocked by overlay', async () => {

--- a/packages/pi-browser-use/src/__tests__/index.test.ts
+++ b/packages/pi-browser-use/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 // --- Mocks ---
 
@@ -12,6 +12,11 @@ const mockListAllTools = vi.fn(() =>
     {
       name: 'take_snapshot',
       description: 'Take snapshot.',
+      inputSchema: { type: 'object' as const },
+    },
+    {
+      name: 'take_screenshot',
+      description: 'Take screenshot.',
       inputSchema: { type: 'object' as const },
     },
     {
@@ -356,20 +361,21 @@ describe('browserUseExtension', () => {
       expect(result.content[0]!.text).toContain('Latest page snapshot');
     });
 
-    test('handles upstream result with no text content (only images)', async () => {
+    it('forwards screenshot image content to Pi', async () => {
       mockCallTool.mockResolvedValueOnce({
         content: [{ type: 'image', data: 'base64data', mimeType: 'image/png' }],
       } as any);
 
       await startExtension();
-      const clickTool = registeredTools.get('browser_click')!;
+      const screenshotTool = registeredTools.get('browser_take_screenshot')!;
 
-      const result = (await clickTool.execute('call-1', {}, undefined, undefined, {})) as {
-        content: Array<{ type: string; text: string }>;
+      const result = (await screenshotTool.execute('call-1', {}, undefined, undefined, {})) as {
+        content: Array<{ type: string; data: string; mimeType: string }>;
       };
 
-      expect(result.content).toHaveLength(1);
-      expect(result.content[0]!.text).toBe('');
+      expect(result.content).toEqual([
+        { type: 'image', data: 'base64data', mimeType: 'image/png' },
+      ]);
     });
   });
 

--- a/packages/pi-browser-use/src/analyze-screenshot.ts
+++ b/packages/pi-browser-use/src/analyze-screenshot.ts
@@ -44,6 +44,7 @@ export type VisionCaller = (
   instruction: string,
   imageBase64: string,
   mimeType: string,
+  signal?: AbortSignal,
 ) => Promise<string>;
 
 /** Create a VisionCaller that resolves credentials from Pi's model registry. Used in CLI standalone mode. */
@@ -51,7 +52,12 @@ export function createFetchVisionCaller(visionConfig: VisionModelConfig): Vision
   const authStorage = AuthStorage.create();
   const registry = ModelRegistry.create(authStorage);
 
-  return async (instruction: string, imageBase64: string, mimeType: string): Promise<string> => {
+  return async (
+    instruction: string,
+    imageBase64: string,
+    mimeType: string,
+    signal?: AbortSignal,
+  ): Promise<string> => {
     const model = registry.find(visionConfig.provider, visionConfig.model);
     if (!model) {
       throw new Error(
@@ -70,6 +76,7 @@ export function createFetchVisionCaller(visionConfig: VisionModelConfig): Vision
     };
     if (auth.apiKey) options.apiKey = auth.apiKey;
     if (auth.headers) options.headers = auth.headers;
+    if (signal) options.signal = signal;
 
     const result = await complete(
       model,
@@ -111,11 +118,13 @@ export async function handleAnalyzeScreenshot(
   client: DevToolsClient,
   callVision: VisionCaller,
   args: Record<string, unknown>,
+  signal?: AbortSignal,
 ): Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }> {
   const instruction = String(args.instruction ?? '');
+  const screenshotArgs = typeof args.pageId === 'number' ? { pageId: args.pageId } : {};
 
   try {
-    const screenshotResult = await client.callTool('take_screenshot', {});
+    const screenshotResult = await client.callTool('take_screenshot', screenshotArgs, signal);
 
     let imageBase64 = '';
     let mimeType = 'image/png';
@@ -141,7 +150,7 @@ export async function handleAnalyzeScreenshot(
       };
     }
 
-    const analysis = await callVision(instruction, imageBase64, mimeType);
+    const analysis = await callVision(instruction, imageBase64, mimeType, signal);
 
     if (!analysis) {
       return {
@@ -159,6 +168,7 @@ export async function handleAnalyzeScreenshot(
       content: [{ type: 'text', text: `Visual Analysis Result:\n${analysis}` }],
     };
   } catch (error) {
+    if (signal?.aborted) throw error;
     const errorMsg = error instanceof Error ? error.message : String(error);
 
     const isModelError =
@@ -167,9 +177,14 @@ export async function handleAnalyzeScreenshot(
       errorMsg.includes('not found') ||
       errorMsg.includes('permission');
 
+    if (!isModelError) {
+      const errorName = error instanceof Error ? error.name : 'UnknownError';
+      console.error(`[pi-browser-use] visual analysis failed (${errorName})`);
+    }
+
     const fallbackMsg = isModelError
       ? 'Visual analysis model is not available. Use accessibility tree elements (uids from take_snapshot) for all interactions instead.'
-      : `Visual analysis failed: ${errorMsg}. Use accessibility tree elements instead.`;
+      : 'Visual analysis failed. Use accessibility tree elements instead.';
 
     return {
       content: [{ type: 'text', text: fallbackMsg }],

--- a/packages/pi-browser-use/src/analyze-screenshot.ts
+++ b/packages/pi-browser-use/src/analyze-screenshot.ts
@@ -71,9 +71,12 @@ export function createFetchVisionCaller(visionConfig: VisionModelConfig): Vision
     }
 
     const options: Record<string, unknown> = {
-      temperature: 0,
       maxTokens: 2048,
     };
+    // Reasoning models such as Kimi K2.6 only accept their provider-defined
+    // temperature. Pi-ai disables thinking for this short single-turn request;
+    // omitting temperature lets the provider choose its required default.
+    if (!model.reasoning) options.temperature = 0;
     if (auth.apiKey) options.apiKey = auth.apiKey;
     if (auth.headers) options.headers = auth.headers;
     if (signal) options.signal = signal;
@@ -98,6 +101,10 @@ export function createFetchVisionCaller(visionConfig: VisionModelConfig): Vision
       },
       options,
     );
+
+    if (result.stopReason === 'error') {
+      throw new Error(result.errorMessage || 'Vision model request failed');
+    }
 
     return result.content
       .filter((c): c is AiTextContent => c.type === 'text')

--- a/packages/pi-browser-use/src/analyze-screenshot.ts
+++ b/packages/pi-browser-use/src/analyze-screenshot.ts
@@ -73,10 +73,6 @@ export function createFetchVisionCaller(visionConfig: VisionModelConfig): Vision
     const options: Record<string, unknown> = {
       maxTokens: 2048,
     };
-    // Reasoning models such as Kimi K2.6 only accept their provider-defined
-    // temperature. Pi-ai disables thinking for this short single-turn request;
-    // omitting temperature lets the provider choose its required default.
-    if (!model.reasoning) options.temperature = 0;
     if (auth.apiKey) options.apiKey = auth.apiKey;
     if (auth.headers) options.headers = auth.headers;
     if (signal) options.signal = signal;

--- a/packages/pi-browser-use/src/cli.ts
+++ b/packages/pi-browser-use/src/cli.ts
@@ -13,7 +13,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { createFetchVisionCaller, handleAnalyzeScreenshot } from './analyze-screenshot.js';
-import type { BrowserUseConfig } from './config.js';
+import { type BrowserUseConfig, resolveConfig } from './config.js';
 import { DevToolsClient } from './index.js';
 import {
   augmentToolDescription,
@@ -35,6 +35,7 @@ const EXCLUDED_TOOLS = new Set([
   'trigger_extension_action',
   'uninstall_extension',
 ]);
+const ARRAY_CONFIG_KEYS = new Set(['allowedUrlPattern', 'blockedUrlPattern']);
 
 export function parseArgs(argv: string[]): BrowserUseConfig {
   const config: BrowserUseConfig = {};
@@ -62,6 +63,12 @@ export function parseArgs(argv: string[]): BrowserUseConfig {
         (config as Record<string, unknown>)[camelKey] = true;
       } else if (value === 'false') {
         (config as Record<string, unknown>)[camelKey] = false;
+      } else if (ARRAY_CONFIG_KEYS.has(camelKey)) {
+        const existing = (config as Record<string, unknown>)[camelKey];
+        (config as Record<string, unknown>)[camelKey] = [
+          ...(Array.isArray(existing) ? existing : []),
+          value,
+        ];
       } else {
         (config as Record<string, unknown>)[camelKey] = value;
       }
@@ -74,7 +81,7 @@ export function parseArgs(argv: string[]): BrowserUseConfig {
 }
 
 async function main(): Promise<void> {
-  const config = parseArgs(process.argv.slice(2));
+  const config = resolveConfig(parseArgs(process.argv.slice(2)));
   const client = new DevToolsClient(config);
   await client.connect();
 
@@ -85,8 +92,8 @@ async function main(): Promise<void> {
     { capabilities: { tools: {} } },
   );
 
-  server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const upstreamTools = await client.listAllTools();
+  server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => {
+    const upstreamTools = await client.listAllTools(extra.signal);
     const tools = [];
     toolNameMap.clear();
 
@@ -110,12 +117,20 @@ async function main(): Promise<void> {
         inputSchema: {
           type: 'object' as const,
           properties: {
+            ...(config.experimentalPageIdRouting
+              ? {
+                  pageId: {
+                    type: 'number',
+                    description: 'Numeric page ID returned by browser_list_pages.',
+                  },
+                }
+              : {}),
             instruction: {
               type: 'string',
               description: 'What to identify or analyze visually.',
             },
           },
-          required: ['instruction'],
+          required: config.experimentalPageIdRouting ? ['pageId'] : [],
         },
       });
     }
@@ -123,17 +138,17 @@ async function main(): Promise<void> {
     return { tools };
   });
 
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const { name, arguments: args } = request.params;
     const originalName = toolNameMap.get(name);
     if (!originalName) throw new Error(`Unknown tool: ${name}`);
 
     if (originalName === 'analyze_screenshot' && config.visionModel) {
       const callVision = createFetchVisionCaller(config.visionModel);
-      return await handleAnalyzeScreenshot(client, callVision, args ?? {});
+      return await handleAnalyzeScreenshot(client, callVision, args ?? {}, extra.signal);
     }
 
-    const result = await client.callTool(originalName, args ?? {});
+    const result = await client.callTool(originalName, args ?? {}, extra.signal);
     const textContent = extractTextContent(result.content);
     const processed = postProcessToolResult(originalName, textContent);
 

--- a/packages/pi-browser-use/src/config.ts
+++ b/packages/pi-browser-use/src/config.ts
@@ -31,11 +31,16 @@ export interface BrowserUseConfig {
   experimentalVision?: boolean;
   experimentalScreencast?: boolean;
   experimentalMemory?: boolean;
+  experimentalPageIdRouting?: boolean;
 
   visionModel?: VisionModelConfig;
 
   usageStatistics?: boolean;
   performanceCrux?: boolean;
+  redactNetworkHeaders?: boolean;
+  acceptInsecureCerts?: boolean;
+  allowedUrlPattern?: string[];
+  blockedUrlPattern?: string[];
 
   slim?: boolean;
   extraArgs?: string[];
@@ -52,13 +57,27 @@ const DEFAULTS: Partial<BrowserUseConfig> = {
   experimentalVision: true,
   experimentalScreencast: false,
   experimentalMemory: false,
+  experimentalPageIdRouting: true,
   usageStatistics: false,
   performanceCrux: false,
+  redactNetworkHeaders: true,
+  acceptInsecureCerts: false,
 };
 
 /** Merge user config over sane defaults. */
 export function resolveConfig(config?: BrowserUseConfig): BrowserUseConfig {
   const resolved = { ...DEFAULTS, ...config };
+
+  if (resolved.allowedUrlPattern?.length && resolved.blockedUrlPattern?.length) {
+    throw new Error('allowedUrlPattern and blockedUrlPattern cannot be used together');
+  }
+
+  if (resolved.slim) {
+    if (config?.experimentalPageIdRouting === true) {
+      throw new Error('experimentalPageIdRouting cannot be used with slim mode');
+    }
+    resolved.experimentalPageIdRouting = false;
+  }
 
   switch (resolved.sessionMode) {
     case 'existing':
@@ -106,9 +125,19 @@ export function configToArgs(config: BrowserUseConfig): string[] {
   if (resolved.experimentalVision) args.push('--experimental-vision');
   if (resolved.experimentalScreencast) args.push('--experimental-screencast');
   if (resolved.experimentalMemory) args.push('--experimental-memory');
+  if (resolved.experimentalPageIdRouting) args.push('--experimental-page-id-routing');
 
   if (resolved.usageStatistics === false) args.push('--no-usage-statistics');
   if (resolved.performanceCrux === false) args.push('--no-performance-crux');
+  if (resolved.redactNetworkHeaders) args.push('--redact-network-headers');
+  if (resolved.acceptInsecureCerts) args.push('--accept-insecure-certs');
+
+  for (const pattern of resolved.allowedUrlPattern ?? []) {
+    args.push(`--allowed-url-pattern=${pattern}`);
+  }
+  for (const pattern of resolved.blockedUrlPattern ?? []) {
+    args.push(`--blocked-url-pattern=${pattern}`);
+  }
 
   if (resolved.extraArgs) args.push(...resolved.extraArgs);
 

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -46,6 +46,32 @@ const EXCLUDED_TOOLS = new Set([
 ]);
 
 const MCP_TIMEOUT_MS = 60_000;
+const MCP_HEALTH_TIMEOUT_MS = 5_000;
+const MCP_HEALTH_CHECK_INTERVAL_MS = 10_000;
+
+function requestOptions(timeout: number, signal?: AbortSignal) {
+  return signal ? { signal, timeout } : { timeout };
+}
+
+function pageRoutingGuidance(enabled: boolean) {
+  return enabled
+    ? {
+        promptSnippet: 'Use browser_list_pages first, then pass its numeric pageId.',
+        promptGuidelines: [
+          'Call browser_list_pages before page-scoped tools to obtain the current numeric pageId.',
+          'Pass pageId explicitly instead of relying on shared browser_select_page state.',
+        ],
+      }
+    : {};
+}
+
+export type ConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'ready'
+  | 'reconnecting'
+  | 'failed'
+  | 'closing';
 
 /**
  * MCP client that spawns chrome-devtools-mcp as a subprocess and communicates
@@ -53,40 +79,139 @@ const MCP_TIMEOUT_MS = 60_000;
  */
 export class DevToolsClient {
   private client: Client | null = null;
-  private transport: StdioClientTransport | null = null;
   private config: BrowserUseConfig;
+  private state: ConnectionState = 'disconnected';
+  private connectPromise: Promise<void> | null = null;
+  private generation = 0;
+  private hasConnected = false;
+  private explicitlyClosed = false;
+  private lastHealthCheckAt = 0;
 
   constructor(config?: BrowserUseConfig) {
     this.config = resolveConfig(config);
   }
 
-  async connect(): Promise<void> {
-    const args = configToArgs(this.config);
+  getState(): ConnectionState {
+    return this.state;
+  }
 
-    this.transport = new StdioClientTransport({
+  async connect(signal?: AbortSignal): Promise<void> {
+    if (this.state === 'ready') return;
+    if (this.connectPromise) return this.connectPromise;
+
+    this.explicitlyClosed = false;
+    this.connectPromise = this.openConnection(signal);
+    try {
+      await this.connectPromise;
+    } finally {
+      this.connectPromise = null;
+    }
+  }
+
+  private async openConnection(signal?: AbortSignal): Promise<void> {
+    this.state = this.hasConnected ? 'reconnecting' : 'connecting';
+    const args = configToArgs(this.config);
+    const generation = ++this.generation;
+
+    const transport = new StdioClientTransport({
       command: 'npx',
       args: ['-y', 'chrome-devtools-mcp@latest', ...args],
       stderr: 'pipe',
     });
 
-    this.client = new Client({ name: 'pi-browser-use', version: '0.1.0' }, { capabilities: {} });
+    const client = new Client({ name: 'pi-browser-use', version: '0.1.0' }, { capabilities: {} });
+    this.client = client;
 
-    this.transport.onerror = (error: Error) => {
-      console.error(`[pi-browser-use] chrome-devtools-mcp transport error: ${error.message}`);
+    transport.onerror = (error: Error) => {
+      if (generation !== this.generation) return;
+      console.error(`[pi-browser-use] chrome-devtools-mcp transport error (${error.name})`);
+      void this.disconnectUnhealthyClient(generation);
     };
+    transport.onclose = () => this.markDisconnected(generation);
 
-    await this.client.connect(this.transport);
+    try {
+      await client.connect(transport, requestOptions(MCP_TIMEOUT_MS, signal));
+      if (generation !== this.generation) return;
+      this.state = 'ready';
+      this.hasConnected = true;
+      this.lastHealthCheckAt = Date.now();
+    } catch (error) {
+      if (generation === this.generation) {
+        ++this.generation;
+        this.client = null;
+        this.state = 'failed';
+      }
+      try {
+        await client.close();
+      } catch {
+        // The failed transport may already be closed.
+      }
+      if (signal?.aborted) throw error;
+      const errorName = error instanceof Error ? error.name : 'UnknownError';
+      console.error(`[pi-browser-use] browser connection failed (${errorName})`);
+      throw new Error('Browser connection failed.');
+    }
   }
 
-  async listAllTools(): Promise<Tool[]> {
-    if (!this.client) throw new Error('Client not connected');
+  private markDisconnected(generation: number): void {
+    if (generation !== this.generation || this.state === 'closing') return;
+    ++this.generation;
+    this.client = null;
+    this.state = 'disconnected';
+  }
+
+  private async disconnectUnhealthyClient(generation: number): Promise<void> {
+    if (generation !== this.generation || this.state === 'closing') return;
+    const failedClient = this.client;
+    this.markDisconnected(generation);
+    if (!failedClient) return;
+
+    try {
+      await failedClient.close();
+    } catch {
+      console.error('[pi-browser-use] failed to close unhealthy MCP client');
+    }
+  }
+
+  async ping(signal?: AbortSignal): Promise<boolean> {
+    if (this.state !== 'ready' || !this.client) return false;
+
+    const generation = this.generation;
+    try {
+      await this.client.ping(requestOptions(MCP_HEALTH_TIMEOUT_MS, signal));
+      if (generation !== this.generation) return false;
+      this.lastHealthCheckAt = Date.now();
+      return true;
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      await this.disconnectUnhealthyClient(generation);
+      return false;
+    }
+  }
+
+  async ensureReady(signal?: AbortSignal): Promise<void> {
+    if (this.explicitlyClosed) throw new Error('Client not connected');
+
+    if (this.state === 'ready') {
+      const healthCheckIsFresh = Date.now() - this.lastHealthCheckAt < MCP_HEALTH_CHECK_INTERVAL_MS;
+      if (healthCheckIsFresh || (await this.ping(signal))) return;
+    }
+
+    await this.connect(signal);
+  }
+
+  async listAllTools(signal?: AbortSignal): Promise<Tool[]> {
+    await this.ensureReady(signal);
+    const client = this.client;
+    if (!client) throw new Error('Client not connected');
 
     const allTools: Tool[] = [];
     let cursor: string | undefined;
     do {
-      const result = await this.client.listTools(cursor ? { cursor } : undefined, {
-        timeout: MCP_TIMEOUT_MS,
-      });
+      const result = await client.listTools(
+        cursor ? { cursor } : undefined,
+        requestOptions(MCP_TIMEOUT_MS, signal),
+      );
       allTools.push(...result.tools);
       cursor = result.nextCursor;
     } while (cursor);
@@ -97,6 +222,7 @@ export class DevToolsClient {
   async callTool(
     name: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<{
     content?: Array<{
       type: string;
@@ -106,27 +232,47 @@ export class DevToolsClient {
     }>;
     isError?: boolean;
   }> {
-    if (!this.client) throw new Error('Client not connected');
+    await this.ensureReady(signal);
+    const client = this.client;
+    if (!client) throw new Error('Client not connected');
 
-    return (await this.client.callTool({ name, arguments: args }, undefined, {
-      timeout: MCP_TIMEOUT_MS,
-    })) as {
-      content?: Array<{
-        type: string;
-        text?: string;
-        data?: string;
-        mimeType?: string;
-      }>;
-      isError?: boolean;
-    };
+    try {
+      return (await client.callTool(
+        { name, arguments: args },
+        undefined,
+        requestOptions(MCP_TIMEOUT_MS, signal),
+      )) as {
+        content?: Array<{
+          type: string;
+          text?: string;
+          data?: string;
+          mimeType?: string;
+        }>;
+        isError?: boolean;
+      };
+    } catch (error) {
+      if (signal?.aborted) throw error;
+      if (this.state !== 'ready' || this.client !== client) {
+        throw new Error('Browser connection lost; retry the tool.');
+      }
+      const errorName = error instanceof Error ? error.name : 'UnknownError';
+      console.error(`[pi-browser-use] upstream tool call failed (${errorName})`);
+      throw new Error('Browser tool call failed.');
+    }
   }
 
   async close(): Promise<void> {
-    if (this.client) {
-      await this.client.close();
-      this.client = null;
+    if (this.explicitlyClosed) return;
+    this.explicitlyClosed = true;
+    this.state = 'closing';
+    const client = this.client;
+    ++this.generation;
+    this.client = null;
+    try {
+      if (client) await client.close();
+    } finally {
+      this.state = 'disconnected';
     }
-    this.transport = null;
   }
 }
 
@@ -200,14 +346,10 @@ function toToolContent(
 export default function browserUseExtension(pi: ExtensionAPI): void {
   let config: BrowserUseConfig | undefined;
   let client: DevToolsClient | undefined;
-  let connected = false;
 
-  async function ensureConnected(): Promise<void> {
+  async function ensureConnected(signal?: AbortSignal): Promise<void> {
     if (!client) throw new Error('browser-use: session not started');
-    if (!connected) {
-      await client.connect();
-      connected = true;
-    }
+    await client.ensureReady(signal);
   }
 
   async function registerUpstreamTools(): Promise<void> {
@@ -220,23 +362,27 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       const prefixedName = `${TOOL_PREFIX}${tool.name}`;
       const originalName = tool.name;
       const description = augmentToolDescription(originalName, tool.description ?? '');
+      const routingGuidance = pageRoutingGuidance(
+        tool.inputSchema.required?.includes('pageId') ?? false,
+      );
 
       pi.registerTool({
         name: prefixedName,
         label: prefixedName,
         description,
+        ...routingGuidance,
         parameters: Type.Unsafe(tool.inputSchema),
         async execute(
           _toolCallId: string,
           params: Record<string, unknown>,
-          _signal: AbortSignal | undefined,
+          signal: AbortSignal | undefined,
           _onUpdate: unknown,
           _ctx: ExtensionContext,
         ) {
-          await ensureConnected();
-          const result = await client!.callTool(originalName, params);
-          const { content } = toToolContent(result, originalName);
-          return { content, details: undefined };
+          await ensureConnected(signal);
+          const result = await client!.callTool(originalName, params, signal);
+          const toolContent = toToolContent(result, originalName);
+          return { ...toolContent, details: undefined };
         },
       });
     }
@@ -247,7 +393,12 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
     visionConfig: VisionModelConfig,
     ctx: ExtensionContext,
   ): VisionCaller {
-    return async (instruction: string, imageBase64: string, mimeType: string): Promise<string> => {
+    return async (
+      instruction: string,
+      imageBase64: string,
+      mimeType: string,
+      signal?: AbortSignal,
+    ): Promise<string> => {
       const model = ctx.modelRegistry.find(visionConfig.provider, visionConfig.model);
       if (!model) {
         throw new Error(
@@ -266,6 +417,7 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       };
       if (auth.apiKey) options.apiKey = auth.apiKey;
       if (auth.headers) options.headers = auth.headers;
+      if (signal) options.signal = signal;
 
       const result = await complete(
         model,
@@ -296,12 +448,23 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
   }
 
   async function registerVisionTool(visionConfig: VisionModelConfig): Promise<void> {
+    const routingGuidance = pageRoutingGuidance(config?.experimentalPageIdRouting === true);
+    const pageIdParameter = config?.experimentalPageIdRouting
+      ? {
+          pageId: Type.Number({
+            description: 'Numeric page ID returned by browser_list_pages.',
+          }),
+        }
+      : {};
+
     pi.registerTool({
       name: `${TOOL_PREFIX}analyze_screenshot`,
       label: `${TOOL_PREFIX}analyze_screenshot`,
       description:
         'Analyze the current page visually using a screenshot. Use when you need to identify elements by visual attributes (color, layout, position) not available in the accessibility tree, or when you need precise pixel coordinates for click_at.',
+      ...routingGuidance,
       parameters: Type.Object({
+        ...pageIdParameter,
         instruction: Type.Optional(
           Type.String({
             description:
@@ -312,13 +475,13 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       async execute(
         _toolCallId: string,
         params: Record<string, unknown>,
-        _signal: AbortSignal | undefined,
+        signal: AbortSignal | undefined,
         _onUpdate: unknown,
         ctx: ExtensionContext,
       ) {
-        await ensureConnected();
+        await ensureConnected(signal);
         const callVision = createPiVisionCaller(visionConfig, ctx);
-        const result = await handleAnalyzeScreenshot(client!, callVision, params);
+        const result = await handleAnalyzeScreenshot(client!, callVision, params, signal);
         const content: Array<{ type: 'text'; text: string }> = [];
         if (result.content) {
           for (const item of result.content) {
@@ -330,7 +493,9 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
         if (content.length === 0) {
           content.push({ type: 'text', text: '' });
         }
-        return { content, details: undefined };
+        return result.isError
+          ? { content, isError: true, details: undefined }
+          : { content, details: undefined };
       },
     });
   }
@@ -338,7 +503,6 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
   pi.on('session_start', async (_event, ctx) => {
     config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
     client = new DevToolsClient(config);
-    connected = false;
     await registerUpstreamTools();
     if (config.visionModel) {
       await registerVisionTool(config.visionModel);
@@ -346,9 +510,9 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
   });
 
   pi.on('session_shutdown', async () => {
-    if (connected && client) {
+    if (client) {
       await client.close();
-      connected = false;
+      client = undefined;
     }
   });
 }

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -137,8 +137,8 @@ function loadConfigFromFile(options?: PiSettingsOptions): BrowserUseConfig {
   });
 }
 
-/** Convert upstream MCP result into pi-agent TextContent[], applying post-processing. */
-function toTextContent(
+/** Convert upstream MCP result into pi-agent content, applying text post-processing. */
+function toToolContent(
   result: {
     content?: Array<{
       type: string;
@@ -149,11 +149,18 @@ function toTextContent(
     isError?: boolean;
   },
   originalName: string,
-): { content: Array<{ type: 'text'; text: string }>; isError?: boolean } {
+): {
+  content: Array<
+    { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+  >;
+  isError?: boolean;
+} {
   const textContent = extractTextContent(result.content);
   const processed = postProcessToolResult(originalName, textContent);
 
-  const content: Array<{ type: 'text'; text: string }> = [];
+  const content: Array<
+    { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+  > = [];
 
   if (processed !== textContent) {
     content.push({ type: 'text', text: processed });
@@ -161,6 +168,14 @@ function toTextContent(
     for (const item of result.content) {
       if (item.type === 'text' && item.text) {
         content.push({ type: 'text', text: item.text });
+      }
+    }
+  }
+
+  if (result.content) {
+    for (const item of result.content) {
+      if (item.type === 'image' && item.data) {
+        content.push({ type: 'image', data: item.data, mimeType: item.mimeType ?? 'image/png' });
       }
     }
   }
@@ -220,7 +235,7 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
         ) {
           await ensureConnected();
           const result = await client!.callTool(originalName, params);
-          const { content } = toTextContent(result, originalName);
+          const { content } = toToolContent(result, originalName);
           return { content, details: undefined };
         },
       });

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -412,9 +412,12 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       }
 
       const options: Record<string, unknown> = {
-        temperature: 0,
         maxTokens: 2048,
       };
+      // Reasoning models such as Kimi K2.6 only accept their provider-defined
+      // temperature. Pi-ai disables thinking for this short single-turn request;
+      // omitting temperature lets the provider choose its required default.
+      if (!model.reasoning) options.temperature = 0;
       if (auth.apiKey) options.apiKey = auth.apiKey;
       if (auth.headers) options.headers = auth.headers;
       if (signal) options.signal = signal;
@@ -439,6 +442,10 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
         },
         options,
       );
+
+      if (result.stopReason === 'error') {
+        throw new Error(result.errorMessage || 'Vision model request failed');
+      }
 
       return result.content
         .filter((c): c is AiTextContent => c.type === 'text')

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -414,10 +414,6 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       const options: Record<string, unknown> = {
         maxTokens: 2048,
       };
-      // Reasoning models such as Kimi K2.6 only accept their provider-defined
-      // temperature. Pi-ai disables thinking for this short single-turn request;
-      // omitting temperature lets the provider choose its required default.
-      if (!model.reasoning) options.temperature = 0;
       if (auth.apiKey) options.apiKey = auth.apiKey;
       if (auth.headers) options.headers = auth.headers;
       if (signal) options.signal = signal;


### PR DESCRIPTION
## Summary

- preserve screenshot image blocks through the Pi tool bridge and add a screenshot-analysis integration case using the dedicated Kimi vision model
- route page-scoped CDP tools by explicit `pageId`, including visual screenshot analysis
- add MCP connection health checks, single-flight reconnects, stale transport protection, and AbortSignal propagation
- add typed URL allow/block, network-header redaction, and insecure-certificate settings
- document the new behavior and expand unit coverage

## Why

The browser bridge previously depended on shared selected-page state, only tracked connection health with a boolean, and dropped screenshot image content. This made multi-tab calls vulnerable to cross-page routing and prevented reliable visual analysis.

## Validation

- `pnpm --filter @amaster.ai/pi-browser-use test` — 130 tests passed
- `pnpm --filter @amaster.ai/pi-browser-use typecheck`
- `pnpm exec biome check packages/pi-browser-use/src packages/pi-browser-use/README.md .github/workflows/integration.yml`
- repository test suite: 1126/1127 passed; the remaining unrelated `pi-memory-mem0` persistence test is blocked by a local better-sqlite3 Node ABI mismatch