### PR TITLE
fix(pi-browser-use): support host Node runtime

### DIFF
--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -27,6 +27,8 @@ Requires Node.js `^20.19.0 || ^22.12.0 || >=23`, Chrome (stable or newer), and `
 
 `chrome-devtools-mcp` is a compatible runtime dependency and its installed entrypoint is resolved when the extension module loads. A missing or malformed installation fails extension loading immediately; the extension does not download a replacement at connection time. Connection failures expose only allowlisted system error codes or Chrome startup categories, not raw subprocess stderr.
 
+Hosts where `process.execPath` is not a directly executable Node runtime can set `PI_BROWSER_USE_NODE` to the Node command used for the MCP subprocess.
+
 ## Usage
 
 ### As pi-coding-agent Extension (Recommended)

--- a/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
+++ b/packages/pi-browser-use/src/__tests__/devtools-client.test.ts
@@ -91,7 +91,9 @@ describe('DevToolsClient', () => {
 
     it('uses the installed chrome-devtools-mcp entrypoint when PATH has no npx', async () => {
       const originalPath = process.env.PATH;
+      const originalNode = process.env.PI_BROWSER_USE_NODE;
       process.env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+      delete process.env.PI_BROWSER_USE_NODE;
       try {
         const client = new DevToolsClient({ headless: true });
         await client.connect();
@@ -103,6 +105,30 @@ describe('DevToolsClient', () => {
         expect(mockTransports[0]!.opts!.args).not.toContain('chrome-devtools-mcp@latest');
       } finally {
         process.env.PATH = originalPath;
+        if (originalNode === undefined) {
+          delete process.env.PI_BROWSER_USE_NODE;
+        } else {
+          process.env.PI_BROWSER_USE_NODE = originalNode;
+        }
+      }
+    });
+
+    it('uses the host-provided Node command when available', async () => {
+      const originalNode = process.env.PI_BROWSER_USE_NODE;
+      process.env.PI_BROWSER_USE_NODE = '/opt/pi-browser-use/node';
+      try {
+        const client = new DevToolsClient();
+        await client.connect();
+
+        expect(mockTransports[0]!.opts).toMatchObject({
+          command: '/opt/pi-browser-use/node',
+        });
+      } finally {
+        if (originalNode === undefined) {
+          delete process.env.PI_BROWSER_USE_NODE;
+        } else {
+          process.env.PI_BROWSER_USE_NODE = originalNode;
+        }
       }
     });
 

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -156,7 +156,7 @@ export class DevToolsClient {
     const generation = ++this.generation;
 
     const transport = new StdioClientTransport({
-      command: process.execPath,
+      command: process.env.PI_BROWSER_USE_NODE?.trim() || process.execPath,
       args: [CHROME_DEVTOOLS_MCP_ENTRYPOINT, ...args],
       stderr: 'pipe',
     });


### PR DESCRIPTION
## Summary

- allow hosts to override the Node command used to launch `chrome-devtools-mcp` with `PI_BROWSER_USE_NODE`
- retain `process.execPath` as the default for normal Node/CLI hosts
- document the host runtime contract and cover both override and fallback behavior

## Why

`pi-browser-use` owns a long-lived stdio MCP subprocess. In hosts where `process.execPath` is not a directly executable Node runtime, hard-coding it prevents the MCP server from starting correctly. Host-specific runtime details should remain outside the extension, so the extension now accepts a directly executable Node command without referencing Electron or other host implementations.

## Impact

Normal pi-coding-agent usage is unchanged. Desktop or embedded hosts can provide their own Node launcher through `PI_BROWSER_USE_NODE`.

## Validation

- `pnpm test` — 83 files, 1223 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- post-implementation Standards and Spec reviews passed with no findings