### PR TITLE
[codex] make browser MCP startup reproducible

### DIFF
--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -8,7 +8,7 @@ pi-coding-agent extension that wraps [chrome-devtools-mcp](https://github.com/Ch
 
 - **pi-coding-agent extension** — registers tools via `pi.registerTool()`, managed by the agent lifecycle
 - **Dynamic tool discovery** — automatically proxies all upstream chrome-devtools-mcp tools with `browser_` prefix
-- **Reproducible MCP runtime** — launches the packaged, pinned chrome-devtools-mcp entrypoint with the current Node executable instead of downloading `@latest` through ambient `npx`
+- **Reproducible MCP runtime** — launches the installed chrome-devtools-mcp entrypoint with the current Node executable instead of downloading `@latest` through ambient `npx`
 - **Page-scoped routing** — routes page tools by explicit `pageId` instead of shared selected-page state
 - **Connection recovery** — detects closed or unhealthy MCP transports and reconnects before the next call
 - **Navigation safety** — supports URL allow/block patterns and redacts sensitive network headers by default
@@ -25,7 +25,7 @@ bun add @amaster.ai/pi-browser-use
 
 Requires Node.js >= 20, Chrome (stable or newer), and `@earendil-works/pi-coding-agent >= 0.74.0`.
 
-`chrome-devtools-mcp` is a pinned runtime dependency and is resolved when the extension module loads. A missing or malformed installation fails extension loading immediately; the extension does not download a replacement at connection time. Connection failures expose only allowlisted system error codes or Chrome startup categories, not raw subprocess stderr.
+`chrome-devtools-mcp` is a compatible runtime dependency and its installed entrypoint is resolved when the extension module loads. A missing or malformed installation fails extension loading immediately; the extension does not download a replacement at connection time. Connection failures expose only allowlisted system error codes or Chrome startup categories, not raw subprocess stderr.
 
 ## Usage
 

--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -8,6 +8,7 @@ pi-coding-agent extension that wraps [chrome-devtools-mcp](https://github.com/Ch
 
 - **pi-coding-agent extension** — registers tools via `pi.registerTool()`, managed by the agent lifecycle
 - **Dynamic tool discovery** — automatically proxies all upstream chrome-devtools-mcp tools with `browser_` prefix
+- **Reproducible MCP runtime** — launches the packaged, pinned chrome-devtools-mcp entrypoint with the current Node executable instead of downloading `@latest` through ambient `npx`
 - **Page-scoped routing** — routes page tools by explicit `pageId` instead of shared selected-page state
 - **Connection recovery** — detects closed or unhealthy MCP transports and reconnects before the next call
 - **Navigation safety** — supports URL allow/block patterns and redacts sensitive network headers by default
@@ -23,6 +24,8 @@ bun add @amaster.ai/pi-browser-use
 ```
 
 Requires Node.js >= 20, Chrome (stable or newer), and `@earendil-works/pi-coding-agent >= 0.74.0`.
+
+`chrome-devtools-mcp` is a pinned runtime dependency and is resolved when the extension module loads. A missing or malformed installation fails extension loading immediately; the extension does not download a replacement at connection time. Connection failures expose only allowlisted system error codes or Chrome startup categories, not raw subprocess stderr.
 
 ## Usage
 

--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -23,7 +23,7 @@ pi-coding-agent extension that wraps [chrome-devtools-mcp](https://github.com/Ch
 bun add @amaster.ai/pi-browser-use
 ```
 
-Requires Node.js >= 20, Chrome (stable or newer), and `@earendil-works/pi-coding-agent >= 0.74.0`.
+Requires Node.js `^20.19.0 || ^22.12.0 || >=23`, Chrome (stable or newer), and `@earendil-works/pi-coding-agent >= 0.74.0`.
 
 `chrome-devtools-mcp` is a compatible runtime dependency and its installed entrypoint is resolved when the extension module loads. A missing or malformed installation fails extension loading immediately; the extension does not download a replacement at connection time. Connection failures expose only allowlisted system error codes or Chrome startup categories, not raw subprocess stderr.
 

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -5,6 +5,9 @@
   "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
   "license": "Apache-2.0",
   "type": "module",
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0 || >=23"
+  },
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@amaster.ai/pi-shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "chrome-devtools-mcp": "1.6.0"
+    "chrome-devtools-mcp": "^1.6.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.10",

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -46,7 +46,8 @@
   },
   "dependencies": {
     "@amaster.ai/pi-shared": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "chrome-devtools-mcp": "1.6.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.10",

--- a/packages/pi-browser-use/src/__tests__/devtools-client-stdio.test.ts
+++ b/packages/pi-browser-use/src/__tests__/devtools-client-stdio.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { DevToolsClient } from '../index.js';
+
+const originalExecPath = process.execPath;
+const originalPath = process.env.PATH;
+
+describe('DevToolsClient real stdio transport', () => {
+  afterEach(() => {
+    process.execPath = originalExecPath;
+    process.env.PATH = originalPath;
+  });
+
+  it('preserves a real spawn error code when the Node executable is missing', async () => {
+    process.execPath = '/definitely-missing/pi-browser-use-node';
+    const client = new DevToolsClient({ headless: true, sessionMode: 'isolated' });
+
+    await expect(client.connect()).rejects.toThrow(
+      'Browser connection failed. MCP subprocess failed (ENOENT).',
+    );
+  });
+
+  it('initializes the real MCP subprocess and lists tools with ambient npx absent', async () => {
+    process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+    const client = new DevToolsClient({
+      headless: true,
+      sessionMode: 'isolated',
+      ...(process.env.CHROME_BIN ? { executablePath: process.env.CHROME_BIN } : {}),
+    });
+
+    try {
+      const tools = await client.listAllTools();
+
+      expect(tools.length).toBeGreaterThan(0);
+      expect(tools.some((tool) => tool.name === 'navigate_page')).toBe(true);
+    } finally {
+      await client.close();
+    }
+  }, 60_000);
+});

--- a/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
+++ b/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
@@ -89,7 +89,7 @@ describe('DevToolsClient', () => {
       expect(mockClientConnect).toHaveBeenCalled();
     });
 
-    test('uses the packaged chrome-devtools-mcp entrypoint when PATH has no npx', async () => {
+    it('uses the installed chrome-devtools-mcp entrypoint when PATH has no npx', async () => {
       const originalPath = process.env.PATH;
       process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
       try {
@@ -106,7 +106,7 @@ describe('DevToolsClient', () => {
       }
     });
 
-    test('preserves an allowlisted MCP subprocess error code when startup fails', async () => {
+    it('preserves an allowlisted MCP subprocess error code when startup fails', async () => {
       mockClientConnect.mockImplementationOnce(async () => {
         mockTransports[0]!.stderr!.write('npm error code ENOTEMPTY path /private/cache\n');
         const error = new Error('MCP error -32000: Connection closed');
@@ -120,7 +120,7 @@ describe('DevToolsClient', () => {
       );
     });
 
-    test('does not expose arbitrary MCP subprocess stderr in connection errors', async () => {
+    it('does not expose arbitrary MCP subprocess stderr in connection errors', async () => {
       mockClientConnect.mockImplementationOnce(async () => {
         mockTransports[0]!.stderr!.write(
           'startup failed --ws-headers={"Authorization":"Bearer secret-token"}\n',

--- a/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
+++ b/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 
 const mockClientConnect = vi.fn(() => Promise.resolve());
@@ -6,6 +7,8 @@ const mockClientPing = vi.fn(() => Promise.resolve({}));
 const mockTransports: Array<{
   onclose?: () => void;
   onerror?: (error: Error) => void;
+  opts?: { command?: string; args?: string[] };
+  stderr?: PassThrough;
 }> = [];
 let _listToolsCalls = 0;
 const mockListTools = vi.fn((opts?: { cursor?: string }) => {
@@ -39,7 +42,8 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   StdioClientTransport: class {
     onclose?: () => void;
     onerror?: (error: Error) => void;
-    constructor(public opts: unknown) {
+    stderr = new PassThrough();
+    constructor(public opts: { command?: string; args?: string[] }) {
       mockTransports.push(this);
     }
   },
@@ -83,6 +87,53 @@ describe('DevToolsClient', () => {
       const client = new DevToolsClient({ headless: true, channel: 'canary' });
       await client.connect();
       expect(mockClientConnect).toHaveBeenCalled();
+    });
+
+    test('uses the packaged chrome-devtools-mcp entrypoint when PATH has no npx', async () => {
+      const originalPath = process.env.PATH;
+      process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+      try {
+        const client = new DevToolsClient({ headless: true });
+        await client.connect();
+
+        expect(mockTransports[0]!.opts).toMatchObject({ command: process.execPath });
+        expect(mockTransports[0]!.opts!.args?.[0]).toMatch(
+          /chrome-devtools-mcp[/\\]build[/\\]src[/\\]bin[/\\]chrome-devtools-mcp\.js$/,
+        );
+        expect(mockTransports[0]!.opts!.args).not.toContain('chrome-devtools-mcp@latest');
+      } finally {
+        process.env.PATH = originalPath;
+      }
+    });
+
+    test('preserves an allowlisted MCP subprocess error code when startup fails', async () => {
+      mockClientConnect.mockImplementationOnce(async () => {
+        mockTransports[0]!.stderr!.write('npm error code ENOTEMPTY path /private/cache\n');
+        const error = new Error('MCP error -32000: Connection closed');
+        error.name = 'McpError';
+        throw error;
+      });
+      const client = new DevToolsClient({ headless: true });
+
+      await expect(client.connect()).rejects.toThrow(
+        'Browser connection failed. MCP subprocess failed (ENOTEMPTY).',
+      );
+    });
+
+    test('does not expose arbitrary MCP subprocess stderr in connection errors', async () => {
+      mockClientConnect.mockImplementationOnce(async () => {
+        mockTransports[0]!.stderr!.write(
+          'startup failed --ws-headers={"Authorization":"Bearer secret-token"}\n',
+        );
+        throw new Error('Connection closed');
+      });
+      const client = new DevToolsClient({ headless: true });
+
+      const connection = client.connect();
+      await expect(connection).rejects.toThrow(
+        'Browser connection failed. MCP transport failed (Error).',
+      );
+      await expect(connection).rejects.not.toThrow('secret-token');
     });
   });
 

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -51,6 +51,8 @@ const MCP_TIMEOUT_MS = 60_000;
 const MCP_HEALTH_TIMEOUT_MS = 5_000;
 const MCP_HEALTH_CHECK_INTERVAL_MS = 10_000;
 const MCP_STDERR_LIMIT = 4_096;
+const MCP_SYSTEM_ERROR_CODE_PATTERN =
+  /^(?:EACCES|EADDRINUSE|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENOENT|ENOTEMPTY|ENOTFOUND|EPERM|ETIMEDOUT)$/;
 const require = createRequire(import.meta.url);
 const chromeDevToolsMcpPackagePath = require.resolve('chrome-devtools-mcp/package.json');
 const chromeDevToolsMcpPackage = require(chromeDevToolsMcpPackagePath) as {
@@ -69,10 +71,16 @@ function requestOptions(timeout: number, signal?: AbortSignal) {
   return signal ? { signal, timeout } : { timeout };
 }
 
-function summarizeMcpFailure(stderr: string, errorName: string): string {
-  const systemError = stderr.match(
-    /\b(EACCES|EADDRINUSE|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENOENT|ENOTEMPTY|ENOTFOUND|EPERM|ETIMEDOUT)\b/,
-  )?.[1];
+function safeMcpSystemErrorCode(value: unknown): string | undefined {
+  return typeof value === 'string' && MCP_SYSTEM_ERROR_CODE_PATTERN.test(value) ? value : undefined;
+}
+
+function summarizeMcpFailure(stderr: string, errorName: string, errorCode?: string): string {
+  const systemError =
+    safeMcpSystemErrorCode(errorCode) ??
+    stderr.match(
+      /\b(EACCES|EADDRINUSE|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENOENT|ENOTEMPTY|ENOTFOUND|EPERM|ETIMEDOUT)\b/,
+    )?.[1];
   if (systemError) return `MCP subprocess failed (${systemError}).`;
   if (/could not find (?:chrome|browser)/i.test(stderr)) {
     return 'Chrome executable was not found.';
@@ -153,6 +161,7 @@ export class DevToolsClient {
       stderr: 'pipe',
     });
     let stderr = '';
+    let transportErrorCode: string | undefined;
     transport.stderr?.on('data', (chunk) => {
       stderr = `${stderr}${String(chunk)}`.slice(-MCP_STDERR_LIMIT);
     });
@@ -162,7 +171,10 @@ export class DevToolsClient {
 
     transport.onerror = (error: Error) => {
       if (generation !== this.generation) return;
-      console.error(`[pi-browser-use] chrome-devtools-mcp transport error (${error.name})`);
+      transportErrorCode = safeMcpSystemErrorCode((error as Error & { code?: unknown }).code);
+      console.error(
+        `[pi-browser-use] chrome-devtools-mcp transport error (${transportErrorCode ?? error.name})`,
+      );
       void this.disconnectUnhealthyClient(generation);
     };
     transport.onclose = () => this.markDisconnected(generation);
@@ -186,7 +198,11 @@ export class DevToolsClient {
       }
       if (signal?.aborted) throw error;
       const errorName = error instanceof Error ? error.name : 'UnknownError';
-      const diagnostic = summarizeMcpFailure(stderr, errorName);
+      const errorCode =
+        error instanceof Error
+          ? safeMcpSystemErrorCode((error as Error & { code?: unknown }).code)
+          : undefined;
+      const diagnostic = summarizeMcpFailure(stderr, errorName, transportErrorCode ?? errorCode);
       console.error(`[pi-browser-use] browser connection failed: ${diagnostic}`);
       throw new Error(`Browser connection failed. ${diagnostic}`);
     }

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -1,3 +1,5 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
 import type { TextContent as AiTextContent } from '@earendil-works/pi-ai';
 import { complete } from '@earendil-works/pi-ai/compat';
@@ -48,9 +50,41 @@ const EXCLUDED_TOOLS = new Set([
 const MCP_TIMEOUT_MS = 60_000;
 const MCP_HEALTH_TIMEOUT_MS = 5_000;
 const MCP_HEALTH_CHECK_INTERVAL_MS = 10_000;
+const MCP_STDERR_LIMIT = 4_096;
+const require = createRequire(import.meta.url);
+const chromeDevToolsMcpPackagePath = require.resolve('chrome-devtools-mcp/package.json');
+const chromeDevToolsMcpPackage = require(chromeDevToolsMcpPackagePath) as {
+  bin?: Record<string, string>;
+};
+const chromeDevToolsMcpBin = chromeDevToolsMcpPackage.bin?.['chrome-devtools-mcp'];
+if (!chromeDevToolsMcpBin) {
+  throw new Error('chrome-devtools-mcp package does not declare its chrome-devtools-mcp binary');
+}
+const CHROME_DEVTOOLS_MCP_ENTRYPOINT = join(
+  dirname(chromeDevToolsMcpPackagePath),
+  chromeDevToolsMcpBin,
+);
 
 function requestOptions(timeout: number, signal?: AbortSignal) {
   return signal ? { signal, timeout } : { timeout };
+}
+
+function summarizeMcpFailure(stderr: string, errorName: string): string {
+  const systemError = stderr.match(
+    /\b(EACCES|EADDRINUSE|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENOENT|ENOTEMPTY|ENOTFOUND|EPERM|ETIMEDOUT)\b/,
+  )?.[1];
+  if (systemError) return `MCP subprocess failed (${systemError}).`;
+  if (/could not find (?:chrome|browser)/i.test(stderr)) {
+    return 'Chrome executable was not found.';
+  }
+  if (/failed to launch (?:the )?(?:browser|chrome)/i.test(stderr)) {
+    return 'Chrome failed to launch.';
+  }
+  if (/(?:browser|chrome).+already running|profile.+in use/i.test(stderr)) {
+    return 'Chrome profile is already in use.';
+  }
+  const safeErrorName = /^[A-Za-z][A-Za-z0-9]{0,63}$/.test(errorName) ? errorName : 'UnknownError';
+  return `MCP transport failed (${safeErrorName}).`;
 }
 
 function pageRoutingGuidance(enabled: boolean) {
@@ -114,9 +148,13 @@ export class DevToolsClient {
     const generation = ++this.generation;
 
     const transport = new StdioClientTransport({
-      command: 'npx',
-      args: ['-y', 'chrome-devtools-mcp@latest', ...args],
+      command: process.execPath,
+      args: [CHROME_DEVTOOLS_MCP_ENTRYPOINT, ...args],
       stderr: 'pipe',
+    });
+    let stderr = '';
+    transport.stderr?.on('data', (chunk) => {
+      stderr = `${stderr}${String(chunk)}`.slice(-MCP_STDERR_LIMIT);
     });
 
     const client = new Client({ name: 'pi-browser-use', version: '0.1.0' }, { capabilities: {} });
@@ -148,8 +186,9 @@ export class DevToolsClient {
       }
       if (signal?.aborted) throw error;
       const errorName = error instanceof Error ? error.name : 'UnknownError';
-      console.error(`[pi-browser-use] browser connection failed (${errorName})`);
-      throw new Error('Browser connection failed.');
+      const diagnostic = summarizeMcpFailure(stderr, errorName);
+      console.error(`[pi-browser-use] browser connection failed: ${diagnostic}`);
+      throw new Error(`Browser connection failed. ${diagnostic}`);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       chrome-devtools-mcp:
-        specifier: 1.6.0
+        specifier: ^1.6.0
         version: 1.6.0
     devDependencies:
       '@earendil-works/pi-ai':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
+      chrome-devtools-mcp:
+        specifier: 1.6.0
+        version: 1.6.0
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: 0.80.10
@@ -1786,6 +1789,19 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chrome-devtools-mcp@1.6.0:
+    resolution: {integrity: sha512-VZX6f/OjQSYhy2BGGRs+y3LsrsAQAz/HwZCWKBLVyST/4r/3zjVEjjVW7gMCVbRDuspnVdcp5hQDPrQ5UFrdZw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+    hasBin: true
+    peerDependencies:
+      '@blackwell-systems/gcf': ^2.2.2
+      '@toon-format/toon': ^2.2.0
+    peerDependenciesMeta:
+      '@blackwell-systems/gcf':
+        optional: true
+      '@toon-format/toon':
+        optional: true
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -5111,6 +5127,8 @@ snapshots:
       readdirp: 4.1.2
 
   chownr@1.1.4: {}
+
+  chrome-devtools-mcp@1.6.0: {}
 
   ci-info@3.9.0: {}
 


### PR DESCRIPTION
## Summary

- replace runtime `npx -y chrome-devtools-mcp@latest` with the installed compatible package dependency and its declared binary, launched through `process.execPath`
- classify MCP startup failures into allowlisted system error codes or Chrome startup categories without exposing arbitrary subprocess stderr
- add real restricted-PATH stdio initialization/tool-listing coverage and real spawn-error coverage
- align the published Node support contract with `chrome-devtools-mcp`: `^20.19.0 || ^22.12.0 || >=23`

## Root cause

The AMaster LaunchAgent originally lacked `npx`. After PATH was expanded, browser-use still failed because every startup ran mutable `@latest` through the shared npm `_npx` cache. The retained failure reproduced as:

```text
ENOTEMPTY: directory not empty, rename .../node_modules/chrome-devtools-mcp -> .../.chrome-devtools-mcp-*
```

`StdioClientTransport` piped the subprocess stderr, but browser-use did not consume it and replaced the MCP error with `Browser connection failed.`, hiding the causal npm failure.

The package now resolves the installed `chrome-devtools-mcp` binary from package metadata and launches it with the current Node executable. `package.json` accepts compatible `^1.6.0` releases while the lockfile resolves exactly `1.6.0`. Startup no longer depends on interactive-shell PATH, network resolution, `@latest`, or shared `_npx` cache mutation.

The dependency and its declared binary are resolved at module load. A missing or malformed hard dependency therefore fails extension loading immediately instead of attempting a lazy runtime download. Connection failures expose only an allowlisted OS error code (`ENOENT`, `ENOTEMPTY`, and related spawn/network codes), a known Chrome startup category, or the sanitized error type; arbitrary stderr, paths, URLs, headers and environment output are not copied into logs or thrown messages.

Tracks [TGYD-helige/pi-agent#369](https://github.com/TGYD-helige/pi-agent/issues/369).

## Verification

- `pnpm pr-check` under the repository-required Node 24 runtime: 79 test files, 1144 tests passed; build and typecheck passed
- focused browser-use package: 7 test files, 138 tests passed; typecheck passed
- real restricted-PATH stdio test initializes installed `chrome-devtools-mcp` and lists tools without ambient `npx`
- real missing-executable spawn test preserves the allowlisted `ENOENT` code
- package `engines.node` and README both declare `^20.19.0 || ^22.12.0 || >=23`
- `git diff --check`
- lockfile follow-up diff is limited to changing the dependency specifier to `^1.6.0`; resolution remains `1.6.0`
