### PR TITLE
Harden image generation and macOS computer-use startup

### DIFF
--- a/packages/pi-computer-use/README.md
+++ b/packages/pi-computer-use/README.md
@@ -14,8 +14,8 @@ runtime comes from the official
   accessibility + screenshot state, native input, browser tools, diagnostics,
   recording, and permission policy support
 - Full MCP text, image, and `structuredContent` forwarding
-- Owned daemon + MCP proxy lifecycle with reconnect and AbortSignal propagation
-- A non-prompting permission probe on session start
+- Owned daemon + MCP proxy lifecycle with session-owned reconnect and per-call cancellation
+- A non-prompting Linux/Windows permission probe on session start
 - Once-per-session app-launch approval and confirmation for high-risk operations
 - Bounded text and structured results before they enter Pi's context
 - Optional secondary vision analysis through a configured Pi model
@@ -78,12 +78,21 @@ Use it only when the primary model cannot resolve visual ambiguity.
 
 ## Runtime and permissions
 
-At `session_start`, the extension starts the driver daemon and MCP proxy, then
-registers the exact live `tools/list` surface for that platform and calls
-`check_permissions({ prompt: false })`. The generated macOS 0.9.0 manifest is
-used only to detect release drift. If startup discovery fails, the extension
+On macOS, `session_start` registers the generated 0.9.0 manifest without
+starting the driver. The signed app and MCP proxy start lazily on the first
+computer-use tool call, which requests any missing permissions through
+`check_permissions({ prompt: true })`. Existing grants do not raise another
+system dialog. The requested tool still runs and reports its own capability or
+permission error. Linux and Windows keep eager startup: they discover the exact
+live `tools/list` surface and call
+`check_permissions({ prompt: false })`. If discovery fails, the extension
 registers `computer_use_connect` (and `/computer-use-connect`) so a later retry
-can install the exact live platform contract without advertising another OS's schemas.
+can install the exact live platform contract without advertising another OS's
+schemas.
+
+Driver startup, reconnect, and the first macOS permission probe are session-owned.
+Cancelling a tool stops only that caller's wait or MCP request; session shutdown
+aborts the shared work.
 
 - **Bundled macOS:** launches the signed `CuaDriver.app` through LaunchServices,
   so Accessibility and Screen Recording grants belong to `com.trycua.driver`.
@@ -112,8 +121,8 @@ can install the exact live platform contract without advertising another OS's sc
 5. Re-run `computer_use_get_window_state` and verify the change
 6. `computer_use_end_session`
 
-Tool descriptions and schemas are discovered from the exact live driver, so the
-model receives the platform-specific contract without a separate bundled skill.
+Linux and Windows tool descriptions and schemas come from the exact live driver.
+macOS uses the generated manifest for the bundled driver release.
 
 ## License
 

--- a/packages/pi-computer-use/src/__tests__/index.test.ts
+++ b/packages/pi-computer-use/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import toolManifest from '../generated/cua-driver-tools.js';
 
 Object.defineProperty(process, 'platform', { value: 'darwin' });
@@ -16,9 +16,45 @@ type LiveTool = {
   inputSchema: unknown;
 };
 
+function abortableDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  let markStarted!: () => void;
+  let signal: AbortSignal | undefined;
+  let aborted = false;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  const started = new Promise<void>((resolveStarted) => {
+    markStarted = resolveStarted;
+  });
+  return {
+    started,
+    wait(nextSignal?: AbortSignal) {
+      signal = nextSignal;
+      const onAbort = () => {
+        aborted = true;
+        reject(signal?.reason);
+      };
+      signal?.aborted ? onAbort() : signal?.addEventListener('abort', onAbort, { once: true });
+      markStarted();
+      return promise;
+    },
+    resolve,
+    get aborted() {
+      return aborted;
+    },
+  };
+}
+
 let mockConfigContent: string | null = null;
-let mockConnect: () => Promise<void> = async () => {};
-let mockCallTool: (name: string, args: Record<string, unknown>) => UpstreamResult = () => ({
+let mockConnect: (signal?: AbortSignal) => Promise<void> = async () => {};
+let mockCallTool: (
+  name: string,
+  args: Record<string, unknown>,
+  signal?: AbortSignal,
+) => UpstreamResult | Promise<UpstreamResult> = () => ({
   content: [{ type: 'text', text: 'Action executed.' }],
 });
 let mockLiveTools: readonly LiveTool[] = toolManifest.tools;
@@ -28,8 +64,8 @@ let closeCount = 0;
 
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: class MockClient {
-    async connect() {
-      return mockConnect();
+    async connect(_transport: unknown, options?: { signal?: AbortSignal }) {
+      return mockConnect(options?.signal);
     }
     async close() {
       closeCount++;
@@ -43,7 +79,11 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
       options: Record<string, unknown> | undefined,
     ) {
       lastRequestOptions = options;
-      return mockCallTool(request.name, request.arguments ?? {});
+      return mockCallTool(
+        request.name,
+        request.arguments ?? {},
+        options?.signal as AbortSignal | undefined,
+      );
     }
   },
 }));
@@ -130,9 +170,12 @@ const mockPi = {
   }),
 };
 
+const { CuaDriverClient } = await import('../mcp-client.js');
 const { default: computerUseExtension } = await import('../index.js');
+const originalCallTool = CuaDriverClient.prototype.callTool;
 
-async function start(config?: Record<string, unknown>) {
+async function start(config?: Record<string, unknown>, platform = 'darwin') {
+  Object.defineProperty(process, 'platform', { value: platform });
   mockConfigContent = config ? JSON.stringify({ 'pi-computer-use': config }) : null;
   tools.clear();
   commands.clear();
@@ -159,7 +202,13 @@ describe('computerUseExtension', () => {
     mockCtx.ui.confirm.mockClear();
   });
 
-  it('registers the complete live Rust 0.9 tool manifest', async () => {
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    for (const handler of handlers.session_shutdown ?? []) await handler({}, mockCtx);
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+  });
+
+  it('registers the pinned Rust 0.9 tool manifest on macOS', async () => {
     await start();
 
     expect(tools.size).toBe(toolManifest.tools.length);
@@ -169,7 +218,11 @@ describe('computerUseExtension', () => {
     expect(tools.has('computer_use_screenshot')).toBe(false);
   });
 
-  it('registers the live platform schema without adding macOS reference tools', async () => {
+  it('does not start the macOS driver to discover its live schema', async () => {
+    let connects = 0;
+    mockConnect = async () => {
+      connects++;
+    };
     mockLiveTools = [
       {
         name: 'platform_specific_tool',
@@ -180,11 +233,247 @@ describe('computerUseExtension', () => {
 
     await start();
 
-    expect(tools.has('computer_use_platform_specific_tool')).toBe(true);
-    expect(tools.has('computer_use_click')).toBe(false);
+    expect(connects).toBe(0);
+    expect(tools.has('computer_use_platform_specific_tool')).toBe(false);
+    expect(tools.has('computer_use_click')).toBe(true);
   });
 
-  it('connects and performs a non-prompting permission probe on session start', async () => {
+  it('requests macOS permissions once on the first computer-use call', async () => {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    mockCallTool = (name, args) => {
+      calls.push({ name, args });
+      return name === 'check_permissions'
+        ? {
+            content: [{ type: 'text', text: 'Permissions granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          }
+        : { content: [{ type: 'text', text: 'ok' }] };
+    };
+    await start();
+
+    const listApps = tools.get('computer_use_list_apps')!;
+    await Promise.all([
+      listApps.execute('first', {}, undefined, undefined, mockCtx),
+      listApps.execute('second', {}, undefined, undefined, mockCtx),
+    ]);
+
+    expect(calls.filter((call) => call.name === 'check_permissions')).toEqual([
+      { name: 'check_permissions', args: { prompt: true } },
+    ]);
+  });
+
+  it('honors an explicit read-only macOS permission check', async () => {
+    const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    mockCallTool = (name, args) => {
+      calls.push({ name, args });
+      return { content: [{ type: 'text', text: 'ok' }] };
+    };
+    await start();
+
+    await tools
+      .get('computer_use_check_permissions')!
+      .execute('check', { prompt: false }, undefined, undefined, mockCtx);
+
+    expect(calls).toEqual([{ name: 'check_permissions', args: { prompt: false } }]);
+  });
+
+  it('lets tools report their own permission requirements', async () => {
+    let actionCalled = false;
+    mockCallTool = (name) => {
+      if (name === 'check_permissions') {
+        return { content: [{ type: 'text', text: 'Permission status unavailable.' }] };
+      }
+      actionCalled = true;
+      return { content: [{ type: 'text', text: 'Action executed.' }] };
+    };
+    await start();
+
+    const result = (await tools
+      .get('computer_use_list_apps')!
+      .execute('list', {}, undefined, undefined, mockCtx)) as any;
+
+    expect(actionCalled).toBe(true);
+    expect(result.isError).not.toBe(true);
+  });
+
+  it('lets one caller cancel without aborting another caller first connection', async () => {
+    const connection = abortableDeferred<void>();
+    mockConnect = connection.wait;
+    await start();
+
+    const controller = new AbortController();
+    const listApps = tools.get('computer_use_list_apps')!;
+    const cancelledCall = listApps.execute('cancelled', {}, controller.signal, undefined, mockCtx);
+    await connection.started;
+    const activeCall = listApps.execute('active', {}, undefined, undefined, mockCtx);
+    controller.abort(new Error('cancelled by user'));
+
+    await expect(cancelledCall).rejects.toThrow('cancelled by user');
+    connection.resolve();
+    const activeResult = (await activeCall) as any;
+    expect(activeResult.isError).not.toBe(true);
+  });
+
+  it('keeps a shared reconnect alive when the first permission probe is cancelled', async () => {
+    let connects = 0;
+    const reconnect = abortableDeferred<void>();
+    mockConnect = (signal) => {
+      connects++;
+      return connects === 1 ? Promise.resolve() : reconnect.wait(signal);
+    };
+    await start();
+
+    let disconnectBeforePermission = true;
+    vi.spyOn(CuaDriverClient.prototype, 'callTool').mockImplementation(function (
+      this: InstanceType<typeof CuaDriverClient>,
+      ...args
+    ) {
+      if (disconnectBeforePermission && args[0] === 'check_permissions') {
+        disconnectBeforePermission = false;
+        lastTransport?.onclose?.();
+      }
+      return originalCallTool.apply(this, args);
+    });
+
+    const controller = new AbortController();
+    const listApps = tools.get('computer_use_list_apps')!;
+    const cancelledCall = listApps.execute('cancelled', {}, controller.signal, undefined, mockCtx);
+    await reconnect.started;
+    const activeCall = listApps.execute('active', {}, undefined, undefined, mockCtx);
+    await Promise.resolve();
+    controller.abort(new Error('cancelled by user'));
+
+    await expect(cancelledCall).rejects.toThrow('cancelled by user');
+    expect(reconnect.aborted).toBe(false);
+    reconnect.resolve();
+    const activeResult = (await activeCall) as any;
+    expect(activeResult.isError).not.toBe(true);
+    expect(connects).toBe(2);
+  });
+
+  it('aborts an unowned first connection when its session shuts down', async () => {
+    const connection = abortableDeferred<void>();
+    mockConnect = connection.wait;
+    await start();
+
+    const call = tools
+      .get('computer_use_list_apps')!
+      .execute('active', {}, undefined, undefined, mockCtx);
+    await connection.started;
+    for (const handler of handlers.session_shutdown ?? []) await handler({}, mockCtx);
+
+    expect(connection.aborted).toBe(true);
+    const result = (await call) as any;
+    expect(result.isError).toBe(true);
+  });
+
+  it('keeps and reuses the first connection when its only caller cancels', async () => {
+    let connects = 0;
+    const connection = abortableDeferred<void>();
+    mockConnect = (signal) => {
+      connects++;
+      return connection.wait(signal);
+    };
+    await start();
+
+    const controller = new AbortController();
+    const listApps = tools.get('computer_use_list_apps')!;
+    const call = listApps.execute('cancelled', {}, controller.signal, undefined, mockCtx);
+    await connection.started;
+    controller.abort(new Error('cancelled by user'));
+
+    await expect(call).rejects.toThrow('cancelled by user');
+    expect(connection.aborted).toBe(false);
+    const retryCall = listApps.execute('retry', {}, undefined, undefined, mockCtx);
+    connection.resolve();
+    const retryResult = (await retryCall) as any;
+    expect(retryResult.isError).not.toBe(true);
+    expect(connects).toBe(1);
+  });
+
+  it('keeps and reuses the permission request when its only caller cancels', async () => {
+    let permissionChecks = 0;
+    const permission = abortableDeferred<UpstreamResult>();
+    mockCallTool = (name, _args, signal) => {
+      if (name !== 'check_permissions') {
+        return { content: [{ type: 'text', text: 'Action executed.' }] };
+      }
+      permissionChecks++;
+      return permission.wait(signal);
+    };
+    await start();
+
+    const controller = new AbortController();
+    const call = tools
+      .get('computer_use_list_apps')!
+      .execute('cancelled', {}, controller.signal, undefined, mockCtx);
+    await permission.started;
+    controller.abort(new Error('cancelled by user'));
+
+    await expect(call).rejects.toThrow('cancelled by user');
+    expect(permission.aborted).toBe(false);
+    const retryCall = tools
+      .get('computer_use_list_apps')!
+      .execute('retry', {}, undefined, undefined, mockCtx);
+    permission.resolve({
+      content: [{ type: 'text', text: 'Permissions granted.' }],
+      structuredContent: { accessibility: true, screen_recording: true },
+    });
+    const retryResult = (await retryCall) as any;
+    expect(retryResult.isError).not.toBe(true);
+    expect(permissionChecks).toBe(1);
+  });
+
+  it('keeps the permission request while another caller is waiting', async () => {
+    const permission = abortableDeferred<UpstreamResult>();
+    mockCallTool = (name, _args, signal) => {
+      if (name !== 'check_permissions') {
+        return { content: [{ type: 'text', text: 'Action executed.' }] };
+      }
+      return permission.wait(signal);
+    };
+    await start();
+
+    const controller = new AbortController();
+    const listApps = tools.get('computer_use_list_apps')!;
+    const cancelledCall = listApps.execute('cancelled', {}, controller.signal, undefined, mockCtx);
+    const activeCall = listApps.execute('active', {}, undefined, undefined, mockCtx);
+    await permission.started;
+    await Promise.resolve();
+    controller.abort(new Error('cancelled by user'));
+
+    await expect(cancelledCall).rejects.toThrow('cancelled by user');
+    expect(permission.aborted).toBe(false);
+    permission.resolve({
+      content: [{ type: 'text', text: 'Permissions granted.' }],
+      structuredContent: { accessibility: true, screen_recording: true },
+    });
+    const activeResult = (await activeCall) as any;
+    expect(activeResult.isError).not.toBe(true);
+  });
+
+  it('aborts an active permission request when its session shuts down', async () => {
+    const permission = abortableDeferred<UpstreamResult>();
+    mockCallTool = (name, _args, signal) => {
+      if (name !== 'check_permissions') {
+        return { content: [{ type: 'text', text: 'Action executed.' }] };
+      }
+      return permission.wait(signal);
+    };
+    await start();
+
+    const call = tools
+      .get('computer_use_list_apps')!
+      .execute('active', {}, undefined, undefined, mockCtx);
+    await permission.started;
+    for (const handler of handlers.session_shutdown ?? []) await handler({}, mockCtx);
+
+    expect(permission.aborted).toBe(true);
+    const result = (await call) as any;
+    expect(result.isError).toBe(true);
+  });
+
+  it('keeps eager discovery and permission probing on non-macOS platforms', async () => {
     let connects = 0;
     let permissionArgs: Record<string, unknown> | undefined;
     mockConnect = async () => {
@@ -195,7 +484,7 @@ describe('computerUseExtension', () => {
       return { content: [{ type: 'text', text: 'ok' }] };
     };
 
-    await start();
+    await start(undefined, 'linux');
 
     expect(connects).toBe(1);
     expect(permissionArgs).toEqual({ prompt: false });
@@ -215,7 +504,7 @@ describe('computerUseExtension', () => {
       },
     ];
 
-    await start();
+    await start(undefined, 'linux');
 
     expect(tools.has('computer_use_click')).toBe(false);
     expect(tools.has('computer_use_connect')).toBe(true);
@@ -234,13 +523,22 @@ describe('computerUseExtension', () => {
 
   it('forwards image content, structured output, and cancellation', async () => {
     await start();
-    mockCallTool = () => ({
-      content: [
-        { type: 'image', data: 'image-base64', mimeType: 'image/png' },
-        { type: 'text', text: 'window state' },
-      ],
-      structuredContent: { snapshot_id: 'snapshot-1', elements: [{ element_token: 'token-1' }] },
-    });
+    mockCallTool = (name) =>
+      name === 'check_permissions'
+        ? {
+            content: [{ type: 'text', text: 'Permissions granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          }
+        : {
+            content: [
+              { type: 'image', data: 'image-base64', mimeType: 'image/png' },
+              { type: 'text', text: 'window state' },
+            ],
+            structuredContent: {
+              snapshot_id: 'snapshot-1',
+              elements: [{ element_token: 'token-1' }],
+            },
+          };
     const controller = new AbortController();
 
     const result = (await tools
@@ -261,6 +559,9 @@ describe('computerUseExtension', () => {
       connects++;
     };
     await start();
+    await tools
+      .get('computer_use_click')!
+      .execute('id', { pid: 1, x: 2, y: 3 }, undefined, undefined, mockCtx);
     lastTransport?.onclose?.();
 
     await tools
@@ -268,6 +569,86 @@ describe('computerUseExtension', () => {
       .execute('id', { pid: 1, x: 2, y: 3 }, undefined, undefined, mockCtx);
 
     expect(connects).toBe(2);
+  });
+
+  it.each([
+    {
+      label: 'macOS ordinary tools',
+      config: undefined,
+      platform: 'darwin',
+      tool: 'computer_use_list_apps',
+      params: {},
+    },
+    {
+      label: 'macOS vision tools',
+      config: { visionModel: { provider: 'openai', model: 'gpt-4o' } },
+      platform: 'darwin',
+      tool: 'computer_use_analyze_screenshot',
+      params: { pid: 1, window_id: 2 },
+    },
+    {
+      label: 'Linux ordinary tools',
+      config: undefined,
+      platform: 'linux',
+      tool: 'computer_use_list_apps',
+      params: {},
+    },
+  ])('lets one caller cancel without aborting a shared $label reconnect', async (testCase) => {
+    let connects = 0;
+    mockConnect = async () => {
+      connects++;
+    };
+    mockCallTool = (name) =>
+      name === 'check_permissions'
+        ? {
+            content: [{ type: 'text', text: 'Permissions granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          }
+        : name === 'get_window_state'
+          ? {
+              content: [{ type: 'image', data: 'image-base64', mimeType: 'image/png' }],
+            }
+          : { content: [{ type: 'text', text: 'Action executed.' }] };
+    await start(testCase.config, testCase.platform);
+
+    const tool = tools.get(testCase.tool)!;
+    await tool.execute('warmup', testCase.params, undefined, undefined, mockCtx);
+
+    let disconnectBeforeCall = true;
+    const callToolSpy = vi
+      .spyOn(CuaDriverClient.prototype, 'callTool')
+      .mockImplementation(function (this: InstanceType<typeof CuaDriverClient>, ...args) {
+        if (disconnectBeforeCall) {
+          disconnectBeforeCall = false;
+          lastTransport?.onclose?.();
+        }
+        return originalCallTool.apply(this, args);
+      });
+    const reconnect = abortableDeferred<void>();
+    mockConnect = (signal) => {
+      connects++;
+      return reconnect.wait(signal);
+    };
+
+    const controller = new AbortController();
+    const cancelledCall = tool.execute(
+      'cancelled',
+      testCase.params,
+      controller.signal,
+      undefined,
+      mockCtx,
+    );
+    const activeCall = tool.execute('active', testCase.params, undefined, undefined, mockCtx);
+    await reconnect.started;
+    controller.abort(new Error('cancelled by user'));
+
+    await expect(cancelledCall).rejects.toThrow('cancelled by user');
+    expect(reconnect.aborted).toBe(false);
+    reconnect.resolve();
+    const activeResult = (await activeCall) as any;
+    expect(activeResult.isError).not.toBe(true);
+    expect(connects).toBe(2);
+    callToolSpy.mockRestore();
   });
 
   it('preserves AbortSignal cancellation instead of rewriting it as a connection error', async () => {
@@ -287,10 +668,16 @@ describe('computerUseExtension', () => {
 
   it('returns platform guidance for permission errors', async () => {
     await start();
-    mockCallTool = () => ({
-      content: [{ type: 'text', text: 'ax_not_granted: permission denied' }],
-      isError: true,
-    });
+    mockCallTool = (name) =>
+      name === 'check_permissions'
+        ? {
+            content: [{ type: 'text', text: 'Permissions granted.' }],
+            structuredContent: { accessibility: true, screen_recording: true },
+          }
+        : {
+            content: [{ type: 'text', text: 'ax_not_granted: permission denied' }],
+            isError: true,
+          };
 
     const result = (await tools
       .get('computer_use_click')!
@@ -348,6 +735,12 @@ describe('computerUseExtension', () => {
     let call: { name: string; args: Record<string, unknown> } | undefined;
     await start({ visionModel: { provider: 'openai', model: 'gpt-4o' } });
     mockCallTool = (name, args) => {
+      if (name === 'check_permissions') {
+        return {
+          content: [{ type: 'text', text: 'Permissions granted.' }],
+          structuredContent: { accessibility: true, screen_recording: true },
+        };
+      }
       call = { name, args };
       return { content: [{ type: 'image', data: 'image-base64', mimeType: 'image/png' }] };
     };
@@ -363,8 +756,32 @@ describe('computerUseExtension', () => {
     expect(result.content[0].text).toBe('vision analysis');
   });
 
-  it('closes the MCP client on session shutdown', async () => {
+  it('isolates daemon state and first connection across sessions', async () => {
+    let connects = 0;
+    mockConnect = async () => {
+      connects++;
+    };
+
     await start();
+    const firstTools = new Map(tools);
+    const firstShutdownHandlers = [...(handlers.session_shutdown ?? [])];
+    await start();
+
+    await Promise.all([
+      firstTools.get('computer_use_list_apps')!.execute('first', {}, undefined, undefined, mockCtx),
+      tools.get('computer_use_list_apps')!.execute('second', {}, undefined, undefined, mockCtx),
+    ]);
+
+    expect(connects).toBe(2);
+    for (const handler of firstShutdownHandlers) await handler({}, mockCtx);
+    expect(closeCount).toBe(1);
+    for (const handler of handlers.session_shutdown ?? []) await handler({}, mockCtx);
+    expect(closeCount).toBe(2);
+  });
+
+  it('closes the MCP client on session shutdown after it was used', async () => {
+    await start();
+    await tools.get('computer_use_list_apps')!.execute('id', {}, undefined, undefined, mockCtx);
     for (const handler of handlers.session_shutdown ?? []) await handler({}, mockCtx);
     expect(closeCount).toBeGreaterThan(0);
   });

--- a/packages/pi-computer-use/src/__tests__/index.test.ts
+++ b/packages/pi-computer-use/src/__tests__/index.test.ts
@@ -296,6 +296,39 @@ describe('computerUseExtension', () => {
     expect(result.isError).not.toBe(true);
   });
 
+  it('runs the requested tool when the macOS permission probe rejects', async () => {
+    let permissionChecks = 0;
+    let actionCalls = 0;
+    mockCallTool = async (name) => {
+      if (name === 'check_permissions') {
+        permissionChecks++;
+        throw new Error('permission dialog token=secret timed out');
+      }
+      actionCalls++;
+      return { content: [{ type: 'text', text: 'Action executed.' }] };
+    };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await start();
+
+    const listApps = tools.get('computer_use_list_apps')!;
+    const firstResult = (await listApps.execute('first', {}, undefined, undefined, mockCtx)) as any;
+    const secondResult = (await listApps.execute(
+      'second',
+      {},
+      undefined,
+      undefined,
+      mockCtx,
+    )) as any;
+
+    expect(firstResult.isError).not.toBe(true);
+    expect(secondResult.isError).not.toBe(true);
+    expect(permissionChecks).toBe(1);
+    expect(actionCalls).toBe(2);
+    const logged = errorSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logged).toContain('macOS permission probe failed');
+    expect(logged).not.toContain('token=secret');
+  });
+
   it('lets one caller cancel without aborting another caller first connection', async () => {
     const connection = abortableDeferred<void>();
     mockConnect = connection.wait;

--- a/packages/pi-computer-use/src/__tests__/manifest.test.ts
+++ b/packages/pi-computer-use/src/__tests__/manifest.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import toolManifest from '../generated/cua-driver-tools.js';
+
+function plistStringValue(plist: string, key: string): string | undefined {
+  return plist.match(new RegExp(`<key>${key}</key>\\s*<string>([^<]*)</string>`))?.[1];
+}
+
+describe('bundled tool manifest', () => {
+  it('matches the bundled macOS driver version metadata', () => {
+    const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+    const releaseTag = readFileSync(
+      resolve(packageDir, 'bin/darwin-universal/.version'),
+      'utf8',
+    ).split(/\r?\n/, 1)[0];
+    const infoPlist = readFileSync(
+      resolve(packageDir, 'bin/darwin-universal/CuaDriver.app/Contents/Info.plist'),
+      'utf8',
+    );
+
+    expect(releaseTag).toBe(`cua-driver-rs-v${toolManifest.driverVersion}`);
+    expect(plistStringValue(infoPlist, 'CFBundleShortVersionString')).toBe(
+      toolManifest.driverVersion,
+    );
+    expect(plistStringValue(infoPlist, 'CFBundleVersion')).toBe(toolManifest.driverVersion);
+  });
+});

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -88,13 +88,20 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
     if (!macPermissionPromise) {
       const permissionPromise = sessionClient
         .callTool('check_permissions', { prompt: true }, sessionSignal)
-        .then(() => undefined);
+        .then(
+          () => undefined,
+          () => {
+            if (!sessionSignal.aborted) {
+              console.error(
+                '[pi-computer-use] macOS permission probe failed; requested tool will continue',
+              );
+            }
+          },
+        );
       macPermissionPromise = permissionPromise;
-      void permissionPromise.catch(() => {
-        if (macPermissionPromise === permissionPromise) macPermissionPromise = undefined;
-      });
     }
     await waitForPromise(macPermissionPromise, signal);
+    sessionSignal.throwIfAborted();
   }
 
   async function confirmToolCall(
@@ -206,17 +213,6 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
     await ensureConnected(signal);
     const liveTools = await client!.listAllTools(signal);
     registerTools(liveTools);
-
-    if (process.platform === 'darwin') {
-      const pinnedNames = new Set(toolManifest.tools.map((tool) => tool.name));
-      const liveNames = new Set(liveTools.map((tool) => tool.name));
-      const drift = [...pinnedNames].filter((name) => !liveNames.has(name));
-      if (drift.length > 0) {
-        console.error(
-          `[pi-computer-use] bundled tool manifest drift: ${drift.length} pinned tools missing`,
-        );
-      }
-    }
 
     return liveTools.length;
   }

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-a
 import { Type } from 'typebox';
 import { type ComputerUseConfig, loadConfigFromFile, resolveConfig } from './config.js';
 import toolManifest from './generated/cua-driver-tools.js';
-import { CuaDriverClient } from './mcp-client.js';
+import { CuaDriverClient, waitForPromise } from './mcp-client.js';
 import { type McpToolResult, toPiToolResult } from './tool-result.js';
 import { createPiVisionCaller } from './vision.js';
 
@@ -28,10 +28,8 @@ const HIGH_RISK_TOOLS = new Set([
   'replay_trajectory',
 ]);
 
-const PLATFORM = process.platform;
-
 function permissionHint(): string {
-  switch (PLATFORM) {
+  switch (process.platform) {
     case 'darwin':
       return 'Check that Accessibility and Screen Recording permissions are granted in System Settings → Privacy & Security.';
     case 'win32':
@@ -42,7 +40,7 @@ function permissionHint(): string {
 }
 
 function accessibilityHint(): string {
-  switch (PLATFORM) {
+  switch (process.platform) {
     case 'darwin':
       return 'Accessibility permission not granted. The user needs to enable it in System Settings → Privacy & Security → Accessibility, then restart the app.';
     case 'win32':
@@ -53,7 +51,7 @@ function accessibilityHint(): string {
 }
 
 function screenRecordingHint(): string {
-  switch (PLATFORM) {
+  switch (process.platform) {
     case 'darwin':
       return 'Screen Recording permission not granted. The user needs to enable it in System Settings → Privacy & Security → Screen & System Audio Recording, then restart the app.';
     case 'win32':
@@ -66,11 +64,37 @@ function screenRecordingHint(): string {
 export default function computerUseExtension(pi: ExtensionAPI): void {
   let config: ComputerUseConfig | undefined;
   let client: CuaDriverClient | undefined;
+  let sessionAbortController: AbortController | undefined;
+  let macPermissionPromise: Promise<void> | undefined;
   const approvedAppTargets = new Set<string>();
 
-  async function ensureConnected(signal?: AbortSignal): Promise<void> {
-    if (!client) throw new Error('pi-computer-use: session not started');
-    await client.ensureReady(signal);
+  async function ensureConnected(
+    signal?: AbortSignal,
+    requestMacPermissions = true,
+  ): Promise<void> {
+    signal?.throwIfAborted();
+    if (!client) {
+      if (!config) throw new Error('pi-computer-use: session not started');
+      client = new CuaDriverClient(config);
+    }
+    const sessionClient = client;
+    const sessionSignal = sessionAbortController?.signal;
+    if (!sessionSignal) throw new Error('pi-computer-use: session not started');
+    sessionSignal.throwIfAborted();
+    await sessionClient.ensureReady(signal);
+    if (process.platform !== 'darwin' || !requestMacPermissions) return;
+
+    sessionSignal.throwIfAborted();
+    if (!macPermissionPromise) {
+      const permissionPromise = sessionClient
+        .callTool('check_permissions', { prompt: true }, sessionSignal)
+        .then(() => undefined);
+      macPermissionPromise = permissionPromise;
+      void permissionPromise.catch(() => {
+        if (macPermissionPromise === permissionPromise) macPermissionPromise = undefined;
+      });
+    }
+    await waitForPromise(macPermissionPromise, signal);
   }
 
   async function confirmToolCall(
@@ -142,7 +166,7 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
           }
 
           try {
-            await ensureConnected(signal);
+            await ensureConnected(signal, originalName !== 'check_permissions');
             const result = await client!.callTool(originalName, params, signal);
 
             if (result.isError) {
@@ -183,7 +207,7 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
     const liveTools = await client!.listAllTools(signal);
     registerTools(liveTools);
 
-    if (PLATFORM === 'darwin') {
+    if (process.platform === 'darwin') {
       const pinnedNames = new Set(toolManifest.tools.map((tool) => tool.name));
       const liveNames = new Set(liveTools.map((tool) => tool.name));
       const drift = [...pinnedNames].filter((name) => !liveNames.has(name));
@@ -378,8 +402,17 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
 
   pi.on('session_start', async (_event, ctx) => {
     config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
-    client = new CuaDriverClient(config);
+    client = undefined;
+    sessionAbortController = new AbortController();
+    macPermissionPromise = undefined;
     approvedAppTargets.clear();
+
+    if (process.platform === 'darwin') {
+      registerTools(toolManifest.tools);
+      registerVisionTool();
+      return;
+    }
+
     let connectedAtStartup = false;
     try {
       await discoverAndRegisterTools(ctx.signal);
@@ -398,7 +431,11 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
     if (!connectedAtStartup) return;
 
     try {
-      const permissions = await client.callTool('check_permissions', { prompt: false }, ctx.signal);
+      const permissions = await client!.callTool(
+        'check_permissions',
+        { prompt: false },
+        ctx.signal,
+      );
       const status = permissions.structuredContent;
       if (status?.accessibility === false || status?.screen_recording === false) {
         ctx.ui.notify(`pi-computer-use: ${permissionHint()}`, 'warning');
@@ -410,9 +447,16 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
   });
 
   pi.on('session_shutdown', async () => {
-    if (client) {
-      await client.close();
-    }
+    const closingClient = client;
+    const sessionAbort = sessionAbortController;
+    const pendingPermission = macPermissionPromise;
+    client = undefined;
+    config = undefined;
+    sessionAbortController = undefined;
+    macPermissionPromise = undefined;
+    approvedAppTargets.clear();
+    sessionAbort?.abort(new Error('pi-computer-use: session shut down'));
+    await Promise.allSettled([pendingPermission, closingClient?.close()]);
   });
 }
 

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -28,6 +28,25 @@ function abortError(signal?: AbortSignal): Error {
   return new Error('Cua Driver operation aborted.');
 }
 
+export async function waitForPromise<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) throw abortError(signal);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+    void promise.then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
 function delay(milliseconds: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
@@ -109,6 +128,7 @@ export class CuaDriverClient {
   private activeLayout: DriverLayout | null = null;
   private state: ConnectionState = 'disconnected';
   private connectPromise: Promise<void> | null = null;
+  private readonly lifecycleController = new AbortController();
   private generation = 0;
   private hasConnected = false;
   private explicitlyClosed = false;
@@ -120,16 +140,17 @@ export class CuaDriverClient {
   }
 
   async connect(signal?: AbortSignal): Promise<void> {
+    if (this.explicitlyClosed) throw new Error('Cua Driver client is closed.');
     if (this.state === 'ready') return;
-    if (this.connectPromise) return this.connectPromise;
-
-    this.explicitlyClosed = false;
-    this.connectPromise = this.openConnection(signal);
-    try {
-      await this.connectPromise;
-    } finally {
-      this.connectPromise = null;
+    if (!this.connectPromise) {
+      const connection = this.openConnection(this.lifecycleController.signal);
+      this.connectPromise = connection;
+      const clearConnection = () => {
+        if (this.connectPromise === connection) this.connectPromise = null;
+      };
+      void connection.then(clearConnection, clearConnection);
     }
+    await waitForPromise(this.connectPromise, signal);
   }
 
   private async openConnection(signal?: AbortSignal): Promise<void> {
@@ -421,6 +442,9 @@ export class CuaDriverClient {
     if (this.explicitlyClosed) return;
     this.explicitlyClosed = true;
     this.state = 'closing';
+    const connection = this.connectPromise;
+    this.lifecycleController.abort(new Error('Cua Driver client is closing.'));
+    if (connection) await Promise.allSettled([connection]);
     const client = this.client;
     ++this.generation;
     this.client = null;

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -285,14 +285,29 @@ If a custom provider has no `models` list, you can still address it with `<provi
 image_generate({
   prompt: string,                  // required — what to draw or how to edit
   image?: string[],                // optional — array of file paths or http(s) URLs
-  n?: number,                      // 1–8, default 1
+  n?: number,                      // 1–8, default 1 (variants of ONE prompt)
   size?: string,                   // e.g. "1024x1024" — provider-specific
+  quality?: 'low'|'medium'|'high'|'auto', // present only for a built-in gpt-image route (see below)
   filename?: string,               // filename prefix (no extension)
   outputDir?: string,              // override settings.outputDir for this call
 })
 ```
 
 Returns the absolute file path(s) of saved images. Files land in `outputDir` (default `<cwd>/.pi/images`), filename pattern `<filename or model-UTC-stamp>.<ext>`.
+
+**The schema is provider-aware.** The tool is registered once settings are loaded (on session start, and again after `/image-gen reload`), so its parameters are shaped for the active model:
+
+- `quality` appears **only** for a **built-in gpt-image** route — the built-in OpenAI provider on `gpt-image-*`, or an OpenRouter route whose model id is gpt-image (e.g. `openrouter/openai/gpt-image-2`). Only there is it constrained to the enum `low`/`medium`/`high`/`auto` (the vocabulary those APIs document). It is **omitted from the schema entirely** for:
+  - Gemini, DashScope/Qwen, and Ark/Seedream — their image APIs have no `quality` field (Seedream varies quality by `size` resolution tier instead);
+  - **non-gpt-image routes** on the OpenAI/OpenRouter wire — e.g. built-in `openai/dall-e-3` (which uses `standard`/`hd`) or an OpenRouter route to a non-OpenAI model like Seedream — because the enum above is gpt-image's vocabulary, not the wire format's; and
+  - **any custom provider**, including OpenAI-*compatible* ones — a self-hosted or third-party model may use a different quality vocabulary (e.g. DALL·E 3's `standard`/`hd`) or none at all, so the OpenAI wire format alone does **not** imply the four values above. Passing an unsupported value would only surface as a provider-side 400.
+
+  If `defaultModel` is unset or misconfigured, `quality` stays present (the tool remains fully featured and `execute` surfaces a friendly config error). Use `"low"` for fast drafts and a higher level for final assets or dense text.
+- `size`'s description is tailored per provider — for Ark/Seedream it spells out the 2K-minimum requirement instead of the generic `1024x1024` hint.
+
+Because the schema is fixed at registration, switching models via `/image-gen reload` re-registers the tool so the parameter set tracks the new provider.
+
+**Non-destructive writes:** a saved file never overwrites an existing one. Two calls with `filename: "hero"` produce `hero.png` then `hero-v2.png`, so an earlier result is preserved rather than clobbered. Path reservation is atomic (`O_EXCL`): even many concurrent calls with the same `filename` each claim a distinct path — no two clobber each other.
 
 ### Tool result format
 
@@ -344,6 +359,11 @@ There is intentionally no `model` parameter on the tool — the active model is 
 ## Slash commands
 
 - `/image-gen list` — show the active model, which provider it routes to, whether the key is set, configured providers, and the catalog of built-in model ids.
-- `/image-gen reload` — re-read settings from disk.
+- `/image-gen reload` — re-read settings from disk and re-register the tool so its schema (e.g. whether `quality` is exposed) tracks the newly selected model.
+- `/image-gen generate <prompt>` — generate an image directly from the command line using the active model. Reports the saved file path(s) as a plain-text notification (the command uses `ctx.ui.notify`, which shows a status line, not rendered Markdown — so unlike the tool result it does not emit an inline `![](…)` image). Use the `image_generate` tool from the agent when you want the image rendered inline.
 
 Use `/image-gen list` to verify your config — it will tell you when `defaultModel` is unset, points at a provider with no API key, or names an unknown id.
+
+## Bundled skill
+
+This package ships an `image-gen` skill (`skills/image-gen/SKILL.md`) that Pi loads on demand. It carries the prompting playbook the one-line tool guidance can't hold: when to use raster generation vs repo-native SVG/CSS, generate-vs-edit intent, `n`-is-variants-not-assets, multi-image role labeling, edit invariants, text-in-image handling, and the labeled prompt schema. The tool works without it; the skill makes the model use the tool well.

--- a/packages/pi-image-gen/package.json
+++ b/packages/pi-image-gen/package.json
@@ -28,6 +28,7 @@
   },
   "files": [
     "dist",
+    "skills",
     "preview.png",
     "README.md"
   ],
@@ -35,6 +36,9 @@
     "image": "https://raw.githubusercontent.com/TGYD-helige/pi/master/packages/pi-image-gen/preview.png",
     "extensions": [
       "./dist/index.js"
+    ],
+    "skills": [
+      "./skills"
     ]
   },
   "publishConfig": {
@@ -54,10 +58,14 @@
     "@amaster.ai/pi-shared": "workspace:*"
   },
   "peerDependencies": {
+    "@earendil-works/pi-ai": ">=0.80.10",
     "@earendil-works/pi-coding-agent": ">=0.74.0",
     "typebox": "*"
   },
   "peerDependenciesMeta": {
+    "@earendil-works/pi-ai": {
+      "optional": true
+    },
     "@earendil-works/pi-coding-agent": {
       "optional": true
     },
@@ -66,6 +74,7 @@
     }
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "0.80.10",
     "@earendil-works/pi-coding-agent": "0.80.10",
     "typebox": "*",
     "vitest": "^4.0.0"

--- a/packages/pi-image-gen/skills/image-gen/SKILL.md
+++ b/packages/pi-image-gen/skills/image-gen/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: image-gen
+description: "Generate or edit raster images with the image_generate tool: photos, illustrations, textures, sprites, product/UI mockups, concept art, or image-to-image edits. Use when the deliverable is a bitmap asset. Do NOT use for icons, logos, diagrams, or UI graphics that should be repo-native SVG/vector/CSS/canvas — edit or write those directly."
+---
+
+# Image generation
+
+This skill guides use of the `image_generate` tool from `@amaster.ai/pi-image-gen`.
+The active model is fixed by `pi-image-gen.defaultModel` in settings — the tool has
+**no `model` parameter**. Run `/image-gen list` to see the active model, its provider,
+and whether its API key is set.
+
+## When to use
+
+- A brand-new bitmap image: concept art, product shot, cover, website hero, texture, sprite.
+- A new image guided by one or more reference images (style, composition, mood, subject).
+- Editing an existing image: inpainting, background replacement, object removal, lighting
+  or weather changes, compositing, style transfer, character preservation.
+- Several assets or variants for one task.
+
+## When NOT to use
+
+- Extending or matching an existing SVG/vector icon set, logo system, or illustration
+  library in the repo — edit those source files directly.
+- Simple shapes, diagrams, wireframes, or icons better produced in SVG, HTML/CSS, or canvas.
+- A small project-local asset edit when the source already exists in an editable native format.
+- Any task where the user clearly wants deterministic code-native output, not a generated bitmap.
+
+## Two questions before every call
+
+1. **Intent — generate or edit?**
+   - No `image`, or `image` entries used only as style/composition/mood references → **generate**.
+   - Modify an existing image while preserving most of it → **edit** (pass that image).
+   - When unsure, assume the user wants a new image unless they clearly ask to change an existing one.
+2. **Strategy — one asset or many?**
+   - `n` produces **variants of ONE prompt**, not distinct assets.
+   - For several *different* assets, make **one `image_generate` call per asset**, each with
+     its own prompt. Do not raise `n` to cover distinct subjects.
+
+## Prompt structure
+
+Order the prompt as: **scene/backdrop → subject → key details → constraints → intended use.**
+For complex requests, use short labeled lines instead of one long paragraph:
+
+```text
+Use case: <e.g. product-mockup, ui-mockup, illustration, photorealistic, concept-art>
+Asset type: <where the asset will be used>
+Primary request: <the main ask>
+Input images: <Image 1: role; Image 2: role>   (only when passing `image`)
+Scene/backdrop: <environment>
+Subject: <main subject>
+Style/medium: <photo / illustration / 3D / etc.>
+Composition/framing: <wide / close / top-down; placement; negative space if needed>
+Lighting/mood: <lighting + mood>
+Color palette: <palette notes>
+Text (verbatim): "<exact text>"
+Constraints: <must keep / must avoid>
+```
+
+## Specificity policy
+
+- If the user's prompt is already **specific and detailed**, normalize it into a clean spec —
+  do not add creative requirements it didn't ask for.
+- If the prompt is **generic**, add tasteful detail only when it materially improves output.
+
+Allowed augmentation: composition/framing cues, polish-level or intended-use hints, practical
+layout guidance, reasonable scene concreteness.
+Do **not** add: extra characters/props not implied, brand palettes/slogans/story beats not
+implied, or arbitrary left/right placement the layout doesn't support.
+
+## Text inside images
+
+- Put literal text in quotes or ALL CAPS; specify typography (style, size, color, placement).
+- Spell uncommon words letter-by-letter when accuracy matters; require verbatim rendering.
+- Where the model exposes a quality knob, use a higher `quality` for small text, dense
+  infographics, legends, axes, and multi-font layouts.
+
+## Editing and multi-image conditioning
+
+- Label every input image by index and role: `Image 1: edit target`, `Image 2: style reference`.
+  Do not assume every provided image is an edit target.
+- For edits, state invariants explicitly — `change only X; keep Y unchanged` — and **repeat them
+  on every iteration** to reduce drift.
+- For compositing, describe how images interact: `place the subject from Image 2 into Image 1;
+  match lighting, perspective, and scale`.
+- To iterate on a previous result, pass its saved file path back as `image`.
+- Reference images must be a **file path** (absolute or relative to cwd) or an **http(s) URL**.
+  Base64 and `data:` URIs are rejected — write bytes to a file first.
+
+## Iterate deliberately
+
+Start from a clean base prompt, then make **one targeted change at a time** and re-check
+subject, style, composition, text accuracy, and invariants. Prefer a single focused follow-up
+over rewriting the whole prompt.
+
+## Parameters
+
+- `prompt` (required) — what to draw or how to edit.
+- `image` — array of reference/target image paths or URLs.
+- `n` — 1–8 variants of the one prompt (default 1).
+- `size` — e.g. `"1024x1024"`. Provider-specific; some models require a minimum (Seedream ≥ 4.5
+  needs 2K+, so `1024x1024` fails there).
+- `quality` — one of `"low"` / `"medium"` / `"high"` / `"auto"` (`"low"` for fast drafts/thumbnails,
+  `"high"` for final assets or dense text). This parameter is **provider-conditional**: it only
+  exists in the tool schema for a built-in gpt-image route — the built-in OpenAI provider on a
+  `gpt-image-*` model, or an OpenRouter route whose model id is gpt-image (e.g.
+  `openrouter/openai/gpt-image-2`). It is absent for Gemini, DashScope/Qwen, Ark/Seedream (Seedream
+  varies quality by `size` resolution tier instead), for non-gpt-image routes like `openai/dall-e-3`
+  or an OpenRouter route to a non-OpenAI model, and for any custom provider — even OpenAI-compatible
+  ones, since their quality vocabulary may differ (e.g. DALL·E 3 uses `standard`/`hd`). If you don't
+  see a `quality` parameter, the active provider has no such knob; do not try to force it.
+- `filename` — output filename prefix (no extension). Reusing a name does not overwrite an
+  earlier file — a sibling `-v2` is written instead.
+- `outputDir` — override the configured output dir for this call.
+
+## Reporting results
+
+The tool result already contains a copy-pasteable markdown line per image
+(`![alt](/abs/path.png)`). Render each generated image inline in your reply so the UI can
+display it — do not paste the bare path. Always report the final saved path(s).

--- a/packages/pi-image-gen/src/__tests__/ark.test.ts
+++ b/packages/pi-image-gen/src/__tests__/ark.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { resolveModel } from '../config.js';
 import { generateImage } from '../generate.js';
 
@@ -18,8 +18,12 @@ function fakeJsonResponse(payload: unknown): Response {
 }
 
 describe('ark provider (Volcengine Seedream)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('routes seedream alias to the latest 5.0 model', () => {
-    process.env.ARK_API_KEY = 'ark-test';
+    vi.stubEnv('ARK_API_KEY', 'ark-test');
     const result = resolveModel('seedream', {});
     if ('error' in result) throw new Error(result.error);
     expect(result.provider.id).toBe('ark');
@@ -30,14 +34,14 @@ describe('ark provider (Volcengine Seedream)', () => {
   });
 
   it('routes seedream-4 alias to the 4.0 model', () => {
-    process.env.ARK_API_KEY = 'ark-test';
+    vi.stubEnv('ARK_API_KEY', 'ark-test');
     const result = resolveModel('seedream-4', {});
     if ('error' in result) throw new Error(result.error);
     expect(result.remoteId).toBe('doubao-seedream-4-0-250828');
   });
 
   it('routes seedream-5-pro alias to the 5.0 pro model', () => {
-    process.env.ARK_API_KEY = 'ark-test';
+    vi.stubEnv('ARK_API_KEY', 'ark-test');
     const result = resolveModel('seedream-5-pro', {});
     if ('error' in result) throw new Error(result.error);
     expect(result.provider.id).toBe('ark');
@@ -46,7 +50,7 @@ describe('ark provider (Volcengine Seedream)', () => {
 
   it('text-to-image posts to /images/generations with prompt/n/size as JSON', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-ark-'));
-    process.env.ARK_API_KEY = 'ark-test';
+    vi.stubEnv('ARK_API_KEY', 'ark-test');
 
     const calls: Array<{ url: string; method: string; body: Record<string, unknown> }> = [];
     const fetchImpl: typeof fetch = (async (input, init) => {
@@ -62,7 +66,8 @@ describe('ark provider (Volcengine Seedream)', () => {
     }) as typeof fetch;
 
     const result = await generateImage(
-      { prompt: '一只猫', size: '1024x1024', filename: 'cat' },
+      // `quality` is passed but Seedream has no such knob — assert it's dropped.
+      { prompt: '一只猫', size: '1024x1024', quality: 'high', filename: 'cat' },
       {
         cwd,
         settings: { defaultModel: 'seedream' },
@@ -81,6 +86,7 @@ describe('ark provider (Volcengine Seedream)', () => {
       size: '1024x1024',
     });
     expect(calls[0]?.body.image).toBeUndefined();
+    expect(calls[0]?.body.quality).toBeUndefined();
     expect(result.provider).toBe('ark');
     expect(result.images).toHaveLength(1);
     expect(readFileSync(result.images[0]!.path)).toEqual(PNG_BYTES);
@@ -88,7 +94,7 @@ describe('ark provider (Volcengine Seedream)', () => {
 
   it('image-to-image inlines reference images as data URIs in the JSON body', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-ark-i2i-'));
-    process.env.ARK_API_KEY = 'ark-test';
+    vi.stubEnv('ARK_API_KEY', 'ark-test');
 
     const refPath = join(cwd, 'ref.png');
     writeFileSync(refPath, PNG_BYTES);
@@ -132,7 +138,7 @@ describe('ark provider (Volcengine Seedream)', () => {
 
   it('reports a helpful error when ARK_API_KEY is not set', async () => {
     const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-ark-nokey-'));
-    delete process.env.ARK_API_KEY;
+    vi.stubEnv('ARK_API_KEY', undefined);
     await expect(
       generateImage(
         { prompt: 'x' },

--- a/packages/pi-image-gen/src/__tests__/errors.test.ts
+++ b/packages/pi-image-gen/src/__tests__/errors.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { classifyHttpError, describeNetworkError } from '../errors.js';
+import {
+  cancelledError,
+  classifyHttpError,
+  describeDownloadError,
+  describeNetworkError,
+  describeWriteError,
+  errorMessageForUser,
+  ImageGenError,
+  missingKeyError,
+  readBodyText,
+  redactUrl,
+  throwHttpError,
+  toLogSummary,
+} from '../errors.js';
 import type { ResolvedProvider } from '../types.js';
 
 const builtIn: ResolvedProvider = {
@@ -24,47 +37,363 @@ function fakeRes(status: number): Response {
   return new Response('', { status });
 }
 
+// A prompt / secret echoed back in a response body — the thing that must reach
+// NEITHER the user/LLM-facing message NOR the log summary.
+const PROMPT_ECHO = 'prompt was: a photo of a user secret 42';
+
 describe('classifyHttpError', () => {
   it('401 → key locator for built-in points at the env var', () => {
-    const msg = classifyHttpError(fakeRes(401), 'unauthorized', builtIn);
-    expect(msg).toMatch(/OPENAI_API_KEY/);
-    expect(msg).toMatch(/Do not retry/);
+    const { message } = classifyHttpError(fakeRes(401), builtIn);
+    expect(message).toMatch(/OPENAI_API_KEY/);
+    expect(message).toMatch(/Do not retry/);
   });
 
   it('401 → key locator for custom points at customProviders settings path', () => {
-    const msg = classifyHttpError(fakeRes(401), 'unauthorized', custom);
-    expect(msg).toMatch(/customProviders\.amaster\.apiKey/);
+    const { message } = classifyHttpError(fakeRes(401), custom);
+    expect(message).toMatch(/customProviders\.amaster\.apiKey/);
   });
 
   it('429 mentions rate limiting', () => {
-    const msg = classifyHttpError(fakeRes(429), '', builtIn);
-    expect(msg).toMatch(/rate-limited/i);
+    const { message } = classifyHttpError(fakeRes(429), builtIn);
+    expect(message).toMatch(/rate-limited/i);
   });
 
   it('5xx flagged as transient', () => {
-    const msg = classifyHttpError(fakeRes(503), '', builtIn);
-    expect(msg).toMatch(/transient/);
+    const { message } = classifyHttpError(fakeRes(503), builtIn);
+    expect(message).toMatch(/transient/);
   });
 
   it('400 hints at parameter / model id mismatch', () => {
-    const msg = classifyHttpError(fakeRes(400), '', builtIn);
-    expect(msg).toMatch(/bad parameter|unsupported model/i);
+    const { message } = classifyHttpError(fakeRes(400), builtIn);
+    expect(message).toMatch(/bad parameter|unsupported model/i);
+  });
+
+  it('never carries a response body — not in the message, not in the summary', () => {
+    // The body is not even passed in anymore; classification is status-only. Both
+    // surfaces stay body-free so no prompt/credential/tenant data can leak.
+    const err = classifyHttpError(fakeRes(400), builtIn);
+    expect(err.message).not.toContain(PROMPT_ECHO);
+    expect(err.message).not.toMatch(/Body:|Raw:/);
+    expect(err.logSummary).not.toContain(PROMPT_ECHO);
+    expect(err.logSummary).toContain('OpenAI');
+    expect(err.logSummary).toContain('400');
+    expect(err.logSummary).toMatch(/bad-request/);
+  });
+
+  it('never logs a custom provider display name', () => {
+    const untrusted = { ...custom, name: 'secret=abc\nFORGED' };
+    for (const err of [
+      classifyHttpError(fakeRes(400), untrusted),
+      describeNetworkError(new Error('ETIMEDOUT'), untrusted),
+      missingKeyError(untrusted),
+    ]) {
+      expect(err.logSummary).not.toContain('secret=abc');
+      expect(err.logSummary).not.toContain('FORGED');
+      expect(err.logSummary).toContain('Custom provider');
+    }
+  });
+
+  it('cancels an unread HTTP error body before throwing the classified error', async () => {
+    let cancelled = false;
+    const body = new ReadableStream({
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const res = new Response(body, { status: 400 });
+
+    await expect(throwHttpError(res, builtIn)).rejects.toMatchObject({
+      logSummary: 'OpenAI HTTP 400 (bad-request)',
+    });
+    expect(cancelled).toBe(true);
   });
 });
 
 describe('describeNetworkError', () => {
   it('classifies timeout', () => {
-    const msg = describeNetworkError(new Error('connect ETIMEDOUT'), builtIn);
-    expect(msg).toMatch(/timed out/i);
+    const { message } = describeNetworkError(new Error('connect ETIMEDOUT'), builtIn);
+    expect(message).toMatch(/timed out/i);
   });
 
   it('classifies DNS failure', () => {
-    const msg = describeNetworkError(new Error('getaddrinfo ENOTFOUND foo'), builtIn);
-    expect(msg).toMatch(/Cannot reach/);
+    const { message } = describeNetworkError(new Error('getaddrinfo ENOTFOUND foo'), builtIn);
+    expect(message).toMatch(/Cannot reach/);
   });
 
-  it('classifies abort', () => {
-    const msg = describeNetworkError(new DOMException('aborted', 'AbortError'), builtIn);
-    expect(msg).toMatch(/cancelled/i);
+  it('classifies AbortError by its structured name, not message wording', () => {
+    const { message } = describeNetworkError(new DOMException('stop now', 'AbortError'), builtIn);
+    expect(message).toMatch(/cancelled/i);
+  });
+
+  it('does not mistake "abort" inside a DNS error message for cancellation', () => {
+    const err = describeNetworkError(new Error('getaddrinfo ENOTFOUND abort.example.com'), builtIn);
+    expect(err.message).toMatch(/Cannot reach/);
+    expect(err.logSummary).toBe('OpenAI request failed (unreachable)');
+  });
+
+  it('never echoes the underlying error text into message or summary', () => {
+    // The raw error can carry the request URL (with a signed ?token=…) or other
+    // internals; it must only CLASSIFY the failure, never be reproduced.
+    const err = describeNetworkError(new Error(`fetch failed: ${PROMPT_ECHO}`), builtIn);
+    expect(err.message).not.toContain(PROMPT_ECHO);
+    expect(err.logSummary).not.toContain(PROMPT_ECHO);
+    expect(err.logSummary).toContain('OpenAI');
+    expect(err.logSummary).toMatch(/network-error/);
+  });
+});
+
+describe('readBodyText', () => {
+  it('returns the body text on a healthy response', async () => {
+    await expect(readBodyText(new Response('{"ok":true}'), builtIn)).resolves.toBe('{"ok":true}');
+  });
+
+  // Read the body, expecting it to reject, and hand back the thrown ImageGenError.
+  const captureReadError = async (res: Response): Promise<ImageGenError> => {
+    try {
+      await readBodyText(res, builtIn);
+    } catch (error) {
+      return error as ImageGenError;
+    }
+    throw new Error('expected readBodyText to reject');
+  };
+
+  it('classifies a body that breaks mid-stream and never echoes its text', async () => {
+    // Headers arrived OK but the body read rejects (broken/cancelled stream). The
+    // raw rejection can carry internals — it must CLASSIFY, not reproduce. A plain
+    // Error here would otherwise be swallowed downstream and misreported as JSON.
+    const res = {
+      async text() {
+        throw new Error(`stream failed: ${PROMPT_ECHO} ECONNRESET`);
+      },
+    } as unknown as Response;
+    const err = await captureReadError(res);
+    expect(err).toBeInstanceOf(ImageGenError);
+    expect(err.logSummary).toBe('OpenAI request failed (unreachable)');
+    expect(err.message).not.toContain(PROMPT_ECHO);
+    expect(err.logSummary).not.toContain(PROMPT_ECHO);
+  });
+
+  it('classifies a cancelled body read as cancelled', async () => {
+    const res = {
+      async text() {
+        throw new DOMException('aborted', 'AbortError');
+      },
+    } as unknown as Response;
+    const err = await captureReadError(res);
+    expect(err).toBeInstanceOf(ImageGenError);
+    expect(err.logSummary).toBe('OpenAI request failed (cancelled)');
+    expect(err.message).toMatch(/cancelled/i);
+  });
+});
+
+describe('redactUrl', () => {
+  it('drops the query string (signed token) but keeps scheme/host/path', () => {
+    expect(redactUrl('https://cdn.example.com/img/abc.png?X-Amz-Signature=SECRET&token=USER')).toBe(
+      'https://cdn.example.com/img/abc.png',
+    );
+  });
+
+  it('drops userinfo credentials embedded in the authority', () => {
+    expect(redactUrl('https://user:pass@host.example/path')).toBe('https://host.example/path');
+  });
+
+  it('collapses an unparseable value to <url>', () => {
+    expect(redactUrl('not a url at all')).toBe('<url>');
+  });
+});
+
+// A resolved absolute path + system errno string, and a signed URL — the kinds
+// of payload a raw fs/fetch Error carries that must reach NEITHER sink.
+const FS_LEAK = "ENOENT: no such file or directory, open '/Users/alice/secret/photo.png'";
+const SIGNED_URL_LEAK = 'https://cdn.example.com/img.png?X-Amz-Signature=SECRET&token=USER';
+
+describe('describeDownloadError', () => {
+  it('redacts the signed query on an HTTP failure and stays body-free', () => {
+    const err = describeDownloadError('generated image', SIGNED_URL_LEAK, { httpStatus: 403 });
+    expect(err).toBeInstanceOf(ImageGenError);
+    for (const surface of [err.message, err.logSummary]) {
+      expect(surface).not.toContain('X-Amz-Signature');
+      expect(surface).not.toContain('SECRET');
+      expect(surface).not.toContain('token=');
+    }
+    expect(err.message).toContain('https://cdn.example.com/img.png');
+    expect(err.message).toContain('403');
+    expect(err.logSummary).toBe('generated image download failed (HTTP 403)');
+  });
+
+  it('never reproduces a fetch rejection that embeds the signed URL', () => {
+    // The raw rejection reproduces the full URL; the error must classify it, not
+    // echo it — neither surface may carry the query credential.
+    const err = describeDownloadError('image input', SIGNED_URL_LEAK, {
+      rejected: new Error(`request to ${SIGNED_URL_LEAK} failed, reason: ECONNREFUSED`),
+    });
+    for (const surface of [err.message, err.logSummary]) {
+      expect(surface).not.toContain('X-Amz-Signature');
+      expect(surface).not.toContain('SECRET');
+      expect(surface).not.toContain('token=');
+    }
+    expect(err.logSummary).toBe('image input download failed (unreachable)');
+  });
+
+  it('classifies an aborted download as cancelled', () => {
+    const err = describeDownloadError('generated image', SIGNED_URL_LEAK, {
+      rejected: new DOMException('stop now', 'AbortError'),
+    });
+    expect(err.message).toMatch(/cancelled/i);
+    expect(err.logSummary).toBe('generated image download failed (cancelled)');
+  });
+});
+
+describe('toLogSummary', () => {
+  it('returns the curated summary for an ImageGenError', () => {
+    const err = new ImageGenError(
+      'rich message with body: secret',
+      'OpenAI HTTP 500 (server-error)',
+    );
+    expect(toLogSummary(err)).toBe('OpenAI HTTP 500 (server-error)');
+  });
+
+  it('keeps a crafted ImageGenError summary on one log line', () => {
+    const err = new ImageGenError('safe user message', 'Gateway\nFORGED secret=abc');
+    const summary = toLogSummary(err);
+    expect(summary).toBe('Gateway');
+    expect(summary).not.toContain('\n');
+    expect(summary).not.toContain('secret=abc');
+  });
+
+  it('never echoes a plain Error message (may carry a path/errno) — fixed label only', () => {
+    // Safe-by-default: a non-ImageGenError is untrusted. We emit a constant
+    // string and read no bytes off the value (which here embeds a path).
+    const summary = toLogSummary(new Error(FS_LEAK));
+    expect(summary).toBe('unexpected error');
+    expect(summary).not.toContain('/Users/alice');
+    expect(summary).not.toContain('ENOENT');
+  });
+
+  it('does not trust a writable Error.name — a crafted name cannot leak or inject', () => {
+    // `Error.name` is writable, so a caller (or a library) can set it to a
+    // secret or a log-injection payload. We never read `name` at all, so anything
+    // it holds — a token, a newline — cannot reach the log line.
+    const secret = new Error('boom');
+    secret.name = 'token=USER_SECRET';
+    expect(toLogSummary(secret)).toBe('unexpected error');
+
+    const injected = new Error('boom');
+    injected.name = 'Error\n[pi-image-gen] FORGED LOG LINE';
+    const summary = toLogSummary(injected);
+    expect(summary).toBe('unexpected error');
+    expect(summary).not.toContain('USER_SECRET');
+    expect(summary).not.toContain('\n');
+  });
+
+  it('collapses every Error subclass to the same fixed label (no class name read)', () => {
+    // The class name is not surfaced either — even a standard subclass yields the
+    // constant string, so the boundary never depends on a readable, spoofable field.
+    expect(toLogSummary(new TypeError('x is not a function'))).toBe('unexpected error');
+    expect(toLogSummary(new RangeError('out of range'))).toBe('unexpected error');
+  });
+
+  it('never echoes a non-Error throw', () => {
+    const summary = toLogSummary(SIGNED_URL_LEAK);
+    expect(summary).toBe('unexpected non-error throw');
+    expect(summary).not.toContain('token=');
+  });
+});
+
+describe('errorMessageForUser', () => {
+  it('surfaces the vetted message for an ImageGenError', () => {
+    const err = new ImageGenError('defaultModel is not set. Configure it.', 'defaultModel not set');
+    expect(errorMessageForUser(err)).toBe('defaultModel is not set. Configure it.');
+  });
+
+  it('never echoes a plain Error message (path/errno) to the user', () => {
+    const msg = errorMessageForUser(new Error(FS_LEAK));
+    expect(msg).not.toContain('/Users/alice');
+    expect(msg).not.toContain('ENOENT');
+    expect(msg).toMatch(/failed unexpectedly/i);
+  });
+
+  it('never echoes a non-Error throw to the user', () => {
+    const msg = errorMessageForUser(SIGNED_URL_LEAK);
+    expect(msg).not.toContain('token=');
+    expect(msg).toMatch(/failed unexpectedly/i);
+  });
+});
+
+describe('describeWriteError', () => {
+  const fsError = (code: string, message: string): NodeJS.ErrnoException => {
+    const e = new Error(message) as NodeJS.ErrnoException;
+    e.code = code;
+    return e;
+  };
+
+  it('classifies EACCES/ENOSPC/ENOENT into a path-free, actionable hint', () => {
+    const denied = describeWriteError(
+      'write the image file',
+      fsError('EACCES', "EACCES: permission denied, open '/root/secret/out.png'"),
+    );
+    expect(denied.message).toMatch(/permission was denied/);
+    expect(denied.message).toMatch(/output directory/);
+    expect(denied.message).not.toContain('/root/secret');
+    expect(denied.logSummary).toBe('write the image file failed (EACCES)');
+
+    expect(
+      describeWriteError('create the output directory', fsError('ENOSPC', 'x')).message,
+    ).toMatch(/disk is full/);
+    expect(
+      describeWriteError('create the output directory', fsError('ENOTDIR', 'x')).message,
+    ).toMatch(/path is invalid/);
+  });
+
+  it('never trusts a bogus .code (only errno-shaped codes reach the summary)', () => {
+    // A crafted `.code` must not smuggle bytes into the log summary.
+    const bogus = new Error('boom') as NodeJS.ErrnoException;
+    bogus.code = 'token=SECRET' as string;
+    const err = describeWriteError('write the image file', bogus);
+    expect(err.logSummary).toBe('write the image file failed (fs-error)');
+    expect(err.logSummary).not.toContain('SECRET');
+    expect(err.message).toMatch(/filesystem error/);
+  });
+});
+
+describe('cancelledError', () => {
+  it('is a body-free ImageGenError naming the operation', () => {
+    const err = cancelledError('image generation');
+    expect(err).toBeInstanceOf(ImageGenError);
+    expect(err.message).toBe('image generation was cancelled.');
+    expect(err.logSummary).toBe('image generation cancelled');
+  });
+});
+
+describe('missingKeyError', () => {
+  it('names the correct env var per provider — OpenRouter is not told to set OPENAI_API_KEY', () => {
+    const openrouter: ResolvedProvider = {
+      id: 'openrouter',
+      api: 'openrouter',
+      baseUrl: 'https://openrouter.ai/api/v1',
+      name: 'OpenRouter',
+      builtIn: true,
+    };
+    const err = missingKeyError(openrouter);
+    expect(err.message).toMatch(/OPENROUTER_API_KEY/);
+    expect(err.message).not.toMatch(/OPENAI_API_KEY/);
+    expect(err.logSummary).toBe('OpenRouter missing API key');
+  });
+
+  it('names ARK_API_KEY for the built-in ark provider', () => {
+    const ark: ResolvedProvider = {
+      id: 'ark',
+      api: 'ark',
+      baseUrl: 'https://ark.cn-beijing.volces.com',
+      name: 'Ark',
+      builtIn: true,
+    };
+    expect(missingKeyError(ark).message).toMatch(/ARK_API_KEY/);
+  });
+
+  it('points a custom provider at its settings path, not an env var', () => {
+    const err = missingKeyError(custom);
+    expect(err.message).toMatch(/customProviders\.amaster\.apiKey/);
+    expect(err.message).not.toMatch(/_API_KEY/);
   });
 });

--- a/packages/pi-image-gen/src/__tests__/errors.test.ts
+++ b/packages/pi-image-gen/src/__tests__/errors.test.ts
@@ -140,6 +140,11 @@ describe('describeNetworkError', () => {
     expect(err.logSummary).toContain('OpenAI');
     expect(err.logSummary).toMatch(/network-error/);
   });
+
+  it('describes an unclassified network failure without doubled error wording', () => {
+    const { message } = describeNetworkError(new Error('socket failed'), builtIn);
+    expect(message).toBe('OpenAI request failed because of a network error.');
+  });
 });
 
 describe('readBodyText', () => {
@@ -311,6 +316,8 @@ describe('errorMessageForUser', () => {
     expect(msg).not.toContain('/Users/alice');
     expect(msg).not.toContain('ENOENT');
     expect(msg).toMatch(/failed unexpectedly/i);
+    expect(msg).toMatch(/report.*pi-image-gen bug/i);
+    expect(msg).not.toMatch(/logs|stderr/i);
   });
 
   it('never echoes a non-Error throw to the user', () => {

--- a/packages/pi-image-gen/src/__tests__/extension.test.ts
+++ b/packages/pi-image-gen/src/__tests__/extension.test.ts
@@ -1,0 +1,454 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import piImageGenExtension, {
+  buildImageGuidelines,
+  buildImageToolParameters,
+  type ImageToolCapabilities,
+  QUALITY_VALUES,
+  resolveImageToolCapabilities,
+  sizeDescription,
+} from '../index.js';
+import type { ImageGenSettings } from '../types.js';
+
+type ToolDef = {
+  name: string;
+  promptSnippet?: string;
+  promptGuidelines?: string[];
+  parameters: { properties?: Record<string, unknown> };
+  execute: (...args: unknown[]) => Promise<unknown>;
+};
+type CommandDef = { description?: string; handler: (args: string, ctx: unknown) => Promise<void> };
+type Handler = (event: unknown, ctx: unknown) => unknown;
+
+function setup() {
+  const tools = new Map<string, ToolDef>();
+  const commands = new Map<string, CommandDef>();
+  const handlers = new Map<string, Handler>();
+  const mockPi = {
+    on: vi.fn((event: string, handler: Handler) => {
+      handlers.set(event, handler);
+    }),
+    registerTool: vi.fn((t: ToolDef) => tools.set(t.name, t)),
+    registerCommand: vi.fn((name: string, opts: CommandDef) => commands.set(name, opts)),
+    appendEntry: vi.fn(),
+  };
+  piImageGenExtension(mockPi as any);
+  return { tools, commands, handlers };
+}
+
+// The tool is registered inside session_start (after settings load), matching
+// pi-web-access / pi-memory. Fire it so `tools` is populated. With no settings
+// on disk the resolved api is null, which yields the fully-featured schema.
+async function startSession(handlers: Map<string, Handler>, cwd = '/tmp') {
+  await handlers.get('session_start')?.({}, { cwd, hasUI: true, ui: { notify: vi.fn() } });
+}
+
+function caps(
+  api: ImageToolCapabilities['api'],
+  quality: readonly string[] | null,
+): ImageToolCapabilities {
+  return { api, quality };
+}
+
+describe('piImageGenExtension', () => {
+  it('registers the /image-gen command at factory time', () => {
+    const { commands } = setup();
+    expect(commands.has('image-gen')).toBe(true);
+  });
+
+  it('registers the image_generate tool on session_start with snippet and guidelines', async () => {
+    const { tools, handlers } = setup();
+    // Not registered until a session starts and settings are loaded.
+    expect(tools.has('image_generate')).toBe(false);
+    await startSession(handlers);
+    const tool = tools.get('image_generate');
+    expect(tool).toBeDefined();
+    expect(tool?.promptSnippet).toBeTruthy();
+    expect(Array.isArray(tool?.promptGuidelines)).toBe(true);
+    expect(tool?.promptGuidelines?.length).toBeGreaterThan(0);
+    // The guidance must steer away from icons/logos and clarify `n` semantics.
+    const guidelines = (tool?.promptGuidelines ?? []).join('\n');
+    expect(guidelines).toMatch(/icon|logo|svg/i);
+    expect(guidelines).toMatch(/\bn\b/);
+    // Invariant params are always present regardless of provider.
+    const props = tool?.parameters.properties ?? {};
+    expect(props).toHaveProperty('prompt');
+    expect(props).toHaveProperty('image');
+    expect(props).toHaveProperty('n');
+    expect(props).toHaveProperty('size');
+    expect(props).toHaveProperty('filename');
+    expect(props).toHaveProperty('outputDir');
+  });
+
+  it('/image-gen generate with no prompt notifies an error and does not generate', async () => {
+    const { commands, handlers } = setup();
+    const notify = vi.fn();
+    const ctx = { cwd: '/tmp', hasUI: true, ui: { notify } };
+    await handlers.get('session_start')?.({}, ctx);
+    await commands.get('image-gen')?.handler('generate', ctx);
+    expect(notify).toHaveBeenCalledWith(expect.stringMatching(/Usage:/), 'error');
+  });
+
+  it('/image-gen reload reloads settings and re-registers the tool', async () => {
+    const { commands, tools } = setup();
+    const notify = vi.fn();
+    await commands.get('image-gen')?.handler('reload', { cwd: '/tmp', ui: { notify } });
+    expect(notify).toHaveBeenCalledWith(expect.stringMatching(/reloaded/i), 'info');
+    // Reload re-registers so the schema tracks the freshly loaded model.
+    expect(tools.has('image_generate')).toBe(true);
+  });
+
+  it('/image-gen list includes ARK_API_KEY when no provider is configured', async () => {
+    for (const name of [
+      'OPENAI_API_KEY',
+      'GEMINI_API_KEY',
+      'DASHSCOPE_API_KEY',
+      'OPENROUTER_API_KEY',
+      'ARK_API_KEY',
+    ]) {
+      vi.stubEnv(name, undefined);
+    }
+    try {
+      const { commands } = setup();
+      const notify = vi.fn();
+      await commands.get('image-gen')?.handler('', { cwd: '/tmp', ui: { notify } });
+      expect(String(notify.mock.calls[0]?.[0])).toContain('ARK_API_KEY');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});
+
+describe('resolveImageToolCapabilities', () => {
+  // These cases set provider API-key env vars so the model resolves. Use
+  // vi.stubEnv so the mutations are auto-reverted after each test rather than
+  // leaking into other tests sharing this worker (which lost the original value).
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('exposes the quality enum for the built-in openai provider', () => {
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+    const c = resolveImageToolCapabilities({ defaultModel: 'gpt-image-2' });
+    expect(c.api).toBe('openai');
+    expect(c.quality).toEqual(QUALITY_VALUES);
+  });
+
+  it('exposes the quality enum for the built-in openrouter provider', () => {
+    vi.stubEnv('OPENROUTER_API_KEY', 'or-test');
+    const settings: ImageGenSettings = {
+      defaultModel: 'openrouter/openai/gpt-image-2',
+    };
+    const c = resolveImageToolCapabilities(settings);
+    expect(c.api).toBe('openrouter');
+    expect(c.quality).toEqual(QUALITY_VALUES);
+  });
+
+  it('omits quality for openai/dall-e-3 on the built-in provider (non-gpt-image vocab)', () => {
+    // Routing DALL·E 3 through the built-in openai provider (slash form) still
+    // must NOT advertise low|medium|high|auto — DALL·E 3 uses standard/hd and
+    // would 400. The gate keys on the gpt-image model id, not the openai wire.
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+    const c = resolveImageToolCapabilities({ defaultModel: 'openai/dall-e-3' });
+    expect(c.api).toBe('openai');
+    expect(c.quality).toBeNull();
+  });
+
+  it('omits quality for an OpenRouter route to a non-gpt-image model', () => {
+    vi.stubEnv('OPENROUTER_API_KEY', 'or-test');
+    const c = resolveImageToolCapabilities({
+      defaultModel: 'openrouter/bytedance-seed/seedream-4.5',
+    });
+    expect(c.api).toBe('openrouter');
+    expect(c.quality).toBeNull();
+  });
+
+  it('omits quality for gemini, dashscope, and ark built-ins', () => {
+    vi.stubEnv('GEMINI_API_KEY', 'gem-test');
+    vi.stubEnv('DASHSCOPE_API_KEY', 'ds-test');
+    vi.stubEnv('ARK_API_KEY', 'ark-test');
+    expect(resolveImageToolCapabilities({ defaultModel: 'nano-banana' }).quality).toBeNull();
+    expect(resolveImageToolCapabilities({ defaultModel: 'qwen-image-2.0' }).quality).toBeNull();
+    expect(resolveImageToolCapabilities({ defaultModel: 'seedream' }).quality).toBeNull();
+  });
+
+  it('omits quality for a CUSTOM openai-compatible provider (vocab unknown, e.g. DALL·E 3)', () => {
+    // A self-hosted / third-party OpenAI-wire model may use a different quality
+    // vocabulary (DALL·E 3: standard/hd) or none — wire format != capability.
+    const settings: ImageGenSettings = {
+      defaultModel: 'dall-e-3',
+      customProviders: {
+        myopenai: {
+          api: 'openai',
+          baseUrl: 'https://api.openai.com/v1',
+          apiKey: 'k',
+          models: [{ id: 'dall-e-3', alias: 'dall-e-3' }],
+        },
+      },
+    };
+    const c = resolveImageToolCapabilities(settings);
+    expect(c.api).toBe('openai');
+    expect(c.quality).toBeNull();
+  });
+
+  it('falls back to the full schema (quality present) when the model is unset', () => {
+    expect(resolveImageToolCapabilities({}).quality).toEqual(QUALITY_VALUES);
+    expect(resolveImageToolCapabilities({}).api).toBeNull();
+  });
+
+  it('falls back to the full schema when the model cannot be resolved', () => {
+    const c = resolveImageToolCapabilities({ defaultModel: 'no-such-model-xyz' });
+    expect(c.quality).toEqual(QUALITY_VALUES);
+    expect(c.api).toBeNull();
+  });
+});
+
+describe('buildImageToolParameters', () => {
+  it('includes a constrained quality enum when capabilities allow it', () => {
+    const props = buildImageToolParameters(caps('openai', QUALITY_VALUES)).properties as Record<
+      string,
+      { enum?: unknown[] }
+    >;
+    expect(props).toHaveProperty('quality');
+    expect(props.quality?.enum).toEqual([...QUALITY_VALUES]);
+  });
+
+  it('omits quality when capabilities disallow it', () => {
+    for (const api of ['gemini', 'dashscope', 'ark'] as const) {
+      const props = buildImageToolParameters(caps(api, null)).properties as Record<string, unknown>;
+      expect(props).not.toHaveProperty('quality');
+    }
+  });
+
+  it('always exposes the invariant params', () => {
+    const cases: ImageToolCapabilities[] = [
+      caps('openai', QUALITY_VALUES),
+      caps('gemini', null),
+      caps('ark', null),
+      caps(null, QUALITY_VALUES),
+    ];
+    for (const c of cases) {
+      const props = buildImageToolParameters(c).properties as Record<string, unknown>;
+      for (const key of ['prompt', 'image', 'n', 'size', 'filename', 'outputDir']) {
+        expect(props).toHaveProperty(key);
+      }
+    }
+  });
+});
+
+describe('sizeDescription', () => {
+  it('warns about the 2K minimum for ark/Seedream', () => {
+    expect(sizeDescription('ark')).toMatch(/2K|2048/);
+  });
+
+  it('uses the generic 1024x1024 hint for other providers', () => {
+    expect(sizeDescription('openai')).toMatch(/1024x1024/);
+    expect(sizeDescription(null)).toMatch(/1024x1024/);
+  });
+});
+
+describe('image_generate execute error surfaces are sanitized', () => {
+  // A provider CDN URL whose credential lives in the query — the thing a raw
+  // fetch rejection would reproduce into stderr / the tool result if we trusted
+  // plain Error messages. It must reach NEITHER surface.
+  const SIGNED_URL = 'https://cdn.example.com/gen/out.png?X-Amz-Signature=SECRET&token=USERTOKEN';
+  // A 1x1 PNG (magic bytes + minimal IDAT) so materialize() accepts the result
+  // and the run reaches the write step, where the output-dir failure fires.
+  const PNG_B64 = Buffer.from(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c63000100000005000115c46f250000000049454e44ae426082',
+    'hex',
+  ).toString('base64');
+  const tmpDirs: string[] = [];
+  let realFetch: typeof fetch;
+
+  const makeProject = (settings: ImageGenSettings): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'pi-image-gen-execute-'));
+    tmpDirs.push(dir);
+    mkdirSync(join(dir, '.pi'), { recursive: true });
+    writeFileSync(join(dir, '.pi', 'settings.json'), JSON.stringify({ 'pi-image-gen': settings }));
+    return dir;
+  };
+
+  const runExecute = async (cwd: string, params: Record<string, unknown> = { prompt: 'a cat' }) => {
+    const { tools, handlers } = setup();
+    await handlers.get('session_start')?.({}, { cwd, hasUI: true, ui: { notify: vi.fn() } });
+    const tool = tools.get('image_generate');
+    if (!tool) throw new Error('tool not registered');
+    return (await tool.execute('call-1', params, undefined, undefined, {
+      cwd,
+    })) as { content: Array<{ text: string }>; isError?: boolean };
+  };
+
+  beforeEach(() => {
+    tmpDirs.length = 0;
+    realFetch = globalThis.fetch;
+    // Stub (don't assign) so it's auto-reverted after each test — a bare
+    // process.env write would leak into other tests sharing this worker.
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    globalThis.fetch = realFetch;
+    for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+    tmpDirs.length = 0;
+  });
+
+  it('leaks neither the signed download URL nor a raw error to stderr or the tool result', async () => {
+    // Generation returns a url-style result; the follow-up download rejects with
+    // the full signed URL in its message — the exact plain-Error leak path.
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/images/generations')) {
+        return new Response(JSON.stringify({ data: [{ url: SIGNED_URL }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      throw new Error(`request to ${SIGNED_URL} failed, reason: ECONNREFUSED`);
+    }) as typeof fetch;
+    globalThis.fetch = fetchImpl;
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runExecute(makeProject({ defaultModel: 'gpt-image-2' }));
+      expect(result.isError).toBe(true);
+      const toolText = result.content.map((c) => c.text).join('\n');
+      const logged = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      for (const surface of [toolText, logged]) {
+        expect(surface).not.toContain('X-Amz-Signature');
+        expect(surface).not.toContain('SECRET');
+        expect(surface).not.toContain('USERTOKEN');
+        expect(surface).not.toContain('token=');
+        expect(surface).not.toContain('ECONNREFUSED');
+      }
+      // The stderr line is the terse, body-free category summary.
+      expect(logged).toContain('generated image download failed');
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('classifies a download body that breaks after headers — not a generic failure', async () => {
+    // Generation returns a url-style result; the download response's headers
+    // arrive OK (200) but the body read (arrayBuffer) rejects mid-stream. Before
+    // the fix this escaped as `unexpected AbortError` with a generic user message;
+    // now it is a body-free download category, and the signed URL never leaks.
+    const brokenBodyResponse = {
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'image/png' }),
+      async arrayBuffer() {
+        throw new DOMException('aborted', 'AbortError');
+      },
+    } as unknown as Response;
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/images/generations')) {
+        return new Response(JSON.stringify({ data: [{ url: SIGNED_URL }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return brokenBodyResponse;
+    }) as typeof fetch;
+    globalThis.fetch = fetchImpl;
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runExecute(makeProject({ defaultModel: 'gpt-image-2' }));
+      expect(result.isError).toBe(true);
+      const toolText = result.content.map((c) => c.text).join('\n');
+      const logged = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      // Real, greppable download category — not the empty "unexpected" fallback.
+      expect(logged).toContain('generated image download failed');
+      expect(logged).not.toContain('unexpected');
+      // User gets an actionable download error, not the generic internal-fault line.
+      expect(toolText).not.toMatch(/failed unexpectedly/i);
+      // The signed URL still leaks to neither surface.
+      for (const surface of [toolText, logged]) {
+        expect(surface).not.toContain('X-Amz-Signature');
+        expect(surface).not.toContain('SECRET');
+        expect(surface).not.toContain('USERTOKEN');
+        expect(surface).not.toContain('token=');
+      }
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('logs only a body-free config summary when the model is unresolvable', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runExecute(makeProject({ defaultModel: 'no-such-model-xyz' }));
+      expect(result.isError).toBe(true);
+      const logged = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('[pi-image-gen] image_generate failed:');
+      expect(logged).toContain('model did not resolve');
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('gives an actionable, path-free error when the output dir cannot be created', async () => {
+    // Generation succeeds, but writing fails: outputDir is nested UNDER a regular
+    // file, so mkdir throws ENOTDIR — the same class as the reviewer's
+    // /dev/null/child repro. The user must get an actionable hint (not a generic
+    // "check the logs" with nothing in them), and no absolute path may leak.
+    const cwd = makeProject({ defaultModel: 'gpt-image-2' });
+    const filePath = join(cwd, 'not-a-dir');
+    writeFileSync(filePath, 'x');
+    const badOutputDir = join(filePath, 'child'); // parent is a file → ENOTDIR
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ data: [{ b64_json: PNG_B64 }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as typeof fetch;
+
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runExecute(cwd, { prompt: 'a cat', outputDir: badOutputDir });
+      expect(result.isError).toBe(true);
+      const toolText = result.content.map((c) => c.text).join('\n');
+      const logged = errSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      // Actionable for the user — points at the output directory knob, and is NOT
+      // the generic internal-fault fallback.
+      expect(toolText).toMatch(/output directory/i);
+      expect(toolText).not.toMatch(/failed unexpectedly/i);
+      // stderr carries a real, greppable category — not an empty "unexpected".
+      expect(logged).toContain('create the output directory failed');
+      // No absolute path leaks to either surface.
+      for (const surface of [toolText, logged]) {
+        expect(surface).not.toContain(badOutputDir);
+        expect(surface).not.toContain(cwd);
+      }
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
+describe('buildImageGuidelines', () => {
+  it('mentions the quality knob only when the schema exposes it', () => {
+    expect(buildImageGuidelines(caps('openai', QUALITY_VALUES)).join('\n')).toMatch(/quality/i);
+    expect(buildImageGuidelines(caps('gemini', null)).join('\n')).not.toMatch(/quality/i);
+    expect(buildImageGuidelines(caps('ark', null)).join('\n')).not.toMatch(/quality/i);
+  });
+
+  it('always steers away from icons/logos and clarifies n semantics', () => {
+    const cases: ImageToolCapabilities[] = [
+      caps('openai', QUALITY_VALUES),
+      caps('gemini', null),
+      caps('ark', null),
+      caps(null, QUALITY_VALUES),
+    ];
+    for (const c of cases) {
+      const text = buildImageGuidelines(c).join('\n');
+      expect(text).toMatch(/icon|logo|svg/i);
+      expect(text).toMatch(/\bn\b/);
+    }
+  });
+});

--- a/packages/pi-image-gen/src/__tests__/format.test.ts
+++ b/packages/pi-image-gen/src/__tests__/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { altFromPath, formatToolResultText } from '../index.js';
+import { altFromPath, formatCommandSummary, formatToolResultText } from '../index.js';
 import type { ImageGenResult } from '../types.js';
 
 describe('altFromPath', () => {
@@ -92,5 +92,52 @@ describe('formatToolResultText', () => {
       }),
     );
     expect(text).toContain('Generated 2 image(s) via amaster (custom) (qwen-image-2.0)');
+  });
+});
+
+describe('formatCommandSummary', () => {
+  function makeResult(overrides: Partial<ImageGenResult> = {}): ImageGenResult {
+    return {
+      model: 'gpt-image-2',
+      provider: 'openai',
+      images: [],
+      ...overrides,
+    };
+  }
+
+  it('lists raw paths WITHOUT markdown image syntax (notify renders plain text)', () => {
+    const text = formatCommandSummary(
+      makeResult({
+        images: [{ path: '/Users/me/.pi/images/white.png', mimeType: 'image/png' }],
+      }),
+    );
+    expect(text).toContain('/Users/me/.pi/images/white.png');
+    // notify() shows a status line, not markdown — the literal `![](…)` would
+    // leak to the user, so the command summary must not contain it.
+    expect(text).not.toContain('![');
+    expect(text).not.toContain('](');
+  });
+
+  it('reports image count, provider, and model in the header', () => {
+    const text = formatCommandSummary(
+      makeResult({
+        images: [
+          { path: '/a.png', mimeType: 'image/png' },
+          { path: '/b.png', mimeType: 'image/png' },
+        ],
+      }),
+    );
+    expect(text).toContain('Generated 2 image(s) via openai (gpt-image-2)');
+  });
+
+  it('includes the revised prompt as an indented note, not a quote line', () => {
+    const text = formatCommandSummary(
+      makeResult({
+        images: [{ path: '/tmp/cat.png', mimeType: 'image/png', revisedPrompt: 'a cute cat' }],
+      }),
+    );
+    expect(text).toContain('/tmp/cat.png');
+    expect(text).toContain('revised prompt: a cute cat');
+    expect(text).not.toContain('> revised prompt');
   });
 });

--- a/packages/pi-image-gen/src/__tests__/generate.test.ts
+++ b/packages/pi-image-gen/src/__tests__/generate.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { open } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -318,6 +318,50 @@ describe('generateImage', () => {
       ),
     ).rejects.toThrow(/cancelled/i);
     expect(existsSync(join(cwd, '.pi', 'images', 'batch-1.png'))).toBe(false);
+  });
+
+  it('preserves the original batch error when cleanup also fails', async () => {
+    const cwd = makeTmpDir();
+    const firstPath = join(cwd, '.pi', 'images', 'batch-cleanup-1.png');
+    const settings: ImageGenSettings = {
+      defaultModel: 'x-img',
+      customProviders: {
+        provider: {
+          api: 'openai',
+          apiKey: 'k',
+          models: ['x-img'],
+        },
+      },
+    };
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/images/generations')) {
+        return fakeJsonResponse({
+          data: [
+            { b64_json: PNG_BYTES.toString('base64') },
+            { url: 'https://cdn.test/generated.png' },
+          ],
+        });
+      }
+      rmSync(firstPath);
+      mkdirSync(firstPath);
+      throw new Error('download failed token=secret');
+    }) as typeof fetch;
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await expect(
+        generateImage({ prompt: 'a cat', filename: 'batch-cleanup' }, { cwd, settings, fetchImpl }),
+      ).rejects.toMatchObject({
+        logSummary: 'generated image download failed (network-error)',
+      });
+      const logged = errorSpy.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logged).toContain('[pi-image-gen] cleanup failed:');
+      expect(logged).not.toContain(firstPath);
+      expect(logged).not.toContain('token=secret');
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('propagates cancellation into an in-flight image file write', async () => {

--- a/packages/pi-image-gen/src/__tests__/generate.test.ts
+++ b/packages/pi-image-gen/src/__tests__/generate.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { open } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateImage } from '../generate.js';
 import type { ImageGenSettings } from '../types.js';
 
@@ -18,9 +19,29 @@ function fakeJsonResponse(payload: unknown): Response {
 }
 
 describe('generateImage', () => {
+  // Track every temp dir created in this suite and clean them up, per the repo
+  // test convention (pi-<pkg>-<suite> prefix + beforeEach/afterEach cleanup).
+  const tmpDirs: string[] = [];
+  const makeTmpDir = () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pi-image-gen-generate-'));
+    tmpDirs.push(dir);
+    return dir;
+  };
+
+  beforeEach(() => {
+    tmpDirs.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const dir of tmpDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tmpDirs.length = 0;
+  });
   it('saves an image returned as base64 to outputDir and returns its path', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
-    process.env.OPENAI_API_KEY = 'sk-test';
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
 
     const calls: Array<{ url: string; body: unknown }> = [];
     const fetchImpl: typeof fetch = (async (input, init) => {
@@ -50,7 +71,7 @@ describe('generateImage', () => {
   });
 
   it('downloads url-style results and writes them to disk', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
+    const cwd = makeTmpDir();
     const settings: ImageGenSettings = {
       defaultModel: 'x-img',
       customProviders: {
@@ -78,16 +99,83 @@ describe('generateImage', () => {
     expect(readFileSync(result.images[0]!.path)).toEqual(PNG_BYTES);
   });
 
+  it('cancels an unread generated-image HTTP error body', async () => {
+    const cwd = makeTmpDir();
+    let cancelled = false;
+    const settings: ImageGenSettings = {
+      defaultModel: 'x-img',
+      customProviders: {
+        myprov: {
+          api: 'openai',
+          apiKey: 'k',
+          models: ['x-img'],
+        },
+      },
+    };
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/images/generations')) {
+        return fakeJsonResponse({ data: [{ url: 'https://cdn.test/rejected.png' }] });
+      }
+      return new Response(
+        new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 403 },
+      );
+    }) as typeof fetch;
+
+    await expect(generateImage({ prompt: 'house' }, { cwd, settings, fetchImpl })).rejects.toThrow(
+      /403/,
+    );
+    expect(cancelled).toBe(true);
+  });
+
+  it.each([
+    'openai',
+    'gemini',
+    'dashscope',
+  ] as const)('cancels an unread %s provider HTTP error body', async (api) => {
+    const cwd = makeTmpDir();
+    let cancelled = false;
+    const settings: ImageGenSettings = {
+      defaultModel: 'x-img',
+      customProviders: {
+        provider: {
+          api,
+          apiKey: 'k',
+          models: ['x-img'],
+        },
+      },
+    };
+    const fetchImpl: typeof fetch = (async () =>
+      new Response(
+        new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 400 },
+      )) as typeof fetch;
+
+    await expect(generateImage({ prompt: 'house' }, { cwd, settings, fetchImpl })).rejects.toThrow(
+      /400/,
+    );
+    expect(cancelled).toBe(true);
+  });
+
   it('raises if defaultModel is not configured', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
+    const cwd = makeTmpDir();
     await expect(generateImage({ prompt: 'hi' }, { cwd, settings: {} })).rejects.toThrow(
       /defaultModel is not set/,
     );
   });
 
   it('raises with a helpful error if no provider can serve the model', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
-    delete process.env.GEMINI_API_KEY;
+    const cwd = makeTmpDir();
+    vi.stubEnv('GEMINI_API_KEY', undefined);
     await expect(
       generateImage(
         { prompt: 'x' },
@@ -97,8 +185,8 @@ describe('generateImage', () => {
   });
 
   it('aborts an in-flight provider request when signal fires', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
-    process.env.OPENAI_API_KEY = 'sk-test';
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
 
     const fetchImpl: typeof fetch = ((_input, init) =>
       new Promise((_resolve, reject) => {
@@ -126,9 +214,260 @@ describe('generateImage', () => {
     await expect(promise).rejects.toThrow(/cancelled|abort/i);
   });
 
+  it('re-checks cancellation before each write, after the provider call (base64 path)', async () => {
+    // A base64 result never fetches during materialize, so the write phase's only
+    // cancellation point is the per-iteration signal check. Abort via the `now`
+    // hook, which fires AFTER the post-provider check but BEFORE the write loop —
+    // so the earlier one-shot check passes and only the new in-loop check can stop
+    // it. Without that check, both files would be written and the call would
+    // resolve successfully.
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+    const ctrl = new AbortController();
+
+    const fetchImpl: typeof fetch = (async () =>
+      fakeJsonResponse({
+        data: [
+          { b64_json: PNG_BYTES.toString('base64') },
+          { b64_json: PNG_BYTES.toString('base64') },
+        ],
+      })) as typeof fetch;
+
+    await expect(
+      generateImage(
+        { prompt: 'a cat', filename: 'nope' },
+        {
+          cwd,
+          settings: { defaultModel: 'gpt-image-2' },
+          fetchImpl,
+          signal: ctrl.signal,
+          now: () => {
+            ctrl.abort();
+            return new Date(Date.UTC(2026, 5, 4, 12, 0, 0));
+          },
+        },
+      ),
+    ).rejects.toThrow(/cancelled/i);
+    // The output dir may be created, but no image file was written (default
+    // outputDir is <cwd>/.pi/images).
+    expect(existsSync(join(cwd, '.pi', 'images', 'nope.png'))).toBe(false);
+  });
+
+  it('re-checks cancellation after materializing bytes, immediately before writing', async () => {
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+    const ctrl = new AbortController();
+
+    const fetchImpl: typeof fetch = (async () =>
+      fakeJsonResponse({
+        data: [{ b64_json: PNG_BYTES.toString('base64') }],
+      })) as typeof fetch;
+
+    await expect(
+      generateImage(
+        { prompt: 'a cat', filename: 'late-cancel' },
+        {
+          cwd,
+          settings: { defaultModel: 'gpt-image-2' },
+          fetchImpl,
+          signal: ctrl.signal,
+          now: () => {
+            // The loop's first signal check has not happened yet. This microtask
+            // runs while `await materialize(...)` yields, after that check but
+            // before writeUnique starts.
+            queueMicrotask(() => ctrl.abort());
+            return new Date(Date.UTC(2026, 5, 4, 12, 0, 0));
+          },
+        },
+      ),
+    ).rejects.toThrow(/cancelled/i);
+    expect(existsSync(join(cwd, '.pi', 'images', 'late-cancel.png'))).toBe(false);
+  });
+
+  it('removes earlier files when a later image in the same batch fails', async () => {
+    const cwd = makeTmpDir();
+    const ctrl = new AbortController();
+    const settings: ImageGenSettings = {
+      defaultModel: 'x-img',
+      customProviders: {
+        provider: {
+          api: 'openai',
+          apiKey: 'k',
+          models: ['x-img'],
+        },
+      },
+    };
+    const fetchImpl: typeof fetch = (async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString();
+      if (url.endsWith('/images/generations')) {
+        return fakeJsonResponse({
+          data: [
+            { b64_json: PNG_BYTES.toString('base64') },
+            { url: 'https://cdn.test/cancelled.png' },
+          ],
+        });
+      }
+      ctrl.abort();
+      throw new DOMException('stop now', 'AbortError');
+    }) as typeof fetch;
+
+    await expect(
+      generateImage(
+        { prompt: 'a cat', filename: 'batch' },
+        { cwd, settings, fetchImpl, signal: ctrl.signal },
+      ),
+    ).rejects.toThrow(/cancelled/i);
+    expect(existsSync(join(cwd, '.pi', 'images', 'batch-1.png'))).toBe(false);
+  });
+
+  it('propagates cancellation into an in-flight image file write', async () => {
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+    const ctrl = new AbortController();
+    const largeImage = Buffer.alloc(8 * 1024 * 1024, 0x61).toString('base64');
+
+    const fetchImpl: typeof fetch = (async () =>
+      fakeJsonResponse({
+        data: [{ b64_json: largeImage }],
+      })) as typeof fetch;
+
+    const promise = generateImage(
+      { prompt: 'a cat', filename: 'in-flight-cancel' },
+      {
+        cwd,
+        settings: { defaultModel: 'gpt-image-2' },
+        fetchImpl,
+        signal: ctrl.signal,
+        now: () => {
+          // Runs after the synchronous pre-write checks, while writeFile is
+          // waiting in the filesystem thread pool.
+          setImmediate(() => ctrl.abort());
+          return new Date(Date.UTC(2026, 5, 4, 12, 0, 0));
+        },
+      },
+    );
+
+    await expect(promise).rejects.toThrow(/cancelled/i);
+    expect(existsSync(join(cwd, '.pi', 'images', 'in-flight-cancel.png'))).toBe(false);
+  });
+
+  it('forwards `quality` to the OpenAI generations body', async () => {
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+
+    const calls: Array<{ body: Record<string, unknown> }> = [];
+    const fetchImpl: typeof fetch = (async (_input, init) => {
+      calls.push({ body: JSON.parse(String(init?.body)) });
+      return fakeJsonResponse({ data: [{ b64_json: PNG_BYTES.toString('base64') }] });
+    }) as typeof fetch;
+
+    await generateImage(
+      { prompt: 'a cat', quality: 'high' },
+      { cwd, settings: { defaultModel: 'gpt-image-2' }, fetchImpl },
+    );
+    expect(calls[0]?.body.quality).toBe('high');
+  });
+
+  it('omits `quality` from the body when not provided', async () => {
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+
+    const calls: Array<{ body: Record<string, unknown> }> = [];
+    const fetchImpl: typeof fetch = (async (_input, init) => {
+      calls.push({ body: JSON.parse(String(init?.body)) });
+      return fakeJsonResponse({ data: [{ b64_json: PNG_BYTES.toString('base64') }] });
+    }) as typeof fetch;
+
+    await generateImage(
+      { prompt: 'a cat' },
+      { cwd, settings: { defaultModel: 'gpt-image-2' }, fetchImpl },
+    );
+    expect(calls[0]?.body).not.toHaveProperty('quality');
+  });
+
+  it('does not overwrite an existing file — writes a -v2 sibling instead', async () => {
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+
+    const fetchImpl: typeof fetch = (async () =>
+      fakeJsonResponse({ data: [{ b64_json: PNG_BYTES.toString('base64') }] })) as typeof fetch;
+
+    const opts = { cwd, settings: { defaultModel: 'gpt-image-2' }, fetchImpl } as const;
+    const first = await generateImage({ prompt: 'a cat', filename: 'hero' }, opts);
+    const second = await generateImage({ prompt: 'a cat', filename: 'hero' }, opts);
+
+    expect(first.images[0]?.path).toMatch(/hero\.png$/);
+    expect(second.images[0]?.path).toMatch(/hero-v2\.png$/);
+    expect(second.images[0]?.path).not.toBe(first.images[0]?.path);
+    // The first file is still intact.
+    expect(readFileSync(first.images[0]!.path)).toEqual(PNG_BYTES);
+  });
+
+  it('removes its newly created file when writing it fails', async () => {
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+    const probePath = join(cwd, 'probe');
+    const probe = await open(probePath, 'w');
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      writeFile(data: string | Uint8Array, options?: unknown): Promise<void>;
+    };
+    await probe.close();
+    rmSync(probePath);
+
+    const error = new Error('simulated write failure') as NodeJS.ErrnoException;
+    error.code = 'EIO';
+    const writeSpy = vi.spyOn(fileHandlePrototype, 'writeFile').mockRejectedValue(error);
+    const fetchImpl: typeof fetch = (async () =>
+      fakeJsonResponse({ data: [{ b64_json: PNG_BYTES.toString('base64') }] })) as typeof fetch;
+
+    try {
+      await expect(
+        generateImage(
+          { prompt: 'a cat', filename: 'write-failure' },
+          { cwd, settings: { defaultModel: 'gpt-image-2' }, fetchImpl },
+        ),
+      ).rejects.toThrow(/filesystem error/i);
+    } finally {
+      writeSpy.mockRestore();
+    }
+    expect(existsSync(join(cwd, '.pi', 'images', 'write-failure.png'))).toBe(false);
+  });
+
+  it('gives every concurrent same-filename call a distinct path (atomic O_EXCL write)', async () => {
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
+
+    // Distinct bytes per call so we can prove nothing was clobbered: the i-th
+    // image is a PNG whose trailing byte encodes i. If two calls resolved to the
+    // same path, one payload would overwrite the other and the read-back set
+    // would be missing a value.
+    const bodyFor = (i: number) => {
+      const bytes = Buffer.concat([PNG_BYTES, Buffer.from([i])]);
+      return { data: [{ b64_json: bytes.toString('base64') }] };
+    };
+    let call = 0;
+    const fetchImpl: typeof fetch = (async () => {
+      const i = call++;
+      return fakeJsonResponse(bodyFor(i));
+    }) as typeof fetch;
+
+    const N = 50;
+    const opts = { cwd, settings: { defaultModel: 'gpt-image-2' }, fetchImpl } as const;
+    const results = await Promise.all(
+      Array.from({ length: N }, () => generateImage({ prompt: 'a cat', filename: 'hero' }, opts)),
+    );
+
+    const paths = results.map((r) => r.images[0]!.path);
+    // Every call must have claimed a unique path — the whole point of the fix.
+    expect(new Set(paths).size).toBe(N);
+    // And every file must survive on disk (nothing overwrote a sibling).
+    const trailingBytes = new Set(paths.map((p) => readFileSync(p).at(-1)));
+    expect(trailingBytes.size).toBe(N);
+  });
+
   it('routes to OpenAI /images/edits when an image input is supplied', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
-    process.env.OPENAI_API_KEY = 'sk-test';
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
 
     const calls: Array<{ url: string; method: string; isFormData: boolean }> = [];
     const fetchImpl: typeof fetch = (async (input, init) => {
@@ -162,8 +501,8 @@ describe('generateImage', () => {
   });
 
   it('accepts a data: URI returned in the `url` field of an OpenAI response', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
-    process.env.OPENAI_API_KEY = 'sk-test';
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
 
     const dataUri = `data:image/png;base64,${PNG_BYTES.toString('base64')}`;
     const fetchImpl: typeof fetch = (async () =>
@@ -181,8 +520,8 @@ describe('generateImage', () => {
   });
 
   it('skips entries that have neither b64_json nor a usable url', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
-    process.env.OPENAI_API_KEY = 'sk-test';
+    const cwd = makeTmpDir();
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test');
 
     const fetchImpl: typeof fetch = (async () =>
       new Response(
@@ -216,7 +555,7 @@ describe('generateImage', () => {
   });
 
   it('routes OpenRouter to POST /api/v1/images (not /images/generations)', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
+    const cwd = makeTmpDir();
     const settings: ImageGenSettings = {
       defaultModel: 'google/gemini-3.1-flash-image',
       customProviders: {
@@ -242,7 +581,7 @@ describe('generateImage', () => {
   });
 
   it('OpenRouter image-to-image sends input_references in JSON body', async () => {
-    const cwd = mkdtempSync(join(tmpdir(), 'pi-image-gen-'));
+    const cwd = makeTmpDir();
     const settings: ImageGenSettings = {
       defaultModel: 'google/gemini-3.1-flash-image',
       customProviders: {

--- a/packages/pi-image-gen/src/__tests__/image-input.test.ts
+++ b/packages/pi-image-gen/src/__tests__/image-input.test.ts
@@ -101,6 +101,23 @@ describe('resolveImageInputs', () => {
     }
   });
 
+  it('identifies the failing entry in a multi-image input without echoing its value', async () => {
+    const secretPath = '/Users/alice/secret/photo.png';
+    const fetchImpl: typeof fetch = (async () =>
+      new Response(PNG_BYTES, {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      })) as typeof fetch;
+
+    try {
+      await resolveImageInputs(['https://example.com/ok.png', secretPath], '/tmp', fetchImpl);
+      throw new Error('expected resolveImageInputs to reject');
+    } catch (error) {
+      expect((error as Error).message).toMatch(/Image input #2/);
+      expect((error as Error).message).not.toContain(secretPath);
+    }
+  });
+
   it('accepts arrays of file paths', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'pi-image-input-'));
     const a = join(dir, 'a.png');

--- a/packages/pi-image-gen/src/__tests__/image-input.test.ts
+++ b/packages/pi-image-gen/src/__tests__/image-input.test.ts
@@ -60,6 +60,24 @@ describe('resolveImageInputs', () => {
     expect(receivedSignal).toBe(ctrl.signal);
   });
 
+  it('cancels an unread image-input HTTP error body', async () => {
+    let cancelled = false;
+    const fetchImpl: typeof fetch = (async () =>
+      new Response(
+        new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { status: 404 },
+      )) as typeof fetch;
+
+    await expect(
+      resolveImageInputs(['https://example.com/missing.png'], '/tmp', fetchImpl),
+    ).rejects.toThrow(/404/);
+    expect(cancelled).toBe(true);
+  });
+
   it('rejects a long raw base64 blob with a clear error', async () => {
     // 600+ bytes of arbitrary content → 800+ chars base64, no internal padding.
     const blob = Buffer.alloc(600, 0xab).toString('base64');
@@ -70,6 +88,17 @@ describe('resolveImageInputs', () => {
     await expect(resolveImageInputs(['nope.png'], '/tmp', fetch)).rejects.toThrow(
       /not a readable file path/,
     );
+  });
+
+  it('does not echo an unreadable absolute path in the error', async () => {
+    const secretPath = '/Users/alice/secret/photo.png';
+    try {
+      await resolveImageInputs([secretPath], '/tmp', fetch);
+      throw new Error('expected resolveImageInputs to reject');
+    } catch (error) {
+      expect((error as Error).message).toMatch(/not a readable file path/);
+      expect((error as Error).message).not.toContain(secretPath);
+    }
   });
 
   it('accepts arrays of file paths', async () => {

--- a/packages/pi-image-gen/src/errors.ts
+++ b/packages/pi-image-gen/src/errors.ts
@@ -34,7 +34,7 @@ export function toLogSummary(error: unknown): string {
 /** user/LLM sink: an ImageGenError's vetted message, else a fixed sentence. */
 export function errorMessageForUser(error: unknown): string {
   if (error instanceof ImageGenError) return error.message;
-  return 'Image generation failed unexpectedly. Check the extension logs (stderr) for details.';
+  return 'Image generation failed unexpectedly. Retry once; if it persists, report a pi-image-gen bug.';
 }
 
 /**
@@ -164,7 +164,7 @@ export function describeNetworkError(error: unknown, provider: ResolvedProvider)
       `Cannot reach ${provider.name}. Tell the user to check network connectivity or verify ${providerBaseUrlLocator(provider)}.`,
     );
   }
-  return err(`${provider.name} request failed with a ${category} error.`);
+  return err(`${provider.name} request failed because of a network error.`);
 }
 
 /** Read a successful provider body, converting mid-stream failures without echoing raw text. */

--- a/packages/pi-image-gen/src/errors.ts
+++ b/packages/pi-image-gen/src/errors.ts
@@ -1,57 +1,251 @@
 import type { ResolvedProvider } from './types.js';
 
 /**
- * Build an error message that an LLM can act on without a human in the loop.
- *
- * The shape is:
- *   "<short verb-phrase>. <hint addressed to the LLM>."
- *
- * The first sentence describes what happened so a human reading the transcript
- * understands. The second sentence tells the LLM what to do — typically "tell
- * the user to verify X" — so the model doesn't fall back to vague apologies or
- * pointless retries.
+ * Trust boundary for the whole extension. Raw provider bodies — and plain
+ * `fs`/`fetch` errors, which embed absolute paths, errno strings, or signed
+ * `?token=…` URLs — must reach NEITHER the user/LLM surface NOR a log. So every
+ * EXPECTED failure is thrown as an `ImageGenError`, the only value whose text is
+ * vetted body-free, carrying two curated views: `message` (LLM-facing, "what
+ * happened + what to do") and `logSummary` (a terse provider/status/category
+ * one-liner, e.g. `OpenAI HTTP 400 (bad-request)`). The sinks below surface
+ * those views and redact anything else.
  */
-export function classifyHttpError(res: Response, body: string, provider: ResolvedProvider): string {
-  const where = providerLocator(provider);
-  const peek = body.slice(0, 200).replace(/\s+/g, ' ');
-
-  if (res.status === 401 || res.status === 403) {
-    return `${provider.name} rejected the API key (HTTP ${res.status}). Tell the user to verify ${where}. Do not retry — this will keep failing until the key is fixed.`;
+export class ImageGenError extends Error {
+  readonly logSummary: string;
+  constructor(message: string, logSummary: string) {
+    super(message);
+    this.name = 'ImageGenError';
+    this.logSummary = logSummary.split(/[\r\n]/, 1)[0] || 'image generation failed';
   }
-  if (res.status === 404) {
-    return `${provider.name} returned 404 at this baseUrl. Tell the user to verify ${providerBaseUrlLocator(provider)} — the model id may be wrong, or this gateway doesn't expose the image API. Body: ${peek}`;
-  }
-  if (res.status === 429) {
-    return `${provider.name} rate-limited the request (HTTP 429). Wait a few seconds before retrying, or suggest a different provider/model. Body: ${peek}`;
-  }
-  if (res.status >= 500 && res.status < 600) {
-    return `${provider.name} had a server-side failure (HTTP ${res.status}). This is likely transient — one retry is reasonable, but if it keeps failing tell the user the provider is down. Body: ${peek}`;
-  }
-  if (res.status === 400 || res.status === 422) {
-    return `${provider.name} rejected the request (HTTP ${res.status}) — likely a bad parameter or unsupported model id. Tell the user the model name or size may not be supported by this provider. Body: ${peek}`;
-  }
-  return `${provider.name} returned HTTP ${res.status}. Body: ${peek}`;
-}
-
-/** Wrap a non-HTTP error (timeout, network, parse) with a hint for the LLM. */
-export function describeNetworkError(error: unknown, provider: ResolvedProvider): string {
-  const msg = error instanceof Error ? error.message : String(error);
-  if (/abort/i.test(msg)) {
-    return `Request to ${provider.name} was cancelled.`;
-  }
-  if (/timeout|timed out|ETIMEDOUT/i.test(msg)) {
-    return `Request to ${provider.name} timed out. The provider was too slow — try a smaller \`n\`, a different model, or check ${providerBaseUrlLocator(provider)}. Original: ${msg}`;
-  }
-  if (/ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET/i.test(msg)) {
-    return `Cannot reach ${provider.name}. Tell the user to check network connectivity or verify ${providerBaseUrlLocator(provider)}. Original: ${msg}`;
-  }
-  return `${provider.name} request failed: ${msg}`;
 }
 
 /**
- * Returns a settings-path string that points to where the user should fix
- * the apiKey. For built-ins we name the env var; for customProviders we name
- * the JSON path.
+ * stderr sink: an ImageGenError's curated summary, else a fixed label. Anything
+ * that isn't an ImageGenError is untrusted — an Error's `message` and its
+ * (writable) `name` can carry a path, errno, signed URL, or a log-injection
+ * newline, and a thrown non-Error is arbitrary — so we surface a constant string
+ * and never read a single byte off the value.
+ */
+export function toLogSummary(error: unknown): string {
+  if (error instanceof ImageGenError) return error.logSummary;
+  return error instanceof Error ? 'unexpected error' : 'unexpected non-error throw';
+}
+
+/** user/LLM sink: an ImageGenError's vetted message, else a fixed sentence. */
+export function errorMessageForUser(error: unknown): string {
+  if (error instanceof ImageGenError) return error.message;
+  return 'Image generation failed unexpectedly. Check the extension logs (stderr) for details.';
+}
+
+/**
+ * Reduce a URL to `scheme://host/path`, dropping the query (where signed
+ * `?token=…` / `?X-Amz-Signature=…` credentials live), the fragment, and any
+ * userinfo. Non-parseable input collapses to `<url>` so it can't smuggle bytes.
+ */
+export function redactUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    return `${u.protocol}//${u.host}${u.pathname}`;
+  } catch {
+    return '<url>';
+  }
+}
+
+/** Fixed-safe provider label for stderr; custom display names are user-controlled. */
+export function providerLogLabel(provider: ResolvedProvider): string {
+  return provider.builtIn ? provider.name : 'Custom provider';
+}
+
+/** Missing-API-key error naming the exact env var / settings path to fix. */
+export function missingKeyError(provider: ResolvedProvider): ImageGenError {
+  return new ImageGenError(
+    `Provider "${provider.id}" has no API key. Tell the user to set ${providerLocator(provider)}.`,
+    `${providerLogLabel(provider)} missing API key`,
+  );
+}
+
+/** Short, body-free category label for an HTTP status. */
+function httpCategory(status: number): string {
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 404) return 'not-found';
+  if (status === 429) return 'rate-limit';
+  if (status >= 500 && status < 600) return 'server-error';
+  if (status === 400 || status === 422) return 'bad-request';
+  return 'http-error';
+}
+
+/**
+ * Actionable, body-free error for a provider HTTP failure. The raw response body
+ * (which can echo the prompt, credentials, a signed URL, or another tenant's
+ * data) is never interpolated — only status + category leave this module.
+ */
+export function classifyHttpError(res: Response, provider: ResolvedProvider): ImageGenError {
+  const where = providerLocator(provider);
+  const summary = `${providerLogLabel(provider)} HTTP ${res.status} (${httpCategory(res.status)})`;
+  const err = (message: string) => new ImageGenError(message, summary);
+
+  if (res.status === 401 || res.status === 403) {
+    return err(
+      `${provider.name} rejected the API key (HTTP ${res.status}). Tell the user to verify ${where}. Do not retry — this will keep failing until the key is fixed.`,
+    );
+  }
+  if (res.status === 404) {
+    return err(
+      `${provider.name} returned 404 at this baseUrl. Tell the user to verify ${providerBaseUrlLocator(provider)} — the model id may be wrong, or this gateway doesn't expose the image API.`,
+    );
+  }
+  if (res.status === 429) {
+    return err(
+      `${provider.name} rate-limited the request (HTTP 429). Wait a few seconds before retrying, or suggest a different provider/model.`,
+    );
+  }
+  if (res.status >= 500 && res.status < 600) {
+    return err(
+      `${provider.name} had a server-side failure (HTTP ${res.status}). This is likely transient — one retry is reasonable, but if it keeps failing tell the user the provider is down.`,
+    );
+  }
+  if (res.status === 400 || res.status === 422) {
+    return err(
+      `${provider.name} rejected the request (HTTP ${res.status}) — likely a bad parameter or unsupported model id. Tell the user the model name or size may not be supported by this provider.`,
+    );
+  }
+  return err(`${provider.name} returned HTTP ${res.status}.`);
+}
+
+/** Release an unread HTTP error body, then throw its body-free classification. */
+export async function throwHttpError(res: Response, provider: ResolvedProvider): Promise<never> {
+  const error = classifyHttpError(res, provider);
+  await cancelResponseBody(res);
+  throw error;
+}
+
+async function cancelResponseBody(res: Response): Promise<void> {
+  try {
+    await res.body?.cancel();
+  } catch {
+    // Preserve the useful HTTP classification if best-effort connection cleanup fails.
+  }
+}
+
+/** Structured cancellation check; the writable name is compared, never logged. */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+/** Short, body-free category label for a non-HTTP (network/parse) error. */
+function networkCategory(error: unknown): string {
+  if (isAbortError(error)) return 'cancelled';
+  const msg = error instanceof Error ? error.message : String(error);
+  if (/timeout|timed out|ETIMEDOUT/i.test(msg)) return 'timeout';
+  if (/ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET/i.test(msg)) return 'unreachable';
+  return 'network-error';
+}
+
+/**
+ * Actionable, body-free error for a non-HTTP failure (timeout / DNS / abort).
+ * The underlying message is used ONLY to classify the failure — it can carry the
+ * full request URL (incl. a signed `?token=…`) or host internals, so it is never
+ * reproduced. Only the provider name + derived category leave this module.
+ */
+export function describeNetworkError(error: unknown, provider: ResolvedProvider): ImageGenError {
+  const category = networkCategory(error);
+  const summary = `${providerLogLabel(provider)} request failed (${category})`;
+  const err = (message: string) => new ImageGenError(message, summary);
+  if (category === 'cancelled') {
+    return err(`Request to ${provider.name} was cancelled.`);
+  }
+  if (category === 'timeout') {
+    return err(
+      `Request to ${provider.name} timed out. The provider was too slow — try a smaller \`n\`, a different model, or check ${providerBaseUrlLocator(provider)}.`,
+    );
+  }
+  if (category === 'unreachable') {
+    return err(
+      `Cannot reach ${provider.name}. Tell the user to check network connectivity or verify ${providerBaseUrlLocator(provider)}.`,
+    );
+  }
+  return err(`${provider.name} request failed with a ${category} error.`);
+}
+
+/** Read a successful provider body, converting mid-stream failures without echoing raw text. */
+export async function readBodyText(res: Response, provider: ResolvedProvider): Promise<string> {
+  try {
+    return await res.text();
+  } catch (error) {
+    throw describeNetworkError(error, provider);
+  }
+}
+
+/**
+ * Body-free error for a failed image download (a caller-supplied URL or the
+ * provider CDN URL, either of which may embed a signed `?token=…`). The URL is
+ * always redacted and no raw fetch text / HTTP body is interpolated. `what` is a
+ * fixed caller label. Pass `{ httpStatus }` for a non-OK response, or
+ * `{ rejected }` with the raw thrown value for a fetch rejection (classify only).
+ */
+export function describeDownloadError(
+  what: string,
+  url: string,
+  cause: { httpStatus: number } | { rejected: unknown },
+): ImageGenError {
+  const where = redactUrl(url);
+  if ('httpStatus' in cause) {
+    return new ImageGenError(
+      `Failed to download ${what} from ${where} (HTTP ${cause.httpStatus}). Tell the user to verify the URL is reachable.`,
+      `${what} download failed (HTTP ${cause.httpStatus})`,
+    );
+  }
+  const category = networkCategory(cause.rejected);
+  return new ImageGenError(
+    category === 'cancelled'
+      ? `Downloading ${what} from ${where} was cancelled.`
+      : `Could not reach ${where} to download ${what}. Tell the user to verify the URL is reachable.`,
+    `${what} download failed (${category})`,
+  );
+}
+
+/** Release an unread download error body, then throw its body-free classification. */
+export async function throwDownloadHttpError(
+  what: string,
+  url: string,
+  res: Response,
+): Promise<never> {
+  const error = describeDownloadError(what, url, { httpStatus: res.status });
+  await cancelResponseBody(res);
+  throw error;
+}
+
+/**
+ * Body-free error for a filesystem write failure (creating the output dir or
+ * writing an image file). The raw fs error embeds the absolute path + errno, so
+ * we classify by its `.code` (validated against an errno shape) into an
+ * actionable, path-free hint. `what` is a fixed caller label.
+ */
+export function describeWriteError(what: string, error: unknown): ImageGenError {
+  const rawCode = (error as NodeJS.ErrnoException | undefined)?.code;
+  const code = typeof rawCode === 'string' && /^E[A-Z]+$/.test(rawCode) ? rawCode : undefined;
+  const reason =
+    code === 'EACCES' || code === 'EPERM' || code === 'EROFS'
+      ? 'permission was denied'
+      : code === 'ENOSPC'
+        ? 'the disk is full'
+        : code === 'ENOTDIR' || code === 'ENOENT'
+          ? 'the path is invalid'
+          : 'of a filesystem error';
+  return new ImageGenError(
+    `Could not ${what} because ${reason}. Tell the user to check the configured output directory (pi-image-gen.outputDir or the tool's outputDir) points at a writable path.`,
+    `${what} failed (${code ?? 'fs-error'})`,
+  );
+}
+
+/** Body-free error for a cancelled operation (`what` is a fixed caller label). */
+export function cancelledError(what: string): ImageGenError {
+  return new ImageGenError(`${what} was cancelled.`, `${what} cancelled`);
+}
+
+/**
+ * Settings path where the user should fix the apiKey: the env var for built-ins,
+ * the JSON path for customProviders. Also used to name the key in HTTP-401 hints.
  */
 function providerLocator(provider: ResolvedProvider): string {
   if (provider.builtIn) {
@@ -73,4 +267,5 @@ const BUILT_IN_ENV_VAR: Record<string, string> = {
   gemini: 'GEMINI_API_KEY',
   dashscope: 'DASHSCOPE_API_KEY',
   openrouter: 'OPENROUTER_API_KEY',
+  ark: 'ARK_API_KEY',
 };

--- a/packages/pi-image-gen/src/generate.ts
+++ b/packages/pi-image-gen/src/generate.ts
@@ -117,7 +117,7 @@ export async function generateImage(
         }),
       );
     } catch (cleanupError) {
-      throw describeWriteError('remove an incomplete image batch', cleanupError);
+      logCleanupFailure('remove an incomplete image batch', cleanupError);
     }
     throw error;
   }
@@ -131,6 +131,12 @@ export async function generateImage(
 
 function providerLabel(provider: ResolvedProvider): string {
   return provider.builtIn ? provider.id : `${provider.id} (custom)`;
+}
+
+function logCleanupFailure(operation: string, error: unknown): void {
+  console.error(
+    `[pi-image-gen] cleanup failed: ${describeWriteError(operation, error).logSummary}`,
+  );
 }
 
 function resolveOutputDir(configured: string | undefined, cwd: string): string {
@@ -194,7 +200,7 @@ async function writeUnique(
           await unlink(candidate);
         } catch (cleanupError) {
           if ((cleanupError as NodeJS.ErrnoException).code !== 'ENOENT') {
-            throw describeWriteError('remove the incomplete image file', cleanupError);
+            logCleanupFailure('remove the incomplete image file', cleanupError);
           }
         }
       }

--- a/packages/pi-image-gen/src/generate.ts
+++ b/packages/pi-image-gen/src/generate.ts
@@ -1,6 +1,14 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, open, unlink } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 import { resolveModel } from './config.js';
+import {
+  cancelledError,
+  describeDownloadError,
+  describeWriteError,
+  ImageGenError,
+  isAbortError,
+  throwDownloadHttpError,
+} from './errors.js';
 import { resolveImageInputs } from './image-input.js';
 import { getAdapter } from './providers/index.js';
 import type {
@@ -16,7 +24,7 @@ export type GenerateImageOptions = {
   cwd: string;
   settings: ImageGenSettings;
   fetchImpl?: typeof fetch;
-  /** Cancellation signal — propagated to every fetch and the DashScope poll loop. */
+  /** Cancellation signal — propagated to fetches, provider polling, and file writes. */
   signal?: AbortSignal;
   /** Override the wall-clock used for filenames. Useful for tests. */
   now?: () => Date;
@@ -39,13 +47,16 @@ export async function generateImage(
 
   const requested = (options.settings.defaultModel ?? '').trim();
   if (!requested) {
-    throw new Error(
+    // Config errors are ImageGenErrors so they survive the body-free log sink
+    // with their actionable text — none of them carry secrets/user content.
+    throw new ImageGenError(
       'pi-image-gen.defaultModel is not set. Configure it in settings.json (e.g. "defaultModel": "nano-banana"). Run /image-gen list to see configured providers.',
+      'defaultModel not set',
     );
   }
 
   const resolved = resolveModel(requested, options.settings);
-  if ('error' in resolved) throw new Error(resolved.error);
+  if ('error' in resolved) throw new ImageGenError(resolved.error, 'model did not resolve');
 
   const adapter = getAdapter(resolved.provider.api);
   const inputs = await resolveImageInputs(params.image, options.cwd, fetchImpl, options.signal);
@@ -58,24 +69,57 @@ export async function generateImage(
     inputs,
   );
 
-  options.signal?.throwIfAborted();
+  if (options.signal?.aborted) throw cancelledError('image generation');
 
   const outDir = resolveOutputDir(params.outputDir ?? options.settings.outputDir, options.cwd);
-  await mkdir(outDir, { recursive: true });
+  try {
+    await mkdir(outDir, { recursive: true });
+  } catch (error) {
+    // The raw fs error embeds the absolute outDir + errno — classify it into a
+    // path-free, actionable hint instead of letting it reach a sink verbatim.
+    throw describeWriteError('create the output directory', error);
+  }
 
   const stamp = formatStamp(now());
   const baseFilename = sanitizeFilename(params.filename ?? `${resolved.requestedId}-${stamp}`);
   const images: GeneratedImage[] = [];
-  for (let i = 0; i < raws.length; i++) {
-    const raw = raws[i]!;
-    const fetched = await materialize(raw, fetchImpl, options.signal);
-    const ext = MIME_TO_EXT[fetched.mimeType] ?? 'png';
-    const suffix = raws.length > 1 ? `-${i + 1}` : '';
-    const path = resolve(outDir, `${baseFilename}${suffix}.${ext}`);
-    await writeFile(path, fetched.bytes);
-    const image: GeneratedImage = { path, mimeType: fetched.mimeType };
-    if (raw.revisedPrompt) image.revisedPrompt = raw.revisedPrompt;
-    images.push(image);
+  try {
+    for (let i = 0; i < raws.length; i++) {
+      // Re-check before each write: a base64 result never touches fetch, so the
+      // signal has no other cancellation point here — without this an abort during
+      // multi-image materialize/write would keep writing files and return success.
+      if (options.signal?.aborted) throw cancelledError('image generation');
+      const raw = raws[i]!;
+      const fetched = await materialize(raw, fetchImpl, options.signal);
+      if (options.signal?.aborted) throw cancelledError('image generation');
+      const ext = MIME_TO_EXT[fetched.mimeType] ?? 'png';
+      const suffix = raws.length > 1 ? `-${i + 1}` : '';
+      const path = await writeUnique(
+        outDir,
+        `${baseFilename}${suffix}`,
+        ext,
+        fetched.bytes,
+        options.signal,
+      );
+      const image: GeneratedImage = { path, mimeType: fetched.mimeType };
+      if (raw.revisedPrompt) image.revisedPrompt = raw.revisedPrompt;
+      images.push(image);
+    }
+  } catch (error) {
+    try {
+      await Promise.all(
+        images.map(async ({ path }) => {
+          try {
+            await unlink(path);
+          } catch (cleanupError) {
+            if ((cleanupError as NodeJS.ErrnoException).code !== 'ENOENT') throw cleanupError;
+          }
+        }),
+      );
+    } catch (cleanupError) {
+      throw describeWriteError('remove an incomplete image batch', cleanupError);
+    }
+    throw error;
   }
 
   return {
@@ -107,6 +151,64 @@ function sanitizeFilename(name: string): string {
   return trimmed.length > 0 ? trimmed.slice(0, 100) : 'image';
 }
 
+/**
+ * Atomically write `bytes` to a non-clobbering path for `<stem>.<ext>` in `dir`,
+ * returning the absolute path actually written.
+ *
+ * Uses the `wx` open flag (O_EXCL) so the "does it exist?" check and the create
+ * are a single syscall: if the name is already taken the write fails with
+ * `EEXIST` and we try `-v2`, `-v3`, … A prior `existsSync`→`writeFile` version
+ * had a TOCTOU race — concurrent calls with the same `filename` could observe
+ * the same free name and clobber each other, breaking the README's
+ * "never overwrites" contract. O_EXCL closes that window: only one racer can
+ * create any given name, the losers retry the next suffix.
+ *
+ * So two calls with `filename: "hero"` yield `hero.png` then `hero-v2.png` — the
+ * earlier output is preserved rather than silently replaced.
+ */
+async function writeUnique(
+  dir: string,
+  stem: string,
+  ext: string,
+  bytes: Uint8Array,
+  signal?: AbortSignal,
+): Promise<string> {
+  for (let v = 1; ; v++) {
+    if (signal?.aborted) throw cancelledError('image generation');
+    const candidate = resolve(dir, v === 1 ? `${stem}.${ext}` : `${stem}-v${v}.${ext}`);
+    let created = false;
+    try {
+      // `wx`: create-and-fail-if-exists in one atomic operation (no TOCTOU gap).
+      const file = await open(candidate, 'wx');
+      created = true;
+      try {
+        await file.writeFile(bytes, { signal });
+      } finally {
+        await file.close();
+      }
+      if (signal?.aborted) throw cancelledError('image generation');
+      return candidate;
+    } catch (error) {
+      if (created) {
+        try {
+          await unlink(candidate);
+        } catch (cleanupError) {
+          if ((cleanupError as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw describeWriteError('remove the incomplete image file', cleanupError);
+          }
+        }
+      }
+      if (signal?.aborted || isAbortError(error)) {
+        throw cancelledError('image generation');
+      }
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') continue;
+      // Disk full / permission / invalid path — the raw fs error embeds the
+      // absolute candidate path + errno, so classify it into a path-free hint.
+      throw describeWriteError('write the image file', error);
+    }
+  }
+}
+
 async function materialize(
   raw: RawImageResult,
   fetchImpl: typeof fetch,
@@ -119,15 +221,32 @@ async function materialize(
     };
   }
   if (!raw.data.url || !/^https?:\/\//i.test(raw.data.url)) {
-    throw new Error(
-      `Provider returned a non-URL image reference (${raw.data.url ? raw.data.url.slice(0, 60) : 'empty'}). The response shape may have changed.`,
+    // Do not echo the reference back: a malformed value could be a giant blob or
+    // carry a token. State the shape problem without reproducing the value.
+    throw new ImageGenError(
+      'Provider returned a non-URL image reference. The response shape may have changed.',
+      'non-URL image reference',
     );
   }
-  const res = await fetchImpl(raw.data.url, { signal: signal ?? null });
-  if (!res.ok) {
-    throw new Error(`Failed to download generated image (${res.status} ${res.statusText}).`);
+  // Wrap the fetch: a raw rejection can reproduce the signed CDN URL in its
+  // message and reach a log via the plain-Error path. describeDownloadError
+  // redacts the URL (dropping ?token=…) and interpolates no raw fetch text.
+  let res: Response;
+  try {
+    res = await fetchImpl(raw.data.url, { signal: signal ?? null });
+  } catch (error) {
+    throw describeDownloadError('generated image', raw.data.url, { rejected: error });
   }
-  const buf = new Uint8Array(await res.arrayBuffer());
+  if (!res.ok) {
+    await throwDownloadHttpError('generated image', raw.data.url, res);
+  }
+  // Body reads can fail after headers; keep them in the sanitized download boundary.
+  let buf: Uint8Array;
+  try {
+    buf = new Uint8Array(await res.arrayBuffer());
+  } catch (error) {
+    throw describeDownloadError('generated image', raw.data.url, { rejected: error });
+  }
   const mimeType = res.headers.get('content-type')?.split(';')[0]?.trim() || 'image/png';
   return { bytes: buf, mimeType };
 }

--- a/packages/pi-image-gen/src/image-input.ts
+++ b/packages/pi-image-gen/src/image-input.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
+import { describeDownloadError, ImageGenError, throwDownloadHttpError } from './errors.js';
 import type { ResolvedImageInput } from './types.js';
 
 const MAGIC_BYTES: Array<{ mimeType: string; bytes: number[] }> = [
@@ -33,33 +34,52 @@ async function resolveOne(
   signal?: AbortSignal,
 ): Promise<ResolvedImageInput> {
   const trimmed = value.trim();
-  if (!trimmed) throw new Error('image input is empty.');
+  // Every throw below is an ImageGenError so it survives the body-free log sink
+  // (toLogSummary) with an actionable message; none interpolate the raw value —
+  // an image input could be a giant base64 blob or a signed URL.
+  if (!trimmed) {
+    throw new ImageGenError('image input is empty.', 'image input empty');
+  }
 
   // Reject base64 / data: URIs — tool-call payloads don't survive megabyte-sized
   // string arguments cleanly across providers. Force callers to point us at a
   // path or URL instead, which is also what /image_generate's tool description
   // tells the model.
   if (/^data:/i.test(trimmed)) {
-    throw new Error(
+    throw new ImageGenError(
       'Image input as a `data:` URI is not supported. Pass a file path (absolute or relative to cwd) or an http(s) URL instead. If you have raw image bytes, write them to a file under .pi/uploads first and pass that path.',
+      'image input rejected (data: URI)',
     );
   }
   // Heuristic for raw base64: long, only base64 chars. Not foolproof but
   // catches the common case where the model dumps a giant base64 blob.
   if (trimmed.length > 256 && !/[\s/\\]/.test(trimmed) && /^[A-Za-z0-9+/]+={0,2}$/.test(trimmed)) {
-    throw new Error(
+    throw new ImageGenError(
       'Image input looks like a raw base64 blob; this is not supported because it bloats the tool argument. Write the bytes to a file path and pass that path instead.',
+      'image input rejected (raw base64)',
     );
   }
 
   if (/^https?:\/\//i.test(trimmed)) {
-    const res = await fetchImpl(trimmed, { signal: signal ?? null });
-    if (!res.ok) {
-      throw new Error(
-        `Failed to download image input from ${trimmed} (HTTP ${res.status}). Tell the user to verify the URL is reachable.`,
-      );
+    // Wrap the fetch: a raw rejection can reproduce the full URL (including a
+    // signed `?token=…`) in its message, which would then reach a log via the
+    // plain-Error path. describeDownloadError redacts the URL and stays body-free.
+    let res: Response;
+    try {
+      res = await fetchImpl(trimmed, { signal: signal ?? null });
+    } catch (error) {
+      throw describeDownloadError('image input', trimmed, { rejected: error });
     }
-    const buf = new Uint8Array(await res.arrayBuffer());
+    if (!res.ok) {
+      await throwDownloadHttpError('image input', trimmed, res);
+    }
+    // Body reads can fail after headers; keep them in the sanitized download boundary.
+    let buf: Uint8Array;
+    try {
+      buf = new Uint8Array(await res.arrayBuffer());
+    } catch (error) {
+      throw describeDownloadError('image input', trimmed, { rejected: error });
+    }
     const mimeType =
       res.headers.get('content-type')?.split(';')[0]?.trim() || sniffMime(buf) || 'image/png';
     return { bytes: buf, mimeType };
@@ -70,9 +90,13 @@ async function resolveOne(
   let bytes: Buffer;
   try {
     bytes = await readFile(absolute);
-  } catch (error) {
-    throw new Error(
-      `Image input "${trimmed}" is not a readable file path or http(s) URL (tried ${absolute}): ${(error as Error).message}. Pass an absolute path, a path relative to the session cwd, or an http(s) URL.`,
+  } catch {
+    // Do NOT interpolate the resolved absolute path or the raw fs error (errno +
+    // full path) — both are sensitive and would reach stderr via the plain-Error
+    // path. Keep the message body-free, path-free, and actionable.
+    throw new ImageGenError(
+      'Image input is not a readable file path or http(s) URL. Pass an absolute path, a path relative to the session cwd, or an http(s) URL.',
+      'image input not readable',
     );
   }
   const mimeType = sniffMime(bytes) ?? extToMime(absolute) ?? 'image/png';

--- a/packages/pi-image-gen/src/image-input.ts
+++ b/packages/pi-image-gen/src/image-input.ts
@@ -21,24 +21,27 @@ export async function resolveImageInputs(
 ): Promise<ResolvedImageInput[]> {
   if (!raw || raw.length === 0) return [];
   const out: ResolvedImageInput[] = [];
-  for (const entry of raw) {
-    out.push(await resolveOne(entry, cwd, fetchImpl, signal));
+  for (let index = 0; index < raw.length; index++) {
+    const inputLabel = raw.length > 1 ? `Image input #${index + 1}` : 'Image input';
+    out.push(await resolveOne(raw[index]!, inputLabel, cwd, fetchImpl, signal));
   }
   return out;
 }
 
 async function resolveOne(
   value: string,
+  inputLabel: string,
   cwd: string,
   fetchImpl: typeof fetch,
   signal?: AbortSignal,
 ): Promise<ResolvedImageInput> {
   const trimmed = value.trim();
+  const logLabel = inputLabel.toLowerCase();
   // Every throw below is an ImageGenError so it survives the body-free log sink
   // (toLogSummary) with an actionable message; none interpolate the raw value —
   // an image input could be a giant base64 blob or a signed URL.
   if (!trimmed) {
-    throw new ImageGenError('image input is empty.', 'image input empty');
+    throw new ImageGenError(`${inputLabel} is empty.`, `${logLabel} empty`);
   }
 
   // Reject base64 / data: URIs — tool-call payloads don't survive megabyte-sized
@@ -47,16 +50,16 @@ async function resolveOne(
   // tells the model.
   if (/^data:/i.test(trimmed)) {
     throw new ImageGenError(
-      'Image input as a `data:` URI is not supported. Pass a file path (absolute or relative to cwd) or an http(s) URL instead. If you have raw image bytes, write them to a file under .pi/uploads first and pass that path.',
-      'image input rejected (data: URI)',
+      `${inputLabel} as a \`data:\` URI is not supported. Pass a file path (absolute or relative to cwd) or an http(s) URL instead. If you have raw image bytes, write them to a file under .pi/uploads first and pass that path.`,
+      `${logLabel} rejected (data: URI)`,
     );
   }
   // Heuristic for raw base64: long, only base64 chars. Not foolproof but
   // catches the common case where the model dumps a giant base64 blob.
   if (trimmed.length > 256 && !/[\s/\\]/.test(trimmed) && /^[A-Za-z0-9+/]+={0,2}$/.test(trimmed)) {
     throw new ImageGenError(
-      'Image input looks like a raw base64 blob; this is not supported because it bloats the tool argument. Write the bytes to a file path and pass that path instead.',
-      'image input rejected (raw base64)',
+      `${inputLabel} looks like a raw base64 blob; this is not supported because it bloats the tool argument. Write the bytes to a file path and pass that path instead.`,
+      `${logLabel} rejected (raw base64)`,
     );
   }
 
@@ -68,17 +71,17 @@ async function resolveOne(
     try {
       res = await fetchImpl(trimmed, { signal: signal ?? null });
     } catch (error) {
-      throw describeDownloadError('image input', trimmed, { rejected: error });
+      throw describeDownloadError(logLabel, trimmed, { rejected: error });
     }
     if (!res.ok) {
-      await throwDownloadHttpError('image input', trimmed, res);
+      await throwDownloadHttpError(logLabel, trimmed, res);
     }
     // Body reads can fail after headers; keep them in the sanitized download boundary.
     let buf: Uint8Array;
     try {
       buf = new Uint8Array(await res.arrayBuffer());
     } catch (error) {
-      throw describeDownloadError('image input', trimmed, { rejected: error });
+      throw describeDownloadError(logLabel, trimmed, { rejected: error });
     }
     const mimeType =
       res.headers.get('content-type')?.split(';')[0]?.trim() || sniffMime(buf) || 'image/png';
@@ -95,8 +98,8 @@ async function resolveOne(
     // full path) — both are sensitive and would reach stderr via the plain-Error
     // path. Keep the message body-free, path-free, and actionable.
     throw new ImageGenError(
-      'Image input is not a readable file path or http(s) URL. Pass an absolute path, a path relative to the session cwd, or an http(s) URL.',
-      'image input not readable',
+      `${inputLabel} is not a readable file path or http(s) URL. Pass an absolute path, a path relative to the session cwd, or an http(s) URL.`,
+      `${logLabel} not readable`,
     );
   }
   const mimeType = sniffMime(bytes) ?? extToMime(absolute) ?? 'image/png';

--- a/packages/pi-image-gen/src/index.ts
+++ b/packages/pi-image-gen/src/index.ts
@@ -1,3 +1,4 @@
+import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import {
@@ -6,29 +7,137 @@ import {
   loadImageGenSettings,
   resolveModel,
 } from './config.js';
+import { errorMessageForUser, toLogSummary } from './errors.js';
 import { generateImage } from './generate.js';
-import type { GenerateImageParams, ImageGenResult, ImageGenSettings } from './types.js';
+import type { ApiStyle, GenerateImageParams, ImageGenResult, ImageGenSettings } from './types.js';
 
 export { loadImageGenSettings, resolveModel } from './config.js';
+export { errorMessageForUser, toLogSummary } from './errors.js';
 export { generateImage } from './generate.js';
 export type { GenerateImageParams, ImageGenSettings } from './types.js';
+
+/**
+ * Quality levels advertised for providers whose `quality` vocabulary we have
+ * verified: the built-in OpenAI gpt-image and OpenRouter image APIs. This is
+ * deliberately NOT applied by wire format — a custom OpenAI-compatible provider
+ * may use a different vocabulary (e.g. DALL·E 3 uses "standard"/"hd") or none at
+ * all, so matching `api: "openai"` does not imply these values. See
+ * {@link resolveImageToolCapabilities}.
+ */
+export const QUALITY_VALUES = ['low', 'medium', 'high', 'auto'] as const;
+
+/** Provider-derived shape decisions for the `image_generate` schema. */
+export interface ImageToolCapabilities {
+  /** Active provider wire format, or null when the default model is unset/unresolvable. */
+  api: ApiStyle | null;
+  /** Allowed `quality` enum values, or null to omit `quality` from the schema entirely. */
+  quality: readonly string[] | null;
+}
 
 export default function piImageGenExtension(pi: ExtensionAPI): void {
   let settings: ImageGenSettings = {};
   let sessionCwd = process.cwd();
 
+  // Single generate path shared by the tool's execute() and the /image-gen
+  // generate command, so options construction and signal wiring can't drift
+  // between the two. Callers layer their own result formatting / error surface
+  // on top (a tool result vs. a UI notification).
+  const runGenerate = (
+    params: GenerateImageParams,
+    cwd: string,
+    signal?: AbortSignal,
+  ): Promise<ImageGenResult> => {
+    const opts: Parameters<typeof generateImage>[1] = { cwd, settings };
+    if (signal) opts.signal = signal;
+    return generateImage(params, opts);
+  };
+
+  // Register (or re-register) the tool with a schema shaped for the currently
+  // configured provider. `registerTool` is keyed by name, so a repeat call
+  // overwrites the previous definition — we call this on session_start (once
+  // settings are loaded) and again after `/image-gen reload`, so the parameter
+  // set always reflects the active model. Notably, `quality` only appears for
+  // providers whose API honors it; the model never sees a no-op knob it would
+  // otherwise have to reason about.
+  const registerImageTool = (): void => {
+    const caps = resolveImageToolCapabilities(settings);
+    pi.registerTool({
+      name: 'image_generate',
+      label: 'ImageGen',
+      description:
+        'Generate or edit images. The image model is fixed by pi-image-gen.defaultModel in settings (this tool does not accept a model parameter). Pass `image` to do image-to-image / edit / style transfer / character preservation: a file path (absolute or relative to cwd) or an http(s) URL. To iterate on a previous result, pass its file path back. Do NOT pass base64 or data: URIs — write bytes to a file first. Saves the output to disk and returns the absolute path(s). When reporting the result to the user, render each generated image as inline markdown `![alt](absolute_path)` (the tool result already includes a copy-pasteable line) so the UI can display it; do not just paste the bare path. Run /image-gen list to see the active model.',
+      promptSnippet:
+        'Generate or edit raster images (photos, illustrations, textures, mockups). Not for icons/logos/diagrams that should be repo-native SVG/CSS/canvas.',
+      promptGuidelines: buildImageGuidelines(caps),
+      parameters: buildImageToolParameters(caps) as never,
+      async execute(_toolCallId: string, rawParams: unknown, signal, _onUpdate, ctx) {
+        const params = rawParams as GenerateImageParams;
+        const cwd = ctx?.cwd ?? sessionCwd;
+        try {
+          const result = await runGenerate(params, cwd, signal);
+          return {
+            content: [{ type: 'text' as const, text: formatToolResultText(result) }],
+            details: result,
+          };
+        } catch (error) {
+          // Both surfaces are sanitized (see errors.ts): errorMessageForUser
+          // returns an ImageGenError's vetted, body-free hint (and a generic
+          // sentence for any unexpected throw), while toLogSummary gives stderr a
+          // terse category. Neither echoes a raw fs/fetch error or response body.
+          console.error(`[pi-image-gen] image_generate failed: ${toLogSummary(error)}`);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `image_generate failed: ${errorMessageForUser(error)}`,
+              },
+            ],
+            details: undefined,
+            isError: true,
+          };
+        }
+      },
+    });
+  };
+
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
     sessionCwd = ctx.cwd;
     settings = loadImageGenSettings(ctx.cwd);
+    registerImageTool();
   });
 
   pi.registerCommand('image-gen', {
-    description: 'Inspect pi-image-gen: /image-gen [list|reload]',
+    description: 'pi-image-gen: /image-gen [list|reload|generate <prompt>]',
     handler: async (args: string | undefined, ctx: ExtensionContext) => {
-      const tokens = (args ?? '').trim().split(/\s+/).filter(Boolean);
+      const raw = (args ?? '').trim();
+      const tokens = raw.split(/\s+/).filter(Boolean);
       if (tokens[0] === 'reload') {
         settings = loadImageGenSettings(ctx.cwd);
+        // Re-register so the schema (e.g. whether `quality` is exposed) tracks
+        // the newly loaded model, not just the settings read at execute time.
+        registerImageTool();
         ctx.ui.notify('pi-image-gen settings reloaded.', 'info');
+        return;
+      }
+      if (tokens[0] === 'generate') {
+        const prompt = raw.slice(tokens[0].length).trim();
+        if (!prompt) {
+          ctx.ui.notify('Usage: /image-gen generate <prompt>', 'error');
+          return;
+        }
+        const cwd = ctx.cwd ?? sessionCwd;
+        try {
+          const result = await runGenerate({ prompt }, cwd, ctx.signal);
+          // notify() renders as a plain status line, not markdown — surface a
+          // readable path summary here rather than `![](…)` image syntax (which
+          // would show up literally). The tool path keeps markdown for the LLM.
+          ctx.ui.notify(formatCommandSummary(result), 'info');
+        } catch (error) {
+          // Terse category summary to stderr; the notify surface gets the fuller
+          // (still body-free) sanitized message. See execute() and errors.ts.
+          console.error(`[pi-image-gen] /image-gen generate failed: ${toLogSummary(error)}`);
+          ctx.ui.notify(`image generation failed: ${errorMessageForUser(error)}`, 'error');
+        }
         return;
       }
       const providers = listConfiguredProviders(settings);
@@ -59,7 +168,7 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
               return `  - ${p.id} ${tags.join(' ')}`;
             })
           : [
-              '  (none — set OPENAI_API_KEY / GEMINI_API_KEY / DASHSCOPE_API_KEY / OPENROUTER_API_KEY)',
+              '  (none — set OPENAI_API_KEY / GEMINI_API_KEY / DASHSCOPE_API_KEY / OPENROUTER_API_KEY / ARK_API_KEY)',
             ]),
         '',
         'Built-in models:',
@@ -68,64 +177,129 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
       ctx.ui.notify(lines.join('\n'), 'info');
     },
   });
+}
 
-  pi.registerTool({
-    name: 'image_generate',
-    label: 'ImageGen',
-    description:
-      'Generate or edit images. The image model is fixed by pi-image-gen.defaultModel in settings (this tool does not accept a model parameter). Pass `image` to do image-to-image / edit / style transfer / character preservation: a file path (absolute or relative to cwd) or an http(s) URL. To iterate on a previous result, pass its file path back. Do NOT pass base64 or data: URIs — write bytes to a file first. Saves the output to disk and returns the absolute path(s). When reporting the result to the user, render each generated image as inline markdown `![alt](absolute_path)` (the tool result already includes a copy-pasteable line) so the UI can display it; do not just paste the bare path. Run /image-gen list to see the active model.',
-    parameters: Type.Object({
-      prompt: Type.String({
-        description: 'Text prompt describing what to generate or how to edit.',
+/**
+ * The `low`/`medium`/`high`/`auto` vocabulary is specific to OpenAI's **gpt-image**
+ * family. Other OpenAI-wire models served under the same API use a different
+ * vocabulary — DALL·E 3, for instance, takes `standard`/`hd` — so matching the
+ * wire format (or even the built-in `openai` provider) is not enough; we must
+ * see a gpt-image model id.
+ *
+ * This holds for two routes to gpt-image:
+ *   - the built-in OpenAI provider (remote id `gpt-image-2`), and
+ *   - OpenRouter, whose remote id embeds the underlying model (`openai/gpt-image-2`).
+ *
+ * It deliberately excludes `openai/dall-e-3` (built-in openai, but non-gpt-image)
+ * and OpenRouter routes to non-OpenAI models (`bytedance-seed/seedream-4.5`, …).
+ */
+function honorsGptImageQuality(api: ApiStyle, remoteId: string): boolean {
+  if (api !== 'openai' && api !== 'openrouter') return false;
+  return /(?:^|\/)gpt-image/i.test(remoteId);
+}
+
+/**
+ * Derive the provider-dependent schema shape from settings.
+ *
+ * `quality` is exposed (as a constrained enum) ONLY when the resolved model is a
+ * built-in-routed OpenAI gpt-image model — via the built-in `openai` provider or
+ * OpenRouter (see {@link honorsGptImageQuality}). For everything else — Gemini,
+ * DashScope/Qwen, Ark/Seedream (no such knob), non-gpt-image OpenAI models like
+ * DALL·E 3 (different vocabulary), and any custom provider (unknown vocabulary) —
+ * `quality` is omitted so the model never sees a knob whose legal values we can't
+ * guarantee. When the default model is unset or fails to resolve, we fall back to
+ * the fully-featured schema so the tool stays usable and `execute` can surface a
+ * friendly config error.
+ */
+export function resolveImageToolCapabilities(settings: ImageGenSettings): ImageToolCapabilities {
+  const defaultModel = settings.defaultModel?.trim();
+  if (!defaultModel) return { api: null, quality: QUALITY_VALUES };
+  const resolved = resolveModel(defaultModel, settings);
+  if ('error' in resolved) return { api: null, quality: QUALITY_VALUES };
+  const { provider } = resolved;
+  const quality =
+    provider.builtIn && honorsGptImageQuality(provider.api, resolved.remoteId)
+      ? QUALITY_VALUES
+      : null;
+  return { api: provider.api, quality };
+}
+
+/** Provider-tailored description for the `size` parameter. */
+export function sizeDescription(api: ApiStyle | null): string {
+  if (api === 'ark') {
+    return 'Image size such as "2048x2048". Seedream 5.0 / 5.0-lite / 4.5 require 2K or larger — "1024x1024" fails with InvalidParameter; only Seedream 4.0 accepts 1K sizes.';
+  }
+  return 'Image size hint such as "1024x1024". Provider-specific; ignored if unsupported.';
+}
+
+/**
+ * Build the `image_generate` parameter schema for the resolved capabilities.
+ * The invariant params are always present; `quality` is a constrained string
+ * enum included only when {@link resolveImageToolCapabilities} says the active
+ * provider honors it, and `size` carries a provider-tailored description.
+ */
+export function buildImageToolParameters(caps: ImageToolCapabilities) {
+  return Type.Object({
+    prompt: Type.String({
+      description: 'Text prompt describing what to generate or how to edit.',
+    }),
+    image: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          'Optional reference image(s) for image-to-image / edit / style transfer / character preservation. Each entry MUST be either (a) a file path — absolute or relative to the session cwd — or (b) an http(s) URL. Base64 strings and data: URIs are rejected; write the bytes to a file first if you have raw image data. For a single image pass ["path"]. Multi-image conditioning is supported by OpenAI gpt-image-2, Gemini, and Qwen sync models. To iterate on a previous output, pass that file path here.',
       }),
-      image: Type.Optional(
-        Type.Array(Type.String(), {
-          description:
-            'Optional reference image(s) for image-to-image / edit / style transfer / character preservation. Each entry MUST be either (a) a file path — absolute or relative to the session cwd — or (b) an http(s) URL. Base64 strings and data: URIs are rejected; write the bytes to a file first if you have raw image data. For a single image pass ["path"]. Multi-image conditioning is supported by OpenAI gpt-image-2, Gemini, and Qwen sync models. To iterate on a previous output, pass that file path here.',
-        }),
-      ),
-      n: Type.Optional(
-        Type.Number({
-          minimum: 1,
-          maximum: 8,
-          description: 'Number of images. Default 1 (integer).',
-        }),
-      ),
-      size: Type.Optional(
-        Type.String({
-          description:
-            'Image size hint such as "1024x1024". Provider-specific; ignored if unsupported.',
-        }),
-      ),
-      filename: Type.Optional(Type.String({ description: 'Filename prefix (without extension).' })),
-      outputDir: Type.Optional(
-        Type.String({
-          description:
-            'Directory to write images into. Relative paths resolve against the session cwd.',
-        }),
-      ),
-    }) as never,
-    async execute(_toolCallId: string, rawParams: unknown, signal, _onUpdate, ctx) {
-      const params = rawParams as GenerateImageParams;
-      const cwd = ctx?.cwd ?? sessionCwd;
-      try {
-        const opts: Parameters<typeof generateImage>[1] = { cwd, settings };
-        if (signal) opts.signal = signal;
-        const result = await generateImage(params, opts);
-        return {
-          content: [{ type: 'text' as const, text: formatToolResultText(result) }],
-          details: result,
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-          content: [{ type: 'text' as const, text: `image_generate failed: ${message}` }],
-          details: undefined,
-          isError: true,
-        };
-      }
-    },
+    ),
+    n: Type.Optional(
+      Type.Number({
+        minimum: 1,
+        maximum: 8,
+        description: 'Number of images. Default 1 (integer).',
+      }),
+    ),
+    size: Type.Optional(Type.String({ description: sizeDescription(caps.api) })),
+    ...(caps.quality
+      ? {
+          quality: Type.Optional(
+            StringEnum(caps.quality, {
+              description:
+                'Quality level honored by the active provider (OpenAI gpt-image / OpenRouter): "low" for fast drafts/thumbnails, "medium", "high" for final assets or dense text, or "auto".',
+            }),
+          ),
+        }
+      : {}),
+    filename: Type.Optional(Type.String({ description: 'Filename prefix (without extension).' })),
+    outputDir: Type.Optional(
+      Type.String({
+        description:
+          'Directory to write images into. Relative paths resolve against the session cwd.',
+      }),
+    ),
   });
+}
+
+/**
+ * Build the tool's prompt guidelines for the resolved capabilities. Most bullets
+ * are provider-independent; the `quality` tip is included only when the schema
+ * actually exposes a `quality` param, so guidance never references a knob the
+ * model cannot use.
+ */
+export function buildImageGuidelines(caps: ImageToolCapabilities): string[] {
+  const guidelines = [
+    'Use image_generate for bitmap assets: photos, illustrations, textures, sprites, product/UI mockups, concept art. Do NOT use it for icons, logos, or diagrams that should match existing repo-native SVG/vector/CSS/canvas assets — edit or write those directly instead.',
+    'Generate vs edit: with no `image`, or when `image` entries are only style/composition/mood references, this is a fresh generation. To modify an existing image while preserving most of it, pass that image and describe the change as an edit.',
+    '`n` produces variants of ONE prompt, not distinct assets. For several different assets, make one image_generate call per asset with its own prompt (do not raise `n` to cover distinct subjects).',
+    'For edits and multi-image conditioning, label each reference by role (e.g. "Image 1: edit target; Image 2: style reference") and restate invariants every iteration ("change only X; keep Y unchanged") to reduce drift.',
+    'For text inside an image, quote the exact string verbatim and specify placement; spell uncommon words letter-by-letter when accuracy matters.',
+  ];
+  guidelines.push(
+    caps.quality
+      ? 'Prefer one targeted change per iteration over rewriting the whole prompt. Use `quality: "low"` for fast drafts and a higher `quality` for final assets or dense text.'
+      : 'Prefer one targeted change per iteration over rewriting the whole prompt.',
+  );
+  guidelines.push(
+    'The active model is fixed in settings — there is no `model` parameter. If generation fails on model/size, run /image-gen list and tell the user which knob (defaultModel or size) to adjust.',
+  );
+  return guidelines;
 }
 
 /**
@@ -143,6 +317,22 @@ export function formatToolResultText(result: ImageGenResult): string {
     }),
   ];
   return lines.join('\n');
+}
+
+/**
+ * Format a generated-image result as a plain-text summary for `ctx.ui.notify`,
+ * which renders a status line rather than markdown. Lists the saved absolute
+ * paths (and any revised prompt) without `![](…)` syntax, which notify would
+ * otherwise show literally.
+ */
+export function formatCommandSummary(result: ImageGenResult): string {
+  const header = `Generated ${result.images.length} image(s) via ${result.provider} (${result.model}):`;
+  const lines = result.images.flatMap((img) =>
+    img.revisedPrompt
+      ? [`  ${img.path}`, `    revised prompt: ${img.revisedPrompt}`]
+      : [`  ${img.path}`],
+  );
+  return [header, ...lines].join('\n');
 }
 
 /**

--- a/packages/pi-image-gen/src/providers/ark.ts
+++ b/packages/pi-image-gen/src/providers/ark.ts
@@ -1,4 +1,4 @@
-import { describeNetworkError } from '../errors.js';
+import { describeNetworkError, missingKeyError } from '../errors.js';
 import { toDataUri } from '../image-input.js';
 import type {
   GenerateImageParams,
@@ -32,7 +32,7 @@ export const arkAdapter: ImageProviderAdapter = {
     inputs?: ResolvedImageInput[],
   ): Promise<RawImageResult[]> {
     if (!provider.apiKey) {
-      throw new Error(missingKeyMessage(provider));
+      throw missingKeyError(provider);
     }
     const base = withDefaultPath(provider.baseUrl, '/api/v3');
     const url = `${base}/images/generations`;
@@ -42,6 +42,9 @@ export const arkAdapter: ImageProviderAdapter = {
       n: params.n ?? 1,
     };
     if (params.size) body.size = params.size;
+    // Seedream sizing is driven by `size` resolution tiers (1K/2K/4K), not an
+    // OpenAI-style `quality` knob — forwarding `quality` here risks a 400, so we
+    // intentionally drop it. See README provider table.
     if (inputs && inputs.length > 0) {
       body.image = inputs.map((input) => toDataUri(input));
     }
@@ -55,15 +58,8 @@ export const arkAdapter: ImageProviderAdapter = {
         signal: signal ?? null,
       });
     } catch (error) {
-      throw new Error(describeNetworkError(error, provider));
+      throw describeNetworkError(error, provider);
     }
     return parseImagesResponse(res, url, provider);
   },
 };
-
-function missingKeyMessage(provider: ResolvedProvider): string {
-  if (provider.builtIn) {
-    return `Provider "${provider.id}" has no API key. Tell the user to set ARK_API_KEY (or pi-image-gen.providers.${provider.id}.apiKey in settings.json).`;
-  }
-  return `Provider "${provider.id}" has no API key. Tell the user to set pi-image-gen.customProviders.${provider.id}.apiKey in settings.json.`;
-}

--- a/packages/pi-image-gen/src/providers/dashscope.ts
+++ b/packages/pi-image-gen/src/providers/dashscope.ts
@@ -1,4 +1,11 @@
-import { classifyHttpError, describeNetworkError } from '../errors.js';
+import {
+  describeNetworkError,
+  ImageGenError,
+  missingKeyError,
+  providerLogLabel,
+  readBodyText,
+  throwHttpError,
+} from '../errors.js';
 import { classifyImageOutput, toDataUri } from '../image-input.js';
 import type {
   GenerateImageParams,
@@ -28,7 +35,7 @@ export const dashscopeAdapter: ImageProviderAdapter = {
     inputs?: ResolvedImageInput[],
   ): Promise<RawImageResult[]> {
     if (!provider.apiKey) {
-      throw new Error(missingKeyMessage(provider));
+      throw missingKeyError(provider);
     }
     const base = withDefaultPath(provider.baseUrl, '/api/v1');
     const headers: Record<string, string> = {
@@ -59,12 +66,14 @@ export const dashscopeAdapter: ImageProviderAdapter = {
         signal: signal ?? null,
       });
     } catch (error) {
-      throw new Error(describeNetworkError(error, provider));
+      throw describeNetworkError(error, provider);
     }
-    const text = await safeText(res);
+    // Status first (body-free), then read: a broken/cancelled body is classified
+    // as a network failure rather than swallowed and misreported as invalid JSON.
     if (!res.ok) {
-      throw new Error(classifyHttpError(res, text, provider));
+      await throwHttpError(res, provider);
     }
+    const text = await readBodyText(res, provider);
     let json: {
       output?: {
         choices?: Array<{
@@ -80,8 +89,10 @@ export const dashscopeAdapter: ImageProviderAdapter = {
     };
     try {
       json = JSON.parse(text);
-    } catch (error) {
-      throw new Error(`${provider.name} returned invalid JSON: ${(error as Error).message}`);
+    } catch {
+      // The parse error message echoes response bytes, so it's dropped entirely.
+      const detail = `${provider.name} returned invalid JSON.`;
+      throw new ImageGenError(detail, `${providerLogLabel(provider)} returned invalid JSON`);
     }
     const out: RawImageResult[] = [];
     for (const choice of json.output?.choices ?? []) {
@@ -93,25 +104,10 @@ export const dashscopeAdapter: ImageProviderAdapter = {
       }
     }
     if (out.length === 0) {
-      throw new Error(
-        `${provider.name} returned no images. The model may have refused the prompt or the response shape changed. Raw: ${text.slice(0, 300).replace(/\s+/g, ' ')}`,
-      );
+      // Drop the raw body ("Raw: …") — it may echo the prompt or provider internals.
+      const detail = `${provider.name} returned no images. The model may have refused the prompt or the response shape changed.`;
+      throw new ImageGenError(detail, `${providerLogLabel(provider)} returned no images`);
     }
     return out;
   },
 };
-
-function missingKeyMessage(provider: ResolvedProvider): string {
-  if (provider.builtIn) {
-    return `Provider "${provider.id}" has no API key. Tell the user to set DASHSCOPE_API_KEY (or pi-image-gen.providers.${provider.id}.apiKey in settings.json).`;
-  }
-  return `Provider "${provider.id}" has no API key. Tell the user to set pi-image-gen.customProviders.${provider.id}.apiKey in settings.json.`;
-}
-
-async function safeText(res: Response): Promise<string> {
-  try {
-    return await res.text();
-  } catch {
-    return '<unreadable response body>';
-  }
-}

--- a/packages/pi-image-gen/src/providers/gemini.ts
+++ b/packages/pi-image-gen/src/providers/gemini.ts
@@ -1,4 +1,11 @@
-import { classifyHttpError, describeNetworkError } from '../errors.js';
+import {
+  describeNetworkError,
+  ImageGenError,
+  missingKeyError,
+  providerLogLabel,
+  readBodyText,
+  throwHttpError,
+} from '../errors.js';
 import type {
   GenerateImageParams,
   ImageProviderAdapter,
@@ -25,7 +32,7 @@ export const geminiAdapter: ImageProviderAdapter = {
     inputs?: ResolvedImageInput[],
   ): Promise<RawImageResult[]> {
     if (!provider.apiKey) {
-      throw new Error(missingKeyMessage(provider));
+      throw missingKeyError(provider);
     }
     const base = withDefaultPath(provider.baseUrl, '/v1beta');
     const url = `${base}/models/${encodeURIComponent(remoteModelId)}:generateContent`;
@@ -68,12 +75,14 @@ export const geminiAdapter: ImageProviderAdapter = {
         signal: signal ?? null,
       });
     } catch (error) {
-      throw new Error(describeNetworkError(error, provider));
+      throw describeNetworkError(error, provider);
     }
-    const text = await safeText(res);
+    // Status first (body-free), then read: a broken/cancelled body is classified
+    // as a network failure rather than swallowed and misreported as invalid JSON.
     if (!res.ok) {
-      throw new Error(classifyHttpError(res, text, provider));
+      await throwHttpError(res, provider);
     }
+    const text = await readBodyText(res, provider);
     let json: {
       candidates?: Array<{
         content?: {
@@ -86,8 +95,10 @@ export const geminiAdapter: ImageProviderAdapter = {
     };
     try {
       json = JSON.parse(text);
-    } catch (error) {
-      throw new Error(`${provider.name} returned invalid JSON: ${(error as Error).message}`);
+    } catch {
+      // The parse error message echoes response bytes, so it's dropped entirely.
+      const detail = `${provider.name} returned invalid JSON.`;
+      throw new ImageGenError(detail, `${providerLogLabel(provider)} returned invalid JSON`);
     }
 
     const out: RawImageResult[] = [];
@@ -113,25 +124,9 @@ export const geminiAdapter: ImageProviderAdapter = {
       }
     }
     if (out.length === 0) {
-      throw new Error(
-        `${provider.name} returned no image data — the model may have refused to generate. Tell the user to rephrase the prompt or try a different model.`,
-      );
+      const detail = `${provider.name} returned no image data — the model may have refused to generate. Tell the user to rephrase the prompt or try a different model.`;
+      throw new ImageGenError(detail, `${providerLogLabel(provider)} returned no image data`);
     }
     return out;
   },
 };
-
-function missingKeyMessage(provider: ResolvedProvider): string {
-  if (provider.builtIn) {
-    return `Provider "${provider.id}" has no API key. Tell the user to set GEMINI_API_KEY (or pi-image-gen.providers.${provider.id}.apiKey in settings.json).`;
-  }
-  return `Provider "${provider.id}" has no API key. Tell the user to set pi-image-gen.customProviders.${provider.id}.apiKey in settings.json.`;
-}
-
-async function safeText(res: Response): Promise<string> {
-  try {
-    return await res.text();
-  } catch {
-    return '<unreadable response body>';
-  }
-}

--- a/packages/pi-image-gen/src/providers/index.ts
+++ b/packages/pi-image-gen/src/providers/index.ts
@@ -1,3 +1,4 @@
+import { ImageGenError } from '../errors.js';
 import type { ApiStyle, ImageProviderAdapter } from '../types.js';
 import { arkAdapter } from './ark.js';
 import { dashscopeAdapter } from './dashscope.js';
@@ -15,6 +16,6 @@ const ADAPTERS: Record<ApiStyle, ImageProviderAdapter> = {
 
 export function getAdapter(api: ApiStyle): ImageProviderAdapter {
   const adapter = ADAPTERS[api];
-  if (!adapter) throw new Error(`Unsupported api "${api}".`);
+  if (!adapter) throw new ImageGenError(`Unsupported api "${api}".`, `unsupported api "${api}"`);
   return adapter;
 }

--- a/packages/pi-image-gen/src/providers/openai.ts
+++ b/packages/pi-image-gen/src/providers/openai.ts
@@ -1,4 +1,12 @@
-import { classifyHttpError, describeNetworkError } from '../errors.js';
+import {
+  describeNetworkError,
+  ImageGenError,
+  missingKeyError,
+  providerLogLabel,
+  readBodyText,
+  redactUrl,
+  throwHttpError,
+} from '../errors.js';
 import { classifyImageOutput, sniffMime } from '../image-input.js';
 import type {
   GenerateImageParams,
@@ -40,7 +48,7 @@ export const openaiAdapter: ImageProviderAdapter = {
     inputs?: ResolvedImageInput[],
   ): Promise<RawImageResult[]> {
     if (!provider.apiKey) {
-      throw new Error(missingKeyMessage(provider));
+      throw missingKeyError(provider);
     }
     const base = withDefaultPath(provider.baseUrl, '/v1');
     if (inputs && inputs.length > 0) {
@@ -54,7 +62,7 @@ async function generateFromText(
   provider: ResolvedProvider,
   base: string,
   remoteModelId: string,
-  params: { prompt: string; n?: number; size?: string },
+  params: { prompt: string; n?: number; size?: string; quality?: string },
   fetchImpl: typeof fetch,
   signal?: AbortSignal,
 ): Promise<RawImageResult[]> {
@@ -65,6 +73,7 @@ async function generateFromText(
     n: params.n ?? 1,
   };
   if (params.size) body.size = params.size;
+  if (params.quality) body.quality = params.quality;
 
   let res: Response;
   try {
@@ -75,7 +84,7 @@ async function generateFromText(
       signal: signal ?? null,
     });
   } catch (error) {
-    throw new Error(describeNetworkError(error, provider));
+    throw describeNetworkError(error, provider);
   }
   return parseImagesResponse(res, url, provider);
 }
@@ -84,7 +93,7 @@ async function generateWithImages(
   provider: ResolvedProvider,
   base: string,
   remoteModelId: string,
-  params: { prompt: string; n?: number; size?: string },
+  params: { prompt: string; n?: number; size?: string; quality?: string },
   inputs: ResolvedImageInput[],
   fetchImpl: typeof fetch,
   signal?: AbortSignal,
@@ -95,6 +104,7 @@ async function generateWithImages(
   form.append('prompt', params.prompt);
   form.append('n', String(params.n ?? 1));
   if (params.size) form.append('size', params.size);
+  if (params.quality) form.append('quality', params.quality);
   // OpenAI accepts repeated `image[]` for multi-image edits on gpt-image-2.
   const fieldName = inputs.length > 1 ? 'image[]' : 'image';
   for (const [i, input] of inputs.entries()) {
@@ -112,7 +122,7 @@ async function generateWithImages(
       signal: signal ?? null,
     });
   } catch (error) {
-    throw new Error(describeNetworkError(error, provider));
+    throw describeNetworkError(error, provider);
   }
   return parseImagesResponse(res, url, provider);
 }
@@ -122,24 +132,29 @@ export async function parseImagesResponse(
   url: string,
   provider: ResolvedProvider,
 ): Promise<RawImageResult[]> {
-  const text = await safeText(res);
+  // Check status BEFORE reading the body: an HTTP error is classified by status
+  // (body-free), and a body that breaks mid-read is classified as a network
+  // failure rather than swallowed and misreported as "invalid JSON".
   if (!res.ok) {
-    throw new Error(classifyHttpError(res, text, provider));
+    await throwHttpError(res, provider);
   }
+  const text = await readBodyText(res, provider);
   const contentType = res.headers.get('content-type') ?? '';
   if (!contentType.includes('json')) {
-    const preview = text.slice(0, 200).replace(/\s+/g, ' ');
-    throw new Error(
-      `${provider.name} returned ${contentType || 'non-JSON'} from ${url}. The endpoint probably doesn't expose the OpenAI-compatible images API at this path. Body: ${preview}`,
-    );
+    // The raw body may carry credentials / another tenant's data — never
+    // interpolate it; `redactUrl(url)` drops any signed query on the endpoint.
+    const detail = `${provider.name} returned ${contentType || 'non-JSON'} from ${redactUrl(url)}. The endpoint probably doesn't expose the OpenAI-compatible images API at this path.`;
+    throw new ImageGenError(detail, `${providerLogLabel(provider)} returned non-JSON`);
   }
   let json: {
     data?: Array<{ url?: string; b64_json?: string; revised_prompt?: string; media_type?: string }>;
   };
   try {
     json = JSON.parse(text);
-  } catch (error) {
-    throw new Error(`${provider.name} returned invalid JSON: ${(error as Error).message}`);
+  } catch {
+    // The parse error message echoes response bytes, so it's dropped entirely.
+    const detail = `${provider.name} returned invalid JSON.`;
+    throw new ImageGenError(detail, `${providerLogLabel(provider)} returned invalid JSON`);
   }
   const data = json.data ?? [];
   const out: RawImageResult[] = [];
@@ -162,24 +177,9 @@ export async function parseImagesResponse(
     out.push(item);
   }
   if (out.length === 0) {
-    throw new Error(
-      `${provider.name} returned no usable images. Response had ${data.length} entries but none had b64_json or a valid url. Raw: ${text.slice(0, 300).replace(/\s+/g, ' ')}`,
-    );
+    // Entry count is safe metadata; the raw body ("Raw: …") is not — drop it.
+    const detail = `${provider.name} returned no usable images. Response had ${data.length} entries but none had b64_json or a valid url.`;
+    throw new ImageGenError(detail, `${providerLogLabel(provider)} returned no usable images`);
   }
   return out;
-}
-
-export function missingKeyMessage(provider: ResolvedProvider): string {
-  if (provider.builtIn) {
-    return `Provider "${provider.id}" has no API key. Tell the user to set OPENAI_API_KEY (or pi-image-gen.providers.${provider.id}.apiKey in settings.json).`;
-  }
-  return `Provider "${provider.id}" has no API key. Tell the user to set pi-image-gen.customProviders.${provider.id}.apiKey in settings.json.`;
-}
-
-async function safeText(res: Response): Promise<string> {
-  try {
-    return await res.text();
-  } catch {
-    return '<unreadable response body>';
-  }
 }

--- a/packages/pi-image-gen/src/providers/openrouter.ts
+++ b/packages/pi-image-gen/src/providers/openrouter.ts
@@ -1,4 +1,4 @@
-import { describeNetworkError } from '../errors.js';
+import { describeNetworkError, missingKeyError } from '../errors.js';
 import { toDataUri } from '../image-input.js';
 import type {
   GenerateImageParams,
@@ -8,7 +8,7 @@ import type {
   ResolvedProvider,
 } from '../types.js';
 import { withDefaultPath } from '../url.js';
-import { bearerHeaders, missingKeyMessage, parseImagesResponse } from './openai.js';
+import { bearerHeaders, parseImagesResponse } from './openai.js';
 
 /**
  * OpenRouter image API. Looks OpenAI-shaped but the endpoint differs:
@@ -27,7 +27,7 @@ export const openrouterAdapter: ImageProviderAdapter = {
     signal?: AbortSignal,
     inputs?: ResolvedImageInput[],
   ): Promise<RawImageResult[]> {
-    if (!provider.apiKey) throw new Error(missingKeyMessage(provider));
+    if (!provider.apiKey) throw missingKeyError(provider);
     const base = withDefaultPath(provider.baseUrl, '/api/v1');
     const url = `${base}/images`;
     const body: Record<string, unknown> = {
@@ -36,6 +36,7 @@ export const openrouterAdapter: ImageProviderAdapter = {
       n: params.n ?? 1,
     };
     if (params.size) body.size = params.size;
+    if (params.quality) body.quality = params.quality;
     if (inputs && inputs.length > 0) {
       body.input_references = inputs.map((input) => ({
         image_url: { url: toDataUri(input) },
@@ -51,7 +52,7 @@ export const openrouterAdapter: ImageProviderAdapter = {
         signal: signal ?? null,
       });
     } catch (error) {
-      throw new Error(describeNetworkError(error, provider));
+      throw describeNetworkError(error, provider);
     }
     return parseImagesResponse(res, url, provider);
   },

--- a/packages/pi-image-gen/src/types.ts
+++ b/packages/pi-image-gen/src/types.ts
@@ -76,6 +76,12 @@ export type GenerateImageParams = {
   n?: number;
   /** Image size hint (e.g. "1024x1024"). Provider may ignore. */
   size?: string;
+  /**
+   * Quality hint (e.g. "low" | "medium" | "high" | "auto" for OpenAI gpt-image).
+   * Provider-specific: forwarded on OpenAI-shaped providers, ignored by adapters
+   * that don't expose a quality knob.
+   */
+  quality?: string;
   /** Output filename prefix. */
   filename?: string;
   /** Override settings.outputDir for this call. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,9 +162,12 @@ importers:
         specifier: workspace:*
         version: link:../shared
     devDependencies:
+      '@earendil-works/pi-ai':
+        specifier: 0.80.10
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       typebox:
         specifier: '*'
         version: 1.1.38

--- a/tests/extension-e2e.test.ts
+++ b/tests/extension-e2e.test.ts
@@ -149,9 +149,18 @@ describe('Extension E2E loading via jiti', () => {
     expect(ext.tools.has('notify')).toBe(true);
   });
 
-  it('pi-image-gen: registers /image-gen command and image_generate tool', async () => {
+  it('pi-image-gen: registers /image-gen command, and image_generate tool after session_start', async () => {
     const { ext } = await loadExtensionWithJiti('pi-image-gen');
     expect(ext.commands.has('image-gen')).toBe(true);
+    // The tool registers inside session_start: its schema is shaped for the
+    // provider resolved from just-loaded settings (e.g. quality is exposed only
+    // for OpenAI/OpenRouter), so it can't be built at factory time.
+    const handler = ext.handlers.get('session_start')?.[0] as (
+      event: unknown,
+      ctx: unknown,
+    ) => Promise<void>;
+    expect(handler).toBeDefined();
+    await handler({}, { cwd: process.cwd() });
     expect(ext.tools.has('image_generate')).toBe(true);
   });
 

--- a/tests/extension-loading.test.ts
+++ b/tests/extension-loading.test.ts
@@ -226,12 +226,20 @@ describe('Extension loading contract', () => {
   });
 
   describe('pi-image-gen registrations', () => {
-    it('registers /image-gen command and image_generate tool at top level', async () => {
+    it('registers /image-gen command at top level and image_generate tool after session_start', async () => {
       const factory = await loadExtension('pi-image-gen');
       const pi = createMockExtensionAPI();
       // biome-ignore lint/suspicious/noExplicitAny: mock API
       factory(pi as any);
       expect(commandsRegistered(pi)).toContain('image-gen');
+      // The tool registers inside session_start so its schema can be shaped for
+      // the provider resolved from just-loaded settings (see pi-web-access).
+      expect(eventsRegistered(pi)).toContain('session_start');
+      const sessionStartHandler = pi.on.mock.calls.find(
+        (c: unknown[]) => c[0] === 'session_start',
+      )?.[1] as (...args: unknown[]) => Promise<void>;
+      expect(sessionStartHandler).toBeDefined();
+      await sessionStartHandler({ type: 'session_start', reason: 'startup' }, { cwd: process.cwd() });
       expect(toolsRegistered(pi)).toContain('image_generate');
     });
   });


### PR DESCRIPTION
## Summary

- Harden `pi-image-gen` with provider-aware tool schemas, safer input/output handling, non-destructive atomic filenames, clearer provider errors, a direct generation command, and a bundled image-generation skill.
- Make macOS `pi-computer-use` startup lazy and session-owned while keeping Linux and Windows eager, and separate caller cancellation from shared connection, reconnect, and permission work.
- Expand package and integration coverage for provider routing, failures, concurrent writes, cancellation, reconnects, permissions, and extension loading.

## Why

Image generation previously exposed parameters that were not valid for every provider, could overwrite an existing output path, and surfaced several provider/configuration failures without enough actionable context. The computer-use lifecycle also allowed individual tool cancellation to interfere with shared driver startup or reconnect work on macOS.

This change aligns the image tool contract with the active provider and makes shared computer-use initialization belong to the session rather than whichever tool call happened to start it.

## Impact

- Image generation preserves existing files, exposes only supported options, reloads its schema with settings, and ships stronger model-facing guidance.
- macOS registers its pinned tool manifest without launching the driver until first use; the first permission probe is coalesced and session-owned.
- Cancelling one computer-use caller stops only that caller's wait or MCP request. Session shutdown aborts shared work and closes the owned client.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @amaster.ai/pi-image-gen build`
- `pnpm --filter @amaster.ai/pi-image-gen typecheck`
- `pnpm --filter @amaster.ai/pi-image-gen test` — 134 tests
- `pnpm --filter @amaster.ai/pi-computer-use build`
- `pnpm --filter @amaster.ai/pi-computer-use typecheck`
- `pnpm --filter @amaster.ai/pi-computer-use test` — 42 tests
- `pnpm vitest run tests/extension-e2e.test.ts tests/extension-loading.test.ts` — 97 tests
- `pnpm lint`

All checks passed locally. The checkout emitted the existing engine warning because local Node is v22.22.3 while the repository declares Node >=24.