### PR TITLE
fix: honor project trust in shared settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,8 @@ This monorepo uses two npm scopes: `@earendil-works/*` for the Pi runtime core p
 import {
   resolveHome,        // ~/.pi/agent (data dir: memories, skills, logs)
   resolveConfigDir,   // config dir (settings.json, policy, auth, models)
-  loadPiSettings,     // load extension config (merges global < agentDir < project)
+  isProjectTrusted,   // fail-closed adapter for ctx.isProjectTrusted()
+  loadPiSettings,     // load extension config (merges global < agentDir < trusted project)
   loadPiPolicyProfiles,
 } from '@amaster.ai/pi-shared/settings';
 ```
@@ -182,9 +183,14 @@ import {
 `loadPiSettings<T>(key, options?)` merges config from three layers (low → high priority):
 1. Global: `~/.pi/agent/settings.json`
 2. Agent dir: `$PI_CODING_AGENT_DIR/settings.json`
-3. Project: `<cwd>/.pi/settings.json`
+3. Trusted project: `<cwd>/.pi/settings.json`
 
-Supports `${ENV_VAR:-fallback}` interpolation in values.
+Extensions must pass `projectTrusted: isProjectTrusted(ctx)` when loading from an
+extension context. If trust is absent or declined, project settings and policies
+are ignored. `${ENV_VAR:-fallback}` interpolation applies only to global and
+agent-dir settings, never to project settings. Loaders may opt into bare
+`$ENV_VAR` compatibility with `expandBareEnvVars`; bare references do not support
+the `:-fallback` form.
 
 ---
 
@@ -299,7 +305,7 @@ Rules:
 ## Security / Secrets
 
 - Never log tokens, API keys, cookies, or full user message content
-- Never embed secrets in source — use env vars and `loadPiSettings` with `${ENV_VAR}` interpolation
+- Never embed secrets in source — use env vars and user/agent-dir `loadPiSettings` values with `${ENV_VAR}` interpolation (or `$ENV_VAR` only where the loader documents support)
 - Error messages exposed to users must not leak internal secrets or full stack traces
 - When reading config that may contain credentials, validate early and fail clearly rather than passing bad values downstream
 - Enforcement: no automated pre-commit hook currently — relies on code review. Reviewers should check for: raw error objects passed to `console.error`, response bodies logged verbatim, secrets in string interpolation, and stack traces reaching tool results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,8 +165,7 @@ This monorepo uses two npm scopes: `@earendil-works/*` for the Pi runtime core p
 import {
   resolveHome,        // ~/.pi/agent (data dir: memories, skills, logs)
   resolveConfigDir,   // config dir (settings.json, policy, auth, models)
-  isProjectTrusted,   // fail-closed adapter for ctx.isProjectTrusted()
-  loadPiSettings,     // load extension config (merges global < agentDir < trusted project)
+  loadPiSettings,     // load extension config (merges global < agentDir < project)
   loadPiPolicyProfiles,
 } from '@amaster.ai/pi-shared/settings';
 ```
@@ -185,12 +184,7 @@ import {
 2. Agent dir: `$PI_CODING_AGENT_DIR/settings.json`
 3. Trusted project: `<cwd>/.pi/settings.json`
 
-Extensions must pass `projectTrusted: isProjectTrusted(ctx)` when loading from an
-extension context. If trust is absent or declined, project settings and policies
-are ignored. `${ENV_VAR:-fallback}` interpolation applies only to global and
-agent-dir settings, never to project settings. Loaders may opt into bare
-`$ENV_VAR` compatibility with `expandBareEnvVars`; bare references do not support
-the `:-fallback` form.
+Extensions must pass `projectTrusted: isProjectTrusted(ctx)` when loading from an extension context. If trust is absent or declined, project settings and policies are ignored. `${ENV_VAR:-fallback}` interpolation applies only to global and agent-dir settings, never to project settings. Loaders may opt into bare `$ENV_VAR` compatibility with `expandBareEnvVars`; bare references do not support the `:-fallback` form.
 
 ---
 

--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -41,6 +41,9 @@ bun add @amaster.ai/pi-browser-use
 
 Configure via `.pi/settings.json` (project-level) or `~/.pi/agent/settings.json` (user-level) under the `"pi-browser-use"` key:
 
+Project settings are loaded only after project trust is accepted. `${ENV_VAR}`
+interpolation is supported in user and agent settings, but not in project settings.
+
 ```json
 {
   "pi-browser-use": {

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -1,6 +1,10 @@
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
-import { loadPiSettings, type PiSettingsOptions } from '@amaster.ai/pi-shared/settings';
+import {
+  isProjectTrusted,
+  loadPiSettings,
+  type PiSettingsOptions,
+} from '@amaster.ai/pi-shared/settings';
 import type { TextContent as AiTextContent } from '@earendil-works/pi-ai';
 import { complete } from '@earendil-works/pi-ai/compat';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
@@ -331,7 +335,7 @@ export class DevToolsClient {
   }
 }
 
-/** Read the pi-browser-use section from .pi/settings.json. */
+/** Read pi-browser-use settings, including the project layer only when trusted. */
 function loadConfigFromFile(options?: PiSettingsOptions): BrowserUseConfig {
   return loadPiSettings<BrowserUseConfig>('pi-browser-use', {
     ...options,
@@ -559,7 +563,12 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
   }
 
   pi.on('session_start', async (_event, ctx) => {
-    config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
+    config = resolveConfig(
+      loadConfigFromFile({
+        cwd: ctx.cwd,
+        projectTrusted: isProjectTrusted(ctx),
+      }),
+    );
     client = new DevToolsClient(config);
     await registerUpstreamTools();
     if (config.visionModel) {

--- a/packages/pi-channels/README.md
+++ b/packages/pi-channels/README.md
@@ -14,6 +14,15 @@ namespace and Slack/Telegram dependencies. This package keeps the same channel
 contract while targeting this repo's `@earendil-works/*` API surface and native
 Feishu/DingTalk/WeCom adapters.
 
+## Configuration
+
+Put the `pi-channels` section in `~/.pi/agent/settings.json`, the configured
+agent directory's `settings.json`, or a project/ancestor `.pi/settings.json`.
+Project-local files are read only after project trust is accepted. `${ENV_VAR}`
+interpolation is supported only in user and agent settings, not in project-local
+files. The direct credential environment variables documented in the examples
+still override loaded adapter values.
+
 ## Channels
 
 - `feishu` - Native Feishu/Lark app messaging backed by the official
@@ -29,6 +38,10 @@ Feishu/DingTalk/WeCom adapters.
 - `webhook` - Generic outgoing HTTP requests.
 
 ## Example
+
+The `${...}` placeholders below assume this section is stored in user or agent
+settings. For trusted project settings, use the corresponding direct credential
+environment variables or literal non-secret values.
 
 ```json
 {

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -51,7 +51,7 @@
     "test": "vitest run src"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "devDependencies": {

--- a/packages/pi-channels/src/__tests__/config.test.ts
+++ b/packages/pi-channels/src/__tests__/config.test.ts
@@ -1,8 +1,8 @@
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { loadChannelConfig } from '../config.js';
+import { loadChannelConfig, updateLocalChannelConfig } from '../config.js';
 
 describe('loadChannelConfig', () => {
   let base: string;
@@ -44,7 +44,7 @@ describe('loadChannelConfig', () => {
       }),
     );
 
-    const config = loadChannelConfig(workspace);
+    const config = loadChannelConfig(workspace, true);
 
     expect(Object.keys(config.adapters ?? {})).toEqual(['feishu']);
     expect(config.routes?.ops).toEqual({ adapter: 'feishu', recipient: 'oc_test' });
@@ -56,6 +56,7 @@ describe('loadChannelConfig', () => {
     const workspace = join(base, 'workspace');
     mkdirSync(piHome, { recursive: true });
     mkdirSync(workspace, { recursive: true });
+    delete process.env.PI_CODING_AGENT_DIR;
     process.env.PI_AGENT_HOME = piHome;
     writeFileSync(
       join(piHome, 'settings.json'),
@@ -77,6 +78,44 @@ describe('loadChannelConfig', () => {
     expect(config.routes?.ops).toEqual({
       adapter: 'webhook',
       recipient: 'https://example.test/hook',
+    });
+  });
+
+  test('updates agent settings when no project settings file exists', () => {
+    const workspace = join(base, 'workspace');
+    const agentSettings = join(base, 'agent', 'settings.json');
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(join(base, 'agent'), { recursive: true });
+    writeFileSync(
+      agentSettings,
+      JSON.stringify({
+        'pi-channels': {
+          routes: {
+            ops: { adapter: 'webhook', recipient: '' },
+          },
+        },
+      }),
+    );
+
+    const updated = updateLocalChannelConfig(
+      workspace,
+      (config) => ({
+        ...config,
+        routes: {
+          ...config.routes,
+          ops: { adapter: 'webhook', recipient: 'https://example.test/hook' },
+        },
+      }),
+      true,
+    );
+
+    expect(updated).toBe(true);
+    expect(JSON.parse(readFileSync(agentSettings, 'utf-8'))).toMatchObject({
+      'pi-channels': {
+        routes: {
+          ops: { adapter: 'webhook', recipient: 'https://example.test/hook' },
+        },
+      },
     });
   });
 });

--- a/packages/pi-channels/src/__tests__/extension.test.ts
+++ b/packages/pi-channels/src/__tests__/extension.test.ts
@@ -60,9 +60,10 @@ const mockPi = {
 const { default: piChannelsExtension } = await import('../index.js');
 const configModule = await import('../config.js');
 
-function mockCtx() {
+function mockCtx(projectTrusted = true) {
   return {
     cwd: '/workspace',
+    isProjectTrusted: () => projectTrusted,
     ui: {
       notify: vi.fn(),
       setStatus: vi.fn(),
@@ -271,6 +272,20 @@ describe('piChannelsExtension', () => {
       }),
     );
     expect(configModule.loadChannelConfig).not.toHaveBeenCalled();
+  });
+
+  test('channel:reload preserves project trust when session autostart is disabled', async () => {
+    vi.stubEnv('PI_CHANNELS_DISABLE_SESSION_AUTOSTART', '1');
+    piChannelsExtension(mockPi as never);
+
+    await handlers.get('session_start')?.({}, mockCtx(true));
+    const callback = vi.fn();
+    events.get('channel:reload')?.({ callback });
+
+    await vi.waitFor(() => {
+      expect(callback).toHaveBeenCalledWith({ ok: true });
+    });
+    expect(configModule.loadChannelConfig).toHaveBeenCalledWith('/workspace', true);
   });
 
   test('channel:capture resolves with matching incoming token', async () => {

--- a/packages/pi-channels/src/config.ts
+++ b/packages/pi-channels/src/config.ts
@@ -9,27 +9,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-function resolveEnvVars(value: unknown): unknown {
-  if (typeof value === 'string') {
-    return value.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
-      const [name, ...rest] = expr.split(':-');
-      const fallback = rest.join(':-');
-      const envVal = process.env[name!];
-      return envVal !== undefined && envVal !== '' ? envVal : fallback;
-    });
-  }
-  if (Array.isArray(value)) return value.map(resolveEnvVars);
-  if (isRecord(value)) {
-    const result: Record<string, unknown> = {};
-    for (const [key, nested] of Object.entries(value)) result[key] = resolveEnvVars(nested);
-    return result;
-  }
-  return value;
-}
-
 function section(settings: Record<string, unknown>): ChannelConfig {
   const value = settings[SETTINGS_KEY];
-  return isRecord(value) ? (resolveEnvVars(value) as ChannelConfig) : {};
+  return isRecord(value) ? (value as ChannelConfig) : {};
 }
 
 function readSettingsFile(path: string): Record<string, unknown> {
@@ -45,7 +27,9 @@ function writeSettingsFile(path: string, settings: Record<string, unknown>): voi
   writeFileSync(path, `${JSON.stringify(settings, null, 2)}\n`);
 }
 
-function discoverLocalSettingsFiles(cwd: string): string[] {
+function discoverLocalSettingsFiles(cwd: string, projectTrusted: boolean): string[] {
+  if (!projectTrusted) return [];
+
   const found: string[] = [];
   const seen = new Set<string>();
 
@@ -55,9 +39,6 @@ function discoverLocalSettingsFiles(cwd: string): string[] {
     seen.add(resolved);
     found.push(resolved);
   };
-
-  const agentDir = resolveConfigDir();
-  add(join(agentDir, 'settings.json'));
 
   let current = resolve(cwd);
   const upwards: string[] = [];
@@ -89,11 +70,10 @@ function mergeChannelConfig(base: ChannelConfig, override: ChannelConfig): Chann
   };
 }
 
-export function loadChannelConfig(cwd: string): ChannelConfig {
-  const agentDir = resolveConfigDir();
-  const config = loadPiSettings<ChannelConfig>(SETTINGS_KEY, { cwd });
+export function loadChannelConfig(cwd: string, projectTrusted = false): ChannelConfig {
+  const config = loadPiSettings<ChannelConfig>(SETTINGS_KEY, { cwd, projectTrusted });
 
-  const settingsFiles = discoverLocalSettingsFiles(cwd);
+  const settingsFiles = discoverLocalSettingsFiles(cwd, projectTrusted);
   const local = settingsFiles.reduce(
     (merged, path) => mergeChannelConfig(merged, section(readSettingsFile(path))),
     {} as ChannelConfig,
@@ -105,7 +85,6 @@ export function loadChannelConfig(cwd: string): ChannelConfig {
   if (process.env.DEBUG?.includes('pi-channels')) {
     console.error('[pi-channels] config', {
       cwd,
-      agentDir,
       settingsFiles,
       adapters: Object.keys(merged.adapters ?? {}),
       routes: Object.keys(merged.routes ?? {}),
@@ -118,8 +97,12 @@ export function loadChannelConfig(cwd: string): ChannelConfig {
 export function updateLocalChannelConfig(
   cwd: string,
   update: (config: ChannelConfig) => ChannelConfig,
+  projectTrusted = false,
 ): boolean {
-  const settingsFile = discoverLocalSettingsFiles(cwd).at(-1);
+  const agentSettingsFile = join(resolveConfigDir(), 'settings.json');
+  const settingsFile =
+    discoverLocalSettingsFiles(cwd, projectTrusted).at(-1) ??
+    (existsSync(agentSettingsFile) ? agentSettingsFile : undefined);
   if (!settingsFile) return false;
 
   const settings = readSettingsFile(settingsFile);

--- a/packages/pi-channels/src/index.ts
+++ b/packages/pi-channels/src/index.ts
@@ -1,3 +1,4 @@
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { ChatBridge } from './bridge.js';
@@ -34,6 +35,7 @@ type AdapterConnectionState = {
 type ChannelRuntimeContext = {
   cwd: string;
   ui: Pick<ExtensionContext['ui'], 'notify' | 'setStatus'>;
+  isProjectTrusted?: () => boolean;
 };
 
 type ChannelSendEvent = ChannelMessage & {
@@ -56,6 +58,7 @@ export default function piChannelsExtension(pi: ExtensionAPI): void {
   const registry = new ChannelRegistry();
   let bridge: ChatBridge | null = null;
   let sessionCwd = process.cwd();
+  let sessionCtx: ChannelRuntimeContext | null = null;
   let currentCtx: ChannelRuntimeContext | null = null;
   let configFingerprint = '';
   let configReloading = false;
@@ -94,7 +97,7 @@ export default function piChannelsExtension(pi: ExtensionAPI): void {
   registry.setOnIncoming(async (message) => {
     pi.events.emit('channel:receive', message);
     const captured = notifyCaptureWaiters(message);
-    autoFillEmptyRouteRecipient(sessionCwd, message, log);
+    autoFillEmptyRouteRecipient(sessionCwd, isProjectTrusted(currentCtx), message, log);
     if (captured) return;
     const turn = bridge?.isActive() ? channelIncomingTurn(message) : undefined;
     if (turn) pi.events.emit('channel:turn', turn);
@@ -110,7 +113,7 @@ export default function piChannelsExtension(pi: ExtensionAPI): void {
     configReloading = true;
     try {
       sessionCwd = ctx.cwd;
-      const config = loadChannelConfig(ctx.cwd);
+      const config = loadChannelConfig(ctx.cwd, isProjectTrusted(ctx));
       const nextFingerprint = JSON.stringify(config);
       if (!force && nextFingerprint === configFingerprint && !lastError)
         return registry.getErrors();
@@ -164,8 +167,9 @@ export default function piChannelsExtension(pi: ExtensionAPI): void {
   }
 
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
+    sessionCtx = ctx;
+    sessionCwd = ctx.cwd;
     if (sessionAutostartDisabled()) {
-      sessionCwd = ctx.cwd;
       log('session_start_skipped', {
         reason: 'PI_CHANNELS_DISABLE_SESSION_AUTOSTART',
         cwd: ctx.cwd,
@@ -173,11 +177,11 @@ export default function piChannelsExtension(pi: ExtensionAPI): void {
       return;
     }
     currentCtx = ctx;
-    sessionCwd = ctx.cwd;
     await applyChannelConfig(ctx, 'session_start', false);
   });
 
   pi.on('session_shutdown', async (_event: unknown, ctx: ExtensionContext) => {
+    sessionCtx = null;
     currentCtx = null;
     connectedAt = undefined;
     lastError = undefined;
@@ -487,7 +491,7 @@ export default function piChannelsExtension(pi: ExtensionAPI): void {
       cwd?: unknown;
       callback?: (result: { ok: boolean; error?: string }) => void;
     };
-    const ctx = currentCtx ?? channelContextFromReload(data);
+    const ctx = currentCtx ?? sessionCtx ?? channelContextFromReload(data);
     if (!ctx) {
       data.callback?.({ ok: false, error: 'pi-channels session is not active.' });
       return;
@@ -702,6 +706,7 @@ function channelIncomingTurn(message: IncomingMessage):
 
 function autoFillEmptyRouteRecipient(
   cwd: string,
+  projectTrusted: boolean,
   message: { adapter: string; sender: string; metadata?: Record<string, unknown> },
   log: (event: string, data?: Record<string, unknown>, level?: string) => void,
 ): void {
@@ -711,30 +716,34 @@ function autoFillEmptyRouteRecipient(
 
   try {
     let filledRoute: string | undefined;
-    const updated = updateLocalChannelConfig(cwd, (config) => {
-      const routes = config.routes ?? {};
-      const fillableRoutes = Object.entries(routes).filter(
-        ([, route]) => route.adapter === message.adapter && !trimToUndefined(route.recipient),
-      );
-      const captureRoutes = fillableRoutes.filter(([, route]) => route.capture === true);
-      const routesToFill = captureRoutes.length > 0 ? captureRoutes : fillableRoutes;
-      if (routesToFill.length !== 1) return config;
+    const updated = updateLocalChannelConfig(
+      cwd,
+      (config) => {
+        const routes = config.routes ?? {};
+        const fillableRoutes = Object.entries(routes).filter(
+          ([, route]) => route.adapter === message.adapter && !trimToUndefined(route.recipient),
+        );
+        const captureRoutes = fillableRoutes.filter(([, route]) => route.capture === true);
+        const routesToFill = captureRoutes.length > 0 ? captureRoutes : fillableRoutes;
+        if (routesToFill.length !== 1) return config;
 
-      const [routeName, route] = routesToFill[0]!;
-      filledRoute = routeName;
-      return {
-        ...config,
-        routes: {
-          ...routes,
-          [routeName]: {
-            ...route,
-            recipient,
-            capture: false,
-            ...(displayName && !trimToUndefined(route.name) ? { name: displayName } : {}),
+        const [routeName, route] = routesToFill[0]!;
+        filledRoute = routeName;
+        return {
+          ...config,
+          routes: {
+            ...routes,
+            [routeName]: {
+              ...route,
+              recipient,
+              capture: false,
+              ...(displayName && !trimToUndefined(route.name) ? { name: displayName } : {}),
+            },
           },
-        },
-      } satisfies ChannelConfig;
-    });
+        } satisfies ChannelConfig;
+      },
+      projectTrusted,
+    );
 
     if (updated && filledRoute) {
       log('route_recipient_auto_filled', {

--- a/packages/pi-computer-use/README.md
+++ b/packages/pi-computer-use/README.md
@@ -37,6 +37,9 @@ installation is required.
 
 Configure `.pi/settings.json` or `~/.pi/agent/settings.json`:
 
+Project settings are loaded only after project trust is accepted. `${ENV_VAR}`
+interpolation is supported in user and agent settings, but not in project settings.
+
 ```json
 {
   "pi-computer-use": {

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.10",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "devDependencies": {

--- a/packages/pi-computer-use/src/index.ts
+++ b/packages/pi-computer-use/src/index.ts
@@ -1,3 +1,4 @@
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { type ComputerUseConfig, loadConfigFromFile, resolveConfig } from './config.js';
@@ -397,7 +398,12 @@ export default function computerUseExtension(pi: ExtensionAPI): void {
   }
 
   pi.on('session_start', async (_event, ctx) => {
-    config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
+    config = resolveConfig(
+      loadConfigFromFile({
+        cwd: ctx.cwd,
+        projectTrusted: isProjectTrusted(ctx),
+      }),
+    );
     client = undefined;
     sessionAbortController = new AbortController();
     macPermissionPromise = undefined;

--- a/packages/pi-dingtalk/README.md
+++ b/packages/pi-dingtalk/README.md
@@ -12,7 +12,11 @@ Pi extension for [DingTalk](https://www.dingtalk.com/) workspace — calendar, d
 
 ## Configuration
 
-Add to your `.pi/settings.json`:
+Add to `~/.pi/agent/settings.json` or a trusted project's `.pi/settings.json`:
+
+Project settings are loaded only after project trust is accepted. For
+environment-backed credentials, use user or agent settings because project
+settings do not expand `${ENV_VAR}`.
 
 ```json
 {

--- a/packages/pi-dingtalk/package.json
+++ b/packages/pi-dingtalk/package.json
@@ -50,7 +50,7 @@
     "test": "vitest run src"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-dingtalk/src/__tests__/config.test.ts
+++ b/packages/pi-dingtalk/src/__tests__/config.test.ts
@@ -42,7 +42,7 @@ describe('loadDingTalkConfig', () => {
       }),
     );
 
-    const config = loadDingTalkConfig(project);
+    const config = loadDingTalkConfig(project, true);
 
     expect(config).toEqual({
       clientId: 'dingabc123',
@@ -60,7 +60,7 @@ describe('loadDingTalkConfig', () => {
       }),
     );
 
-    const config = loadDingTalkConfig(project);
+    const config = loadDingTalkConfig(project, true);
     expect(config).toBeUndefined();
   });
 });

--- a/packages/pi-dingtalk/src/config.ts
+++ b/packages/pi-dingtalk/src/config.ts
@@ -7,8 +7,11 @@ export type DingTalkConfig = {
 
 const SETTINGS_KEY = 'pi-dingtalk';
 
-export function loadDingTalkConfig(cwd: string): DingTalkConfig | undefined {
-  const config = loadPiSettings<DingTalkConfig>(SETTINGS_KEY, { cwd });
+export function loadDingTalkConfig(
+  cwd: string,
+  projectTrusted = false,
+): DingTalkConfig | undefined {
+  const config = loadPiSettings<DingTalkConfig>(SETTINGS_KEY, { cwd, projectTrusted });
   if (!config || (!config.clientId && !config.clientSecret)) return undefined;
   return config;
 }

--- a/packages/pi-dingtalk/src/index.ts
+++ b/packages/pi-dingtalk/src/index.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { ensureDws, getDwsSkillsDir, initDws } from './cli.js';
 import { loadDingTalkConfig } from './config.js';
@@ -19,7 +20,7 @@ export default function piDingTalkExtension(pi: ExtensionAPI): void {
   let skillsDir: string | undefined;
 
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
-    const config = loadDingTalkConfig(ctx.cwd);
+    const config = loadDingTalkConfig(ctx.cwd, isProjectTrusted(ctx));
     if (!config?.clientId || !config?.clientSecret) return;
 
     if (existsSync(BUNDLED_SKILLS_DIR)) {

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -90,6 +90,8 @@ pi --goal '' -p '<prompt>'              Derive the goal from the prompt (at befo
 ## Configuration
 
 Settings key: `pi-goal` (in `~/.pi/agent/settings.json`, agent dir, or project `.pi/settings.json`).
+Project settings are loaded only after project trust is accepted. Environment-variable
+interpolation is available in user and agent settings, but not in project settings.
 
 ```json
 {

--- a/packages/pi-goal/package.json
+++ b/packages/pi-goal/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "@earendil-works/pi-agent-core": ">=0.74.0",
     "@earendil-works/pi-ai": ">=0.80.10",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-goal/src/config.ts
+++ b/packages/pi-goal/src/config.ts
@@ -58,9 +58,9 @@ export function resolveConfig(raw?: PiGoalConfig): ResolvedGoalConfig {
   return resolved;
 }
 
-export function loadSettings(cwd: string): PiGoalConfig | undefined {
+export function loadSettings(cwd: string, projectTrusted = false): PiGoalConfig | undefined {
   try {
-    const config = loadPiSettings<Partial<PiGoalConfig>>(SETTINGS_KEY, { cwd });
+    const config = loadPiSettings<Partial<PiGoalConfig>>(SETTINGS_KEY, { cwd, projectTrusted });
     return Object.keys(config).length > 0 ? (config as PiGoalConfig) : undefined;
   } catch {
     return undefined;

--- a/packages/pi-goal/src/extension.ts
+++ b/packages/pi-goal/src/extension.ts
@@ -1,3 +1,4 @@
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import {
   buildSessionContext,
   type ExtensionAPI,
@@ -126,7 +127,7 @@ export default function goalExtension(
   let pendingDerive = false;
 
   pi.on('session_start', async (_event, ctx) => {
-    const fileConfig = loadSettings(ctx.cwd);
+    const fileConfig = loadSettings(ctx.cwd, isProjectTrusted(ctx));
     config = resolveConfig({ ...fileConfig, ...injectedConfig });
     registry = ctx.modelRegistry as unknown as GoalModelRegistry;
     ctx.ui.setStatus(STATUS_KEY, config.model ? 'goal: none' : 'goal: disabled (no model)');

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -40,7 +40,11 @@ Settings are read by `pi-shared`'s `loadPiSettings`, which merges three files (l
 
 1. `~/.pi/agent/settings.json` (global)
 2. `$PI_AGENT_HOME/settings.json` (agent dir, if `PI_AGENT_HOME` is set)
-3. `<cwd>/.pi/settings.json` (project)
+3. `<cwd>/.pi/settings.json` (trusted project)
+
+Project settings are ignored when project trust is declined. `${ENV_VAR}`
+interpolation is supported in global and agent settings only, so keep
+environment-backed credentials out of project settings.
 
 All settings live under the `pi-image-gen` key. The minimum viable config sets `defaultModel`:
 
@@ -99,7 +103,10 @@ That's it. From the agent: `image_generate({ prompt: "a cyberpunk cat" })`.
 | `providers`       | Per-built-in-provider override. Set `apiKey`, `baseUrl`, or `headers` to point at a proxy or non-standard env var. |
 | `customProviders` | User-defined providers — see below.                                                      |
 
-`apiKey`, `baseUrl`, and `headers` values support `$VAR` and `${VAR}` env interpolation, with `:-` fallback (e.g. `${FOO:-default}`).
+In global and agent settings, `apiKey`, `baseUrl`, and `headers` values support
+`$VAR` and `${VAR}` environment interpolation. Fallbacks require the braced
+form (for example, `${FOO:-default}`); `$FOO:-default` is not supported.
+Project settings keep all of these placeholders literal.
 
 ## Built-in setup walkthrough
 

--- a/packages/pi-image-gen/package.json
+++ b/packages/pi-image-gen/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.10",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-image-gen/src/__tests__/config.test.ts
+++ b/packages/pi-image-gen/src/__tests__/config.test.ts
@@ -31,7 +31,7 @@ describe('resolveModel', () => {
     expect(result.provider.baseUrl).toContain('dashscope.aliyuncs.com');
   });
 
-  it('respects per-provider apiKey override with env-var interpolation', () => {
+  it('does not interpolate environment variables in resolver input', () => {
     process.env.MY_KEY = 'override-key';
     const settings: ImageGenSettings = {
       providers: {
@@ -43,8 +43,19 @@ describe('resolveModel', () => {
     };
     const result = resolveModel('gpt-image-2', settings);
     if ('error' in result) throw new Error(result.error);
-    expect(result.provider.apiKey).toBe('override-key');
+    expect(result.provider.apiKey).toBe(`$${'{MY_KEY}'}`);
     expect(result.provider.baseUrl).toBe('https://proxy.example.com/v1');
+  });
+
+  it('falls back to the provider environment key after an empty override', () => {
+    process.env.OPENAI_API_KEY = 'provider-key';
+    const result = resolveModel('gpt-image-2', {
+      providers: {
+        openai: { apiKey: '' },
+      },
+    });
+    if ('error' in result) throw new Error(result.error);
+    expect(result.provider.apiKey).toBe('provider-key');
   });
 
   it('matches a custom provider by alias', () => {
@@ -54,7 +65,7 @@ describe('resolveModel', () => {
         'my-sd': {
           api: 'openai',
           baseUrl: 'https://api.my-sd.test/v1',
-          apiKey: '$MY_SD_KEY',
+          apiKey: 'sd-key',
           models: [{ id: 'sd-3-large', alias: 'sd3' }, 'sd-3-medium'],
         },
       },
@@ -69,6 +80,21 @@ describe('resolveModel', () => {
     const b = resolveModel('sd-3-medium', settings);
     if ('error' in b) throw new Error(b.error);
     expect(b.remoteId).toBe('sd-3-medium');
+  });
+
+  it('falls back to the API default after an empty custom provider base URL', () => {
+    const result = resolveModel('custom-image', {
+      customProviders: {
+        gateway: {
+          api: 'openai',
+          baseUrl: '',
+          apiKey: 'gateway-key',
+          models: ['custom-image'],
+        },
+      },
+    });
+    if ('error' in result) throw new Error(result.error);
+    expect(result.provider.baseUrl).toBe('https://api.openai.com/v1');
   });
 
   it('supports <provider>/<remote-id> fallback for openrouter', () => {

--- a/packages/pi-image-gen/src/__tests__/extension.test.ts
+++ b/packages/pi-image-gen/src/__tests__/extension.test.ts
@@ -42,7 +42,10 @@ function setup() {
 // pi-web-access / pi-memory. Fire it so `tools` is populated. With no settings
 // on disk the resolved api is null, which yields the fully-featured schema.
 async function startSession(handlers: Map<string, Handler>, cwd = '/tmp') {
-  await handlers.get('session_start')?.({}, { cwd, hasUI: true, ui: { notify: vi.fn() } });
+  await handlers.get('session_start')?.(
+    {},
+    { cwd, isProjectTrusted: () => true, hasUI: true, ui: { notify: vi.fn() } },
+  );
 }
 
 function caps(
@@ -273,7 +276,10 @@ describe('image_generate execute error surfaces are sanitized', () => {
 
   const runExecute = async (cwd: string, params: Record<string, unknown> = { prompt: 'a cat' }) => {
     const { tools, handlers } = setup();
-    await handlers.get('session_start')?.({}, { cwd, hasUI: true, ui: { notify: vi.fn() } });
+    await handlers.get('session_start')?.(
+      {},
+      { cwd, isProjectTrusted: () => true, hasUI: true, ui: { notify: vi.fn() } },
+    );
     const tool = tools.get('image_generate');
     if (!tool) throw new Error('tool not registered');
     return (await tool.execute('call-1', params, undefined, undefined, {

--- a/packages/pi-image-gen/src/config.ts
+++ b/packages/pi-image-gen/src/config.ts
@@ -17,36 +17,16 @@ import type {
 
 const SETTINGS_KEY = 'pi-image-gen';
 
-export function loadImageGenSettings(cwd: string): ImageGenSettings {
+export function loadImageGenSettings(cwd: string, projectTrusted = false): ImageGenSettings {
   try {
     return loadPiSettings<ImageGenSettings>(SETTINGS_KEY, {
       cwd,
+      projectTrusted,
+      expandBareEnvVars: true,
     });
   } catch {
     return {};
   }
-}
-
-/**
- * Returns the resolved value for an apiKey/header field. Supports `$VAR`
- * and `${VAR}` env substitution; returns undefined for missing env vars
- * so downstream code can fall through to defaults.
- *
- * pi-shared/settings already runs `${VAR}` substitution on settings.json
- * payloads, but we re-run resolution here so that settings constructed in
- * code (or read from other sources) get the same treatment.
- */
-function resolveString(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  const replaced = value.replace(/\$\{([^}]+)\}|\$([A-Z_][A-Z0-9_]*)/g, (_match, braced, bare) => {
-    const name = (braced ?? bare) as string | undefined;
-    if (!name) return '';
-    const [varName, ...rest] = name.split(':-');
-    const fallback = rest.join(':-');
-    const env = process.env[varName!];
-    return env !== undefined && env !== '' ? env : fallback;
-  });
-  return replaced.length > 0 ? replaced : undefined;
 }
 
 function buildBuiltInProvider(
@@ -54,11 +34,11 @@ function buildBuiltInProvider(
   settings: ImageGenSettings,
 ): ResolvedProvider | null {
   const override = settings.providers?.[id] ?? {};
-  const apiKey = resolveString(override.apiKey) ?? process.env[ENV_VARS[id]];
+  const apiKey = override.apiKey || process.env[ENV_VARS[id]];
   const provider: ResolvedProvider = {
     id,
     api: DEFAULT_API_STYLE[id],
-    baseUrl: resolveString(override.baseUrl) ?? DEFAULT_BASE_URL[id],
+    baseUrl: override.baseUrl || DEFAULT_BASE_URL[id],
     name: PROVIDER_DISPLAY_NAME[id],
     builtIn: true,
   };
@@ -70,7 +50,7 @@ function buildBuiltInProvider(
 function buildCustomProvider(name: string, raw: CustomImageProvider): ResolvedProvider | null {
   const api = raw.api;
   if (!api) return null;
-  const baseUrl = resolveString(raw.baseUrl) ?? DEFAULT_BASE_URL[api as BuiltInProviderId];
+  const baseUrl = raw.baseUrl || DEFAULT_BASE_URL[api as BuiltInProviderId];
   if (!baseUrl) return null;
   const provider: ResolvedProvider = {
     id: name,
@@ -79,7 +59,7 @@ function buildCustomProvider(name: string, raw: CustomImageProvider): ResolvedPr
     name: raw.name ?? name,
     builtIn: false,
   };
-  const apiKey = resolveString(raw.apiKey);
+  const apiKey = raw.apiKey;
   if (apiKey) provider.apiKey = apiKey;
   if (raw.headers) provider.headers = raw.headers;
   return provider;

--- a/packages/pi-image-gen/src/index.ts
+++ b/packages/pi-image-gen/src/index.ts
@@ -1,3 +1,4 @@
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
@@ -102,7 +103,7 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
 
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
     sessionCwd = ctx.cwd;
-    settings = loadImageGenSettings(ctx.cwd);
+    settings = loadImageGenSettings(ctx.cwd, isProjectTrusted(ctx));
     registerImageTool();
   });
 
@@ -112,7 +113,7 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
       const raw = (args ?? '').trim();
       const tokens = raw.split(/\s+/).filter(Boolean);
       if (tokens[0] === 'reload') {
-        settings = loadImageGenSettings(ctx.cwd);
+        settings = loadImageGenSettings(ctx.cwd, isProjectTrusted(ctx));
         // Re-register so the schema (e.g. whether `quality` is exposed) tracks
         // the newly loaded model, not just the settings read at execute time.
         registerImageTool();

--- a/packages/pi-image-gen/src/types.ts
+++ b/packages/pi-image-gen/src/types.ts
@@ -17,7 +17,7 @@ export type CustomImageProvider = {
   /** Override the API base URL. Optional; defaults to the api's default. */
   baseUrl?: string;
   /**
-   * API key. Supports `$ENV_VAR` and `${ENV_VAR}` syntax — resolved at load time.
+   * API key. User and agent settings support `$ENV_VAR` and `${ENV_VAR}` syntax.
    * Required unless the api does not need one.
    */
   apiKey?: string;

--- a/packages/pi-lark/README.md
+++ b/packages/pi-lark/README.md
@@ -12,7 +12,11 @@ Pi extension for [Lark/Feishu](https://www.feishu.cn/) workspace — calendar, d
 
 ## Configuration
 
-Add to your `.pi/settings.json`:
+Add to `~/.pi/agent/settings.json` or a trusted project's `.pi/settings.json`:
+
+Project settings are loaded only after project trust is accepted. For
+environment-backed credentials, use user or agent settings because project
+settings do not expand `${ENV_VAR}`.
 
 ```json
 {

--- a/packages/pi-lark/package.json
+++ b/packages/pi-lark/package.json
@@ -52,7 +52,7 @@
     "test": "vitest run src"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-lark/src/__tests__/config.test.ts
+++ b/packages/pi-lark/src/__tests__/config.test.ts
@@ -40,7 +40,7 @@ describe('loadLarkConfig', () => {
       }),
     );
 
-    const config = loadLarkConfig(project);
+    const config = loadLarkConfig(project, true);
 
     expect(config).toEqual({
       appId: 'cli_test123',
@@ -59,7 +59,7 @@ describe('loadLarkConfig', () => {
       }),
     );
 
-    const config = loadLarkConfig(project);
+    const config = loadLarkConfig(project, true);
     expect(config).toBeUndefined();
   });
 });

--- a/packages/pi-lark/src/config.ts
+++ b/packages/pi-lark/src/config.ts
@@ -8,8 +8,8 @@ export type LarkConfig = {
 
 const SETTINGS_KEY = 'pi-lark';
 
-export function loadLarkConfig(cwd: string): LarkConfig | undefined {
-  const config = loadPiSettings<LarkConfig>(SETTINGS_KEY, { cwd });
+export function loadLarkConfig(cwd: string, projectTrusted = false): LarkConfig | undefined {
+  const config = loadPiSettings<LarkConfig>(SETTINGS_KEY, { cwd, projectTrusted });
   if (!config || (!config.appId && !config.appSecret)) return undefined;
   return config;
 }

--- a/packages/pi-lark/src/index.ts
+++ b/packages/pi-lark/src/index.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { ensureLarkCli, getLarkCliSkillsDir, initLarkCli } from './cli.js';
 import { loadLarkConfig } from './config.js';
@@ -19,7 +20,7 @@ export default function piLarkExtension(pi: ExtensionAPI): void {
   let skillsDir: string | undefined;
 
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
-    const config = loadLarkConfig(ctx.cwd);
+    const config = loadLarkConfig(ctx.cwd, isProjectTrusted(ctx));
     if (!config?.appId || !config?.appSecret) return;
 
     if (existsSync(BUNDLED_SKILLS_DIR)) {

--- a/packages/pi-memory-mem0/README.md
+++ b/packages/pi-memory-mem0/README.md
@@ -33,6 +33,11 @@ User ←→ Agent ←→ Mem0 OSS Memory
 
 ## Quick Start
 
+Store configuration in user/agent settings or in a trusted project's
+`.pi/settings.json`. Project settings are ignored when trust is declined and do
+not expand `${ENV_VAR}`; the environment-backed examples below therefore belong
+in user or agent settings.
+
 ### Platform Mode
 
 ```json

--- a/packages/pi-memory-mem0/package.json
+++ b/packages/pi-memory-mem0/package.json
@@ -54,7 +54,7 @@
     "mem0ai": "3.0.7"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-memory-mem0/src/index.ts
+++ b/packages/pi-memory-mem0/src/index.ts
@@ -6,10 +6,11 @@
  * - **open-source**: Runs locally with SQLite vector store (needs OPENAI_API_KEY or Ollama)
  *
  * Configuration via settings.json key "pi-memory-mem0".
- * Supports ${ENV_VAR:-fallback} in all string values.
+ * Supports ${ENV_VAR:-fallback} in user and agent settings.
+ * Trusted project settings are loaded without environment interpolation.
  */
 
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+import { isProjectTrusted, loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Prefetch } from './prefetch.js';
 import { createMem0Provider, type Mem0Provider } from './provider.js';
@@ -19,10 +20,11 @@ import type { Mem0ExtensionConfig } from './types.js';
 const SETTINGS_KEY = 'pi-memory-mem0';
 const STATUS_KEY = 'mem0';
 
-function loadConfig(cwd: string): Mem0ExtensionConfig {
+function loadConfig(cwd: string, projectTrusted = false): Mem0ExtensionConfig {
   try {
     return loadPiSettings<Mem0ExtensionConfig>(SETTINGS_KEY, {
       cwd,
+      projectTrusted,
     });
   } catch {
     return {};
@@ -44,7 +46,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
   let pendingWrite: Promise<void> = Promise.resolve();
 
   pi.on('session_start', async (_event, ctx) => {
-    const config = loadConfig(ctx.cwd);
+    const config = loadConfig(ctx.cwd, isProjectTrusted(ctx));
     const mode = config.mode ?? 'platform';
 
     // Platform mode requires apiKey; OSS mode requires an LLM provider (env key)
@@ -162,7 +164,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
         return;
       }
 
-      const config = loadConfig(ctx.cwd);
+      const config = loadConfig(ctx.cwd, isProjectTrusted(ctx));
       const userId = resolveUserId(config.userId);
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const subcommand = parts[0]?.toLowerCase() ?? 'status';

--- a/packages/pi-memory/README.md
+++ b/packages/pi-memory/README.md
@@ -64,6 +64,10 @@ pi.extensions → session_start → initialize store → register tools
 
 Configure via the `pi-memory` settings key:
 
+Project `.pi/settings.json` values are loaded only after project trust is
+accepted and are not environment-interpolated. User and agent settings retain
+environment interpolation.
+
 ```json
 {
   "pi-memory": {

--- a/packages/pi-memory/src/extension.ts
+++ b/packages/pi-memory/src/extension.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { loadPiSettings, resolveHome } from '@amaster.ai/pi-shared/settings';
+import { isProjectTrusted, loadPiSettings, resolveHome } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
   createExtractionRunner,
@@ -67,10 +67,11 @@ function resolveConfig(raw?: PiMemoryExtensionConfig): ResolvedConfig {
   return resolved;
 }
 
-function loadSettings(cwd: string): PiMemoryExtensionConfig | undefined {
+function loadSettings(cwd: string, projectTrusted = false): PiMemoryExtensionConfig | undefined {
   try {
     const config = loadPiSettings<Partial<PiMemoryExtensionConfig>>(SETTINGS_KEY, {
       cwd,
+      projectTrusted,
     });
     return Object.keys(config).length > 0 ? (config as PiMemoryExtensionConfig) : undefined;
   } catch {
@@ -86,7 +87,7 @@ export default function memoryExtension(
   let extractionRunner: ExtractionRunner | undefined;
 
   pi.on('session_start', async (_event, ctx) => {
-    const fileConfig = loadSettings(ctx.cwd);
+    const fileConfig = loadSettings(ctx.cwd, isProjectTrusted(ctx));
     const config = resolveConfig({ ...fileConfig, ...injectedConfig });
 
     try {

--- a/packages/pi-security/README.md
+++ b/packages/pi-security/README.md
@@ -60,18 +60,19 @@ Baseline secret protection (denying `.ssh/`, `.env`, `*.pem`, `*.key`, etc.) is 
 
 Profiles can be defined in three places. Higher-priority sources override lower-priority ones with the same name:
 
-1. **Project**: `<cwd>/.pi/policy/<name>.json` (highest priority)
+1. **Trusted project**: `<cwd>/.pi/policy/<name>.json` (highest priority when project trust is accepted)
 2. **Agent**: `<agentDir>/policy/<name>.json`
 3. **User**: `~/.pi/agent/policy/<name>.json`
 4. **Settings**: under `pi-security.security.profiles` in `pi.json`
 
 Each JSON file defines a single profile; the filename (without `.json`) is the profile name.
+Project policies are ignored when project trust is declined or unavailable.
 
 ### JSON config examples
 
 Ready-to-copy samples live under [`examples/`](./examples) and are exercised by the test suite:
 
-- [`examples/reviewer.json`](./examples/reviewer.json) — a project-level file policy. Drop into `<project>/.pi/policy/reviewer.json`. Starts from `read-only`, opens to `workspace-write`, asks on `bash`, denies external network.
+- [`examples/reviewer.json`](./examples/reviewer.json) — a project-level file policy. For a trusted project, drop it into `<project>/.pi/policy/reviewer.json`. Starts from `read-only`, opens to `workspace-write`, asks on `bash`, denies external network.
 - [`examples/auto-review.settings.json`](./examples/auto-review.settings.json) — a `pi.json` snippet that defines a custom `auto-review` profile inline. Extends `default` and asks before package-manager installs (`npm/pnpm/yarn/pip install|add`) via `argsRegex`.
 
 ### Profile schema

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -50,7 +50,7 @@
     "@amaster.ai/pi-shared": "workspace:*"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.79.1"
   },
   "devDependencies": {
     "@earendil-works/pi-coding-agent": "0.80.10",

--- a/packages/pi-security/src/__tests__/policy-loader.test.ts
+++ b/packages/pi-security/src/__tests__/policy-loader.test.ts
@@ -144,7 +144,7 @@ describe('loadFilePolicies', () => {
       JSON.stringify({ extends: 'full-access', sandbox: 'full-access' }),
     );
 
-    const result = loadFilePolicies(cwd);
+    const result = loadFilePolicies({ cwd, projectTrusted: true });
     expect(result.custom).toEqual({ extends: 'full-access', sandbox: 'full-access' });
   });
 
@@ -155,7 +155,7 @@ describe('loadFilePolicies', () => {
       JSON.stringify({ extends: 'full-access' }),
     );
 
-    const result = loadFilePolicies(cwd);
+    const result = loadFilePolicies({ cwd, projectTrusted: true });
     expect(result['user-only']).toEqual({ extends: 'read-only' });
     expect(result['project-only']).toEqual({ extends: 'full-access' });
   });
@@ -164,7 +164,7 @@ describe('loadFilePolicies', () => {
     rmSync(projectDir, { recursive: true });
     writeFileSync(join(userDir, 'only-user.json'), JSON.stringify({ extends: 'read-only' }));
 
-    const result = loadFilePolicies(cwd);
+    const result = loadFilePolicies({ cwd, projectTrusted: true });
     expect(result['only-user']).toEqual({ extends: 'read-only' });
   });
 
@@ -175,7 +175,7 @@ describe('loadFilePolicies', () => {
       JSON.stringify({ extends: 'full-access' }),
     );
 
-    const result = loadFilePolicies(cwd);
+    const result = loadFilePolicies({ cwd, projectTrusted: true });
     expect(result['only-project']).toEqual({ extends: 'full-access' });
   });
 
@@ -183,7 +183,7 @@ describe('loadFilePolicies', () => {
     rmSync(userDir, { recursive: true });
     rmSync(projectDir, { recursive: true });
 
-    const result = loadFilePolicies(cwd);
+    const result = loadFilePolicies({ cwd, projectTrusted: true });
     expect(result).toEqual({});
   });
 });
@@ -225,7 +225,7 @@ describe('loadFilePolicies 3-layer with agentDir', () => {
       }),
     );
 
-    const result = loadFilePolicies(cwd, agentDir);
+    const result = loadFilePolicies({ cwd, configDir: agentDir, projectTrusted: true });
     expect(result['agent-profile']).toEqual({
       sandbox: 'workspace-write',
       approval: 'on-request',
@@ -239,7 +239,7 @@ describe('loadFilePolicies 3-layer with agentDir', () => {
       JSON.stringify({ extends: 'full-access' }),
     );
 
-    const result = loadFilePolicies(cwd, agentDir);
+    const result = loadFilePolicies({ cwd, configDir: agentDir, projectTrusted: true });
     expect(result.custom).toEqual({ extends: 'full-access' });
   });
 
@@ -252,7 +252,7 @@ describe('loadFilePolicies 3-layer with agentDir', () => {
       }),
     );
 
-    const filePolicies = loadFilePolicies(cwd, agentDir);
+    const filePolicies = loadFilePolicies({ cwd, configDir: agentDir, projectTrusted: true });
     const policy = resolveCapabilityPolicy('agent-profile', {}, filePolicies);
     expect(isCapabilityExposed('read', policy)).toBe(true);
     expect(isCapabilityExposed('write', policy)).toBe(true);

--- a/packages/pi-security/src/__tests__/readme-examples.test.ts
+++ b/packages/pi-security/src/__tests__/readme-examples.test.ts
@@ -57,7 +57,7 @@ describe('examples/reviewer.json', () => {
   });
 
   it('exposes workspace-write capabilities (read + write + bash)', () => {
-    const filePolicies = loadFilePolicies(cwd);
+    const filePolicies = loadFilePolicies({ cwd, projectTrusted: true });
     const policy = resolveCapabilityPolicy('reviewer', {}, filePolicies);
     expect(isCapabilityExposed('read', policy)).toBe(true);
     expect(isCapabilityExposed('write', policy)).toBe(true);
@@ -66,7 +66,7 @@ describe('examples/reviewer.json', () => {
   });
 
   it('asks for approval on bash via custom rule', () => {
-    const filePolicies = loadFilePolicies(cwd);
+    const filePolicies = loadFilePolicies({ cwd, projectTrusted: true });
     const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
     const result = engine.evaluate({
       request,
@@ -77,7 +77,7 @@ describe('examples/reviewer.json', () => {
   });
 
   it('denies bash commands that touch external network', () => {
-    const filePolicies = loadFilePolicies(cwd);
+    const filePolicies = loadFilePolicies({ cwd, projectTrusted: true });
     const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
     const result = engine.evaluate({
       request,
@@ -88,7 +88,7 @@ describe('examples/reviewer.json', () => {
   });
 
   it('asks for approval on workspace writes (inherited from on-request approval)', () => {
-    const filePolicies = loadFilePolicies(cwd);
+    const filePolicies = loadFilePolicies({ cwd, projectTrusted: true });
     const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
     const result = engine.evaluate({
       request,
@@ -100,7 +100,7 @@ describe('examples/reviewer.json', () => {
   });
 
   it('still denies secret reads (baseline rule inherited from read-only)', () => {
-    const filePolicies = loadFilePolicies(cwd);
+    const filePolicies = loadFilePolicies({ cwd, projectTrusted: true });
     const engine = createSecurityPolicyEngineForProfile('reviewer', {}, filePolicies);
     const result = engine.evaluate({
       request,

--- a/packages/pi-security/src/extension.ts
+++ b/packages/pi-security/src/extension.ts
@@ -5,7 +5,7 @@ import type {
   ToolCallRequest,
   ToolSource,
 } from '@amaster.ai/pi-shared';
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+import { isProjectTrusted, loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import type {
   ExtensionAPI,
   ExtensionContext,
@@ -66,7 +66,7 @@ export default function piSecurityExtension(pi: ExtensionAPI): void {
   };
 
   pi.on('session_start', async (_event, ctx) => {
-    state.config = resolvePiSecurityConfig(loadSettings(ctx.cwd));
+    state.config = resolvePiSecurityConfig(loadSettings(ctx.cwd, isProjectTrusted(ctx)));
     state.auditLog = [];
     state.grants = [];
     ctx.ui.setStatus(
@@ -186,7 +186,11 @@ function createGate(ctx: ExtensionContext, state: PiSecurityExtensionState): Sec
   return new SecurityGate({
     profile: state.config.profile,
     ...(state.config.security ? { config: state.config.security } : {}),
-    filePolicies: loadFilePolicies(ctx.cwd, getAgentDir()),
+    filePolicies: loadFilePolicies({
+      cwd: ctx.cwd,
+      configDir: getAgentDir(),
+      projectTrusted: isProjectTrusted(ctx),
+    }),
     approvalHandler: async ({ toolCall, decision }) =>
       resolveApproval(ctx, state, toolCall, decision),
     auditSink: (event) => {
@@ -235,10 +239,11 @@ async function resolveApproval(
   return denyByUser(decision);
 }
 
-function loadSettings(cwd: string): PiSecurityExtensionConfig | undefined {
+function loadSettings(cwd: string, projectTrusted = false): PiSecurityExtensionConfig | undefined {
   try {
     const config = loadPiSettings<Partial<PiSecurityExtensionConfig>>(SETTINGS_KEY, {
       cwd,
+      projectTrusted,
     });
     return Object.keys(config).length > 0 ? (config as PiSecurityExtensionConfig) : undefined;
   } catch {

--- a/packages/pi-security/src/policy-loader.ts
+++ b/packages/pi-security/src/policy-loader.ts
@@ -27,12 +27,18 @@ export function loadPolicyDir(dirPath: string): Record<string, SecurityProfileCo
   return result;
 }
 
+export type LoadFilePoliciesOptions = {
+  cwd: string;
+  configDir?: string;
+  projectTrusted?: boolean;
+};
+
 export function loadFilePolicies(
-  cwd: string,
-  configDir?: string,
+  options: LoadFilePoliciesOptions,
 ): Record<string, SecurityProfileConfig> {
   return loadPiPolicyProfiles<SecurityProfileConfig>({
-    cwd,
-    ...(configDir !== undefined ? { configDir } : {}),
+    cwd: options.cwd,
+    projectTrusted: options.projectTrusted === true,
+    ...(options.configDir !== undefined ? { configDir: options.configDir } : {}),
   });
 }

--- a/packages/pi-task-scheduler/README.md
+++ b/packages/pi-task-scheduler/README.md
@@ -83,6 +83,10 @@ pi.extensions → session_start → creates file-based scheduler → registers t
 
 Configuration via settings key `pi-scheduler`:
 
+Project `.pi/settings.json` values are loaded only after project trust is
+accepted and are not environment-interpolated. User and agent settings retain
+environment interpolation.
+
 ```json
 {
   "pi-scheduler": {

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -58,7 +58,7 @@
     "croner": "^10.0.1"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-task-scheduler/src/extension.ts
+++ b/packages/pi-task-scheduler/src/extension.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { loadPiSettings, resolveHome } from '@amaster.ai/pi-shared/settings';
+import { isProjectTrusted, loadPiSettings, resolveHome } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
   PersistentTaskScheduler,
@@ -39,10 +39,11 @@ function resolveConfig(raw?: PiSchedulerExtensionConfig): ResolvedConfig {
   return resolved;
 }
 
-function loadSettings(cwd: string): PiSchedulerExtensionConfig | undefined {
+function loadSettings(cwd: string, projectTrusted = false): PiSchedulerExtensionConfig | undefined {
   try {
     const config = loadPiSettings<Partial<PiSchedulerExtensionConfig>>(SETTINGS_KEY, {
       cwd,
+      projectTrusted,
     });
     return Object.keys(config).length > 0 ? (config as PiSchedulerExtensionConfig) : undefined;
   } catch {
@@ -58,7 +59,7 @@ export default function taskSchedulerExtension(
   let ownsScheduler = false;
 
   pi.on('session_start', async (_event, ctx) => {
-    const fileConfig = loadSettings(ctx.cwd);
+    const fileConfig = loadSettings(ctx.cwd, isProjectTrusted(ctx));
     const config = resolveConfig({ ...fileConfig, ...injectedConfig });
 
     try {

--- a/packages/pi-teamwork/README.md
+++ b/packages/pi-teamwork/README.md
@@ -20,6 +20,11 @@ When the extension starts and `multica` is not found on `$PATH`, it will automat
 
 Set `autoInstall: false` to disable this behavior.
 
+Configuration may live in user/agent settings or in a trusted project's
+`.pi/settings.json`. Project settings are ignored when trust is declined and do
+not expand `${ENV_VAR}`; keep environment-backed credentials in user or agent
+settings.
+
 ### Mode 1 — Self-hosted server
 
 For teams running their own Multica server. The extension runs `multica setup self-host` with the provided URLs, then authenticates with the token:

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -45,7 +45,7 @@
     "@amaster.ai/pi-shared": "workspace:*"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-teamwork/src/__tests__/index.test.ts
+++ b/packages/pi-teamwork/src/__tests__/index.test.ts
@@ -765,6 +765,7 @@ describe('piTeamworkExtension AMaster provider', () => {
       },
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: (_key: string, value: string) => statusUpdates.push(value),
           notify: vi.fn(),
@@ -833,6 +834,7 @@ describe('piTeamworkExtension AMaster provider', () => {
       {},
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),
@@ -896,6 +898,7 @@ describe('piTeamworkExtension AMaster provider', () => {
       { amasterEmployee: { apiKey: 'session-key' } },
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),
@@ -969,6 +972,7 @@ describe('piTeamworkExtension AMaster provider', () => {
         },
         {
           cwd: settingsDir,
+          isProjectTrusted: () => true,
           ui: {
             setStatus: vi.fn(),
             notify: vi.fn(),
@@ -1078,6 +1082,7 @@ describe('piTeamworkExtension AMaster provider', () => {
         { amasterEmployee: { apiKey: 'session-key' } },
         {
           cwd: settingsDir,
+          isProjectTrusted: () => true,
           ui: {
             setStatus: vi.fn(),
             notify: vi.fn(),
@@ -1169,6 +1174,7 @@ describe('piTeamworkExtension AMaster provider', () => {
       {},
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),
@@ -1222,6 +1228,7 @@ describe('piTeamworkExtension AMaster provider', () => {
       { amasterEmployee: { apiKey: 'session-key' } },
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),
@@ -1278,6 +1285,7 @@ describe('piTeamworkExtension AMaster provider', () => {
       {},
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),
@@ -1344,6 +1352,7 @@ describe('piTeamworkExtension Multica provider', () => {
       {},
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),
@@ -1394,6 +1403,7 @@ describe('piTeamworkExtension Multica provider', () => {
     )?.[1];
     const ctx = {
       cwd: settingsDir,
+      isProjectTrusted: () => true,
       ui: {
         setStatus: vi.fn(),
         notify: vi.fn(),
@@ -1449,6 +1459,7 @@ describe('piTeamworkExtension Multica provider', () => {
     )?.[1];
     const ctx = {
       cwd: settingsDir,
+      isProjectTrusted: () => true,
       ui: {
         setStatus: vi.fn(),
         notify: vi.fn(),
@@ -1508,6 +1519,7 @@ describe('piTeamworkExtension Multica provider', () => {
     )?.[1];
     const ctx = {
       cwd: settingsDir,
+      isProjectTrusted: () => true,
       ui: {
         setStatus: vi.fn(),
         notify: vi.fn(),
@@ -1563,6 +1575,7 @@ describe('piTeamworkExtension Multica provider', () => {
     )?.[1];
     const ctx = {
       cwd: settingsDir,
+      isProjectTrusted: () => true,
       ui: {
         setStatus: vi.fn(),
         notify: vi.fn(),
@@ -1640,6 +1653,7 @@ describe('piTeamworkExtension Multica provider', () => {
     const statusUpdates: string[] = [];
     const ctx = {
       cwd: settingsDir,
+      isProjectTrusted: () => true,
       ui: {
         setStatus: (_key: string, value: string) => statusUpdates.push(value),
         notify: vi.fn(),
@@ -1709,6 +1723,7 @@ describe('piTeamworkExtension Multica provider', () => {
       {},
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),
@@ -1752,6 +1767,7 @@ describe('piTeamworkExtension Multica provider', () => {
       {},
       {
         cwd: settingsDir,
+        isProjectTrusted: () => true,
         ui: {
           setStatus: vi.fn(),
           notify: vi.fn(),

--- a/packages/pi-teamwork/src/index.ts
+++ b/packages/pi-teamwork/src/index.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
+import { isProjectTrusted, loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import { defineTool, type ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { initAmasterProvider } from './adapters/amaster.js';
@@ -76,7 +76,7 @@ export default function piTeamworkExtension(pi: ExtensionAPI): void {
     provider = undefined;
     readyPromise = undefined;
 
-    const config = loadConfig(ctx.cwd);
+    const config = loadConfig(ctx.cwd, isProjectTrusted(ctx));
     if (config.enabled === false) {
       suspendTeamworkTools();
       ctx.ui.setStatus(STATUS_KEY, 'teamwork: disabled');
@@ -615,10 +615,11 @@ function optionalTrimmed<K extends string>(key: K, value: unknown): Partial<Reco
   return trimmed ? ({ [key]: trimmed } as Record<K, string>) : {};
 }
 
-function loadConfig(cwd: string): TeamworkConfig {
+function loadConfig(cwd: string, projectTrusted = false): TeamworkConfig {
   try {
     const config = loadPiSettings<Partial<TeamworkConfig>>(SETTINGS_KEY, {
       cwd,
+      projectTrusted,
     });
     return Object.keys(config).length > 0 ? (config as TeamworkConfig) : {};
   } catch {

--- a/packages/pi-telemetry/README.md
+++ b/packages/pi-telemetry/README.md
@@ -38,7 +38,12 @@ Traces are scoped to user input boundaries (not individual turns). A single user
 
 ## Configuration
 
-Configuration is read from `.pi/settings.json` under the `"pi-telemetry"` key. Project-level settings (`.pi/settings.json` in the working directory) take priority over user-level settings (`~/.pi/agent/settings.json`).
+Configuration is read from the `"pi-telemetry"` section of, in increasing
+priority, `~/.pi/agent/settings.json`, the configured agent directory's
+`settings.json` (for example `$PI_CODING_AGENT_DIR/settings.json`), and a trusted
+project's `.pi/settings.json`. Project settings are ignored when project trust
+is declined. Environment variables are expanded only in user and agent-directory
+settings.
 
 ```json
 {
@@ -71,7 +76,7 @@ Configuration is read from `.pi/settings.json` under the `"pi-telemetry"` key. P
 |-------|------|---------|-------------|
 | `serviceName` | `string` | `"pi-server"` | Service name for traces |
 | `serviceVersion` | `string` | — | Service version for traces |
-| `includePayloads` | `boolean` | `true` | Include chat payloads, tool args, LLM I/O |
+| `includePayloads` | `boolean` | `false` | Include chat payloads, tool args, LLM I/O |
 
 ### Langfuse Config
 
@@ -111,4 +116,4 @@ const otel = createOtelExporter(config);
 
 ## Privacy
 
-Runtime events may include user prompts, assistant responses, tool arguments, tool outputs, and model inputs/outputs. Set `includePayloads: false` to strip these from exported telemetry. For finer control, construct an exporter directly and pass `redactEvent`.
+Runtime events omit user prompts, assistant responses, tool arguments, tool outputs, and model inputs/outputs by default. Set `includePayloads: true` to include them. For finer control, construct an exporter directly and pass `redactEvent`.

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -62,7 +62,7 @@
     "langfuse": "^3.38.20"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0"
+    "@earendil-works/pi-coding-agent": ">=0.79.1"
   },
   "peerDependenciesMeta": {
     "@earendil-works/pi-coding-agent": {

--- a/packages/pi-telemetry/src/__tests__/config.test.ts
+++ b/packages/pi-telemetry/src/__tests__/config.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { resolveConfig } from '../config.js';
+
+describe('config', () => {
+  it('excludes payloads by default', () => {
+    expect(resolveConfig()).toMatchObject({
+      includePayloads: false,
+    });
+  });
+});

--- a/packages/pi-telemetry/src/__tests__/extension.test.ts
+++ b/packages/pi-telemetry/src/__tests__/extension.test.ts
@@ -22,6 +22,7 @@ vi.mock('../otel.js', () => ({
   })),
 }));
 
+import { loadConfigFromFile } from '../config.js';
 import { NoopRuntimeEventExporter } from '../index.js';
 import { createLangfuseExporter } from '../langfuse.js';
 import { createOtelExporter } from '../otel.js';
@@ -58,6 +59,7 @@ describe('telemetryExtension', () => {
     handlers.clear();
     mockPi.on.mockClear();
     mockPi.registerTool.mockClear();
+    (loadConfigFromFile as ReturnType<typeof vi.fn>).mockClear();
     (createLangfuseExporter as ReturnType<typeof vi.fn>).mockClear();
     (createOtelExporter as ReturnType<typeof vi.fn>).mockClear();
 
@@ -90,10 +92,40 @@ describe('telemetryExtension', () => {
 
   test('initializes exporter from config on session_start', async () => {
     telemetryExtension(mockPi as any);
-    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    await fireEvent(
+      'session_start',
+      { type: 'session_start', reason: 'startup' },
+      { cwd: '/project', isProjectTrusted: () => false },
+    );
 
+    expect(loadConfigFromFile).toHaveBeenCalledWith({
+      cwd: '/project',
+      projectTrusted: false,
+    });
     expect(createLangfuseExporter).toHaveBeenCalledTimes(1);
     expect(createOtelExporter).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retain an exporter after telemetry is disabled in a later session', async () => {
+    const previousExporter = {
+      publish: vi.fn(() => Promise.resolve()),
+      flush: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+    };
+    (createLangfuseExporter as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(previousExporter)
+      .mockReturnValueOnce(new NoopRuntimeEventExporter());
+
+    telemetryExtension(mockPi as any);
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    await fireEvent('session_start', { type: 'session_start', reason: 'new' });
+    await fireEvent('turn_start', {
+      type: 'turn_start',
+      turnIndex: 0,
+      timestamp: 1700000000000,
+    });
+
+    expect(previousExporter.publish).not.toHaveBeenCalled();
   });
 
   test('publishes chat_turn_started on turn_start', async () => {

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -69,6 +69,7 @@ describe('telemetry', () => {
       baseUrl: 'https://cloud.langfuse.com',
       flushAt: 20,
       flushIntervalMs: 5000,
+      includePayloads: false,
     });
 
     expect(
@@ -269,6 +270,17 @@ describe('telemetry', () => {
     });
 
     expect(client.flushed).toBe(1);
+  });
+
+  it('excludes OTEL payloads by default', () => {
+    expect(
+      resolveOtelConfig({
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'https://otel.example.com',
+      }),
+    ).toMatchObject({
+      enabled: true,
+      includePayloads: false,
+    });
   });
 
   it('exports completed spans through a generic OTEL traces endpoint', async () => {

--- a/packages/pi-telemetry/src/config.ts
+++ b/packages/pi-telemetry/src/config.ts
@@ -29,7 +29,7 @@ export interface TelemetryConfig {
 
 const DEFAULTS: TelemetryConfig = {
   serviceName: 'pi-server',
-  includePayloads: true,
+  includePayloads: false,
 };
 
 export function resolveConfig(config?: TelemetryConfig): TelemetryConfig {

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -5,6 +5,7 @@ import type {
   RuntimeLlmUsage,
   RuntimeModelConfig,
 } from '@amaster.ai/pi-shared';
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { loadConfigFromFile, resolveConfig } from './config.js';
 import {
@@ -215,16 +216,20 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
   let lastModelConfig: RuntimeModelConfig = { provider: 'unknown', model: 'unknown' };
 
   pi.on('session_start', async (_event, ctx) => {
-    const config = resolveConfig(loadConfigFromFile({ cwd: ctx.cwd }));
+    const config = resolveConfig(
+      loadConfigFromFile({
+        cwd: ctx.cwd,
+        projectTrusted: isProjectTrusted(ctx),
+      }),
+    );
     const langfuse = createLangfuseExporter(config);
     const otel = createOtelExporter(config);
 
     const active = [langfuse, otel].filter((e) => !(e instanceof NoopRuntimeEventExporter));
-    if (active.length > 1) {
-      exporter = new CompositeRuntimeEventExporter(active);
-    } else if (active.length === 1) {
-      exporter = active[0]!;
-    }
+    exporter =
+      active.length > 1
+        ? new CompositeRuntimeEventExporter(active)
+        : (active[0] ?? new NoopRuntimeEventExporter());
   });
 
   pi.on('input', async (event) => {

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -619,7 +619,7 @@ export function resolveLangfuseExporterConfig(
     flushIntervalMs: lf?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS,
     serviceName: telemetryConfig.serviceName ?? 'pi-server',
     ...(telemetryConfig.serviceVersion ? { serviceVersion: telemetryConfig.serviceVersion } : {}),
-    includePayloads: telemetryConfig.includePayloads ?? true,
+    includePayloads: telemetryConfig.includePayloads ?? false,
   };
 }
 
@@ -644,7 +644,7 @@ export function resolveLangfuseConfig(env: TelemetryEnvironment): LangfuseExport
     ...(serviceVersion ? { serviceVersion } : {}),
     includePayloads: parseBooleanWithDefault(
       env.TELEMETRY_INCLUDE_PAYLOADS ?? env.LANGFUSE_INCLUDE_PAYLOADS,
-      true,
+      false,
     ),
   };
 }

--- a/packages/pi-telemetry/src/otel.ts
+++ b/packages/pi-telemetry/src/otel.ts
@@ -34,7 +34,7 @@ export function resolveOtelExporterConfig(telemetryConfig: TelemetryConfig): Ote
     ...(otel?.errorLabel ? { errorLabel: otel.errorLabel } : {}),
     serviceName: telemetryConfig.serviceName ?? 'pi',
     ...(telemetryConfig.serviceVersion ? { serviceVersion: telemetryConfig.serviceVersion } : {}),
-    includePayloads: telemetryConfig.includePayloads ?? true,
+    includePayloads: telemetryConfig.includePayloads ?? false,
   };
 }
 
@@ -70,7 +70,7 @@ export function resolveOtelConfig(env: TelemetryEnvironment): OtelExporterConfig
     ),
     serviceName,
     ...(serviceVersion ? { serviceVersion } : {}),
-    includePayloads: parseBooleanWithDefault(env.TELEMETRY_INCLUDE_PAYLOADS, true),
+    includePayloads: parseBooleanWithDefault(env.TELEMETRY_INCLUDE_PAYLOADS, false),
   };
 }
 

--- a/packages/pi-web-access/README.md
+++ b/packages/pi-web-access/README.md
@@ -63,6 +63,10 @@ Search X (Twitter) for posts and social media content. Only registered when xai 
 
 Settings key: `pi-web-access`
 
+Project `.pi/settings.json` values are loaded only after project trust is
+accepted and are not environment-interpolated. User and agent settings retain
+environment interpolation.
+
 ```json
 {
   "pi-web-access": {
@@ -115,7 +119,7 @@ Per-provider configuration. Each provider supports:
 
 | Field | Description |
 |-------|-------------|
-| `apiKey` | API key. Supports `${ENV_VAR}` syntax. |
+| `apiKey` | API key. User and agent settings support `$ENV_VAR` and `${ENV_VAR}`; only the braced form supports `:-fallback`. Project settings keep placeholders literal. |
 | `baseUrl` | Override the default API endpoint. |
 | `model` | Override the default model. |
 | `headers` | Extra headers merged into every request. |

--- a/packages/pi-web-access/package.json
+++ b/packages/pi-web-access/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.10",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-web-access/src/__tests__/config.test.ts
+++ b/packages/pi-web-access/src/__tests__/config.test.ts
@@ -131,7 +131,7 @@ describe('resolveProvider', () => {
   });
 
   // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional env var syntax test
-  it('resolves ${ENV_VAR} in apiKey', () => {
+  it('does not interpolate ${ENV_VAR} in resolver input', () => {
     process.env.MY_TAVILY_KEY = 'resolved-key';
     const settings: WebToolSettings = {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional
@@ -140,12 +140,12 @@ describe('resolveProvider', () => {
     const result = resolveProvider('tavily', settings);
     expect(result).not.toHaveProperty('error');
     if (!('error' in result)) {
-      expect(result.apiKey).toBe('resolved-key');
+      expect(result.apiKey).toBe(`$${'{MY_TAVILY_KEY}'}`);
     }
   });
 
   // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional env var syntax test
-  it('resolves ${ENV_VAR} in baseUrl', () => {
+  it('does not interpolate ${ENV_VAR} in resolver base URLs', () => {
     process.env.MY_BASE = 'https://custom.example.com';
     const settings: WebToolSettings = {
       // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional
@@ -154,7 +154,21 @@ describe('resolveProvider', () => {
     const result = resolveProvider('kimi', settings);
     expect(result).not.toHaveProperty('error');
     if (!('error' in result)) {
-      expect(result.baseUrl).toBe('https://custom.example.com');
+      expect(result.baseUrl).toBe(`$${'{MY_BASE}'}`);
+    }
+  });
+
+  it('falls back after empty provider overrides', () => {
+    process.env.TAVILY_API_KEY = 'provider-key';
+    const result = resolveProvider('tavily', {
+      providers: {
+        tavily: { apiKey: '', baseUrl: '' },
+      },
+    });
+    expect(result).not.toHaveProperty('error');
+    if (!('error' in result)) {
+      expect(result.apiKey).toBe('provider-key');
+      expect(result.baseUrl).toBe('https://api.tavily.com');
     }
   });
 

--- a/packages/pi-web-access/src/config.ts
+++ b/packages/pi-web-access/src/config.ts
@@ -48,32 +48,16 @@ const DEFAULT_MODEL: Partial<Record<BuiltInProviderId, string>> = {
 
 // ─── Settings loading ────────────────────────────────────────────────────────
 
-export function loadWebToolSettings(cwd: string): WebToolSettings {
+export function loadWebToolSettings(cwd: string, projectTrusted = false): WebToolSettings {
   try {
     return loadPiSettings<WebToolSettings>(SETTINGS_KEY, {
       cwd,
+      projectTrusted,
+      expandBareEnvVars: true,
     });
   } catch {
     return {};
   }
-}
-
-// ─── Env-var resolution ──────────────────────────────────────────────────────
-
-function resolveString(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  const replaced = value.replace(
-    /\$\{([^}]+)\}|\$([A-Z_][A-Z0-9_]*)/g,
-    (_match, braced: string | undefined, bare: string | undefined) => {
-      const name = (braced ?? bare) as string | undefined;
-      if (!name) return '';
-      const [varName, ...rest] = name.split(':-');
-      const fallback = rest.join(':-');
-      const env = process.env[varName!];
-      return env !== undefined && env !== '' ? env : fallback;
-    },
-  );
-  return replaced.length > 0 ? replaced : undefined;
 }
 
 // ─── Provider resolution ─────────────────────────────────────────────────────
@@ -96,8 +80,8 @@ export function resolveProvider(
   }
 
   const config = settings.providers?.[requested] ?? {};
-  const apiKey = resolveString(config.apiKey) ?? process.env[ENV_VARS[requested]];
-  const baseUrl = resolveString(config.baseUrl) ?? DEFAULT_BASE_URL[requested];
+  const apiKey = config.apiKey || process.env[ENV_VARS[requested]];
+  const baseUrl = config.baseUrl || DEFAULT_BASE_URL[requested];
 
   const provider: ResolvedProvider = {
     id: requested,

--- a/packages/pi-web-access/src/index.ts
+++ b/packages/pi-web-access/src/index.ts
@@ -1,3 +1,4 @@
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { loadWebToolSettings, resolveProvider, resolveSearchProvider } from './config.js';
@@ -35,7 +36,7 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
   let settings: WebToolSettings = {};
 
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
-    settings = loadWebToolSettings(ctx.cwd);
+    settings = loadWebToolSettings(ctx.cwd, isProjectTrusted(ctx));
 
     const searchResolved = resolveSearchProvider(settings);
     const hasSearch = !('error' in searchResolved) && Boolean(searchResolved.apiKey);

--- a/packages/pi-wecom/README.md
+++ b/packages/pi-wecom/README.md
@@ -12,7 +12,11 @@ Pi extension for [WeCom (企业微信)](https://work.weixin.qq.com/) workspace �
 
 ## Configuration
 
-Add to your `.pi/settings.json`:
+Add to `~/.pi/agent/settings.json` or a trusted project's `.pi/settings.json`:
+
+Project settings are loaded only after project trust is accepted. For
+environment-backed credentials, use user or agent settings because project
+settings do not expand `${ENV_VAR}`.
 
 ```json
 {

--- a/packages/pi-wecom/package.json
+++ b/packages/pi-wecom/package.json
@@ -51,7 +51,7 @@
     "test": "vitest run src"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.79.1",
     "typebox": "*"
   },
   "peerDependenciesMeta": {

--- a/packages/pi-wecom/src/__tests__/config.test.ts
+++ b/packages/pi-wecom/src/__tests__/config.test.ts
@@ -39,7 +39,7 @@ describe('loadWeComConfig', () => {
       }),
     );
 
-    const config = loadWeComConfig(project);
+    const config = loadWeComConfig(project, true);
 
     expect(config).toEqual({
       botId: 'bot_abc123',
@@ -57,7 +57,7 @@ describe('loadWeComConfig', () => {
       }),
     );
 
-    const config = loadWeComConfig(project);
+    const config = loadWeComConfig(project, true);
     expect(config).toBeUndefined();
   });
 });

--- a/packages/pi-wecom/src/config.ts
+++ b/packages/pi-wecom/src/config.ts
@@ -7,8 +7,8 @@ export type WeComConfig = {
 
 const SETTINGS_KEY = 'pi-wecom';
 
-export function loadWeComConfig(cwd: string): WeComConfig | undefined {
-  const config = loadPiSettings<WeComConfig>(SETTINGS_KEY, { cwd });
+export function loadWeComConfig(cwd: string, projectTrusted = false): WeComConfig | undefined {
+  const config = loadPiSettings<WeComConfig>(SETTINGS_KEY, { cwd, projectTrusted });
   if (!config || (!config.botId && !config.botSecret)) return undefined;
   return config;
 }

--- a/packages/pi-wecom/src/index.ts
+++ b/packages/pi-wecom/src/index.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { ensureWeComCli, getWeComCliSkillsDir, isWeComCliAuthenticated } from './cli.js';
 import { loadWeComConfig } from './config.js';
@@ -19,7 +20,7 @@ export default function piWeComExtension(pi: ExtensionAPI): void {
   let skillsDir: string | undefined;
 
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
-    const config = loadWeComConfig(ctx.cwd);
+    const config = loadWeComConfig(ctx.cwd, isProjectTrusted(ctx));
     if (!config?.botId || !config?.botSecret) return;
 
     if (existsSync(BUNDLED_SKILLS_DIR)) {

--- a/packages/shared/src/__tests__/settings.test.ts
+++ b/packages/shared/src/__tests__/settings.test.ts
@@ -19,6 +19,17 @@ function envRef(expr: string): string {
   return '$' + `{${expr}}`;
 }
 
+describe('isProjectTrusted', () => {
+  it('grants project access only for an explicit true result', async () => {
+    const { isProjectTrusted } = await import('../../src/settings.js');
+
+    expect(isProjectTrusted({ isProjectTrusted: () => true })).toBe(true);
+    expect(isProjectTrusted({ isProjectTrusted: () => false })).toBe(false);
+    expect(isProjectTrusted({})).toBe(false);
+    expect(isProjectTrusted(undefined)).toBe(false);
+  });
+});
+
 describe('loadPiSettings env var resolution', () => {
   let tempDir: string;
   let settingsPath: string;
@@ -27,8 +38,9 @@ describe('loadPiSettings env var resolution', () => {
 
   beforeEach(() => {
     tempDir = join(tmpdir(), `pi-settings-test-${Date.now()}`);
-    mkdirSync(join(tempDir, '.pi'), { recursive: true });
-    settingsPath = join(tempDir, '.pi', 'settings.json');
+    mkdirSync(join(tempDir, '.pi', 'agent'), { recursive: true });
+    settingsPath = join(tempDir, '.pi', 'agent', 'settings.json');
+    mockedHome = tempDir;
     originalCwd = process.cwd();
     originalEnv = { ...process.env };
     process.chdir(tempDir);
@@ -37,6 +49,7 @@ describe('loadPiSettings env var resolution', () => {
   afterEach(() => {
     process.chdir(originalCwd);
     process.env = originalEnv;
+    mockedHome = undefined;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -54,6 +67,33 @@ describe('loadPiSettings env var resolution', () => {
       }),
     );
     const result = await loadSettings<{ name: string }>('myExt');
+    expect(result.name).toBe('claude-opus');
+  });
+
+  it('keeps bare env refs literal by default', async () => {
+    process.env.TEST_MODEL = 'claude-opus';
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { name: '$TEST_MODEL' },
+      }),
+    );
+    const result = await loadSettings<{ name: string }>('myExt');
+    expect(result.name).toBe('$TEST_MODEL');
+  });
+
+  it('resolves bare env refs when explicitly enabled', async () => {
+    process.env.TEST_MODEL = 'claude-opus';
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        myExt: { name: '$TEST_MODEL' },
+      }),
+    );
+    const { loadPiSettings } = await import('../../src/settings.js');
+    const result = loadPiSettings<{ name: string }>('myExt', {
+      expandBareEnvVars: true,
+    });
     expect(result.name).toBe('claude-opus');
   });
 
@@ -206,7 +246,7 @@ describe('3-layer settings resolution', () => {
     expect(result.b).toBe('global');
   });
 
-  it('project settings override configDir settings', async () => {
+  it('ignores project settings when trust is not explicitly granted', async () => {
     writeFileSync(
       join(configDir, 'settings.json'),
       JSON.stringify({ ext: { a: 'agent', b: 'agent' } }),
@@ -221,8 +261,55 @@ describe('3-layer settings resolution', () => {
       configDir,
       cwd: projectDir,
     });
+    expect(result.a).toBe('agent');
+    expect(result.b).toBe('agent');
+  });
+
+  it('project settings override configDir settings when project is trusted', async () => {
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({ ext: { a: 'agent', b: 'agent' } }),
+    );
+    writeFileSync(
+      join(projectDir, '.pi', 'settings.json'),
+      JSON.stringify({ ext: { a: 'project' } }),
+    );
+
+    const { loadPiSettings } = await import('../../src/settings.js');
+    const result = loadPiSettings<{ a: string; b: string }>('ext', {
+      configDir,
+      cwd: projectDir,
+      projectTrusted: true,
+    });
     expect(result.a).toBe('project');
     expect(result.b).toBe('agent');
+  });
+
+  it('does not interpolate env vars from trusted project settings', async () => {
+    const originalSecret = process.env.PROJECT_SECRET;
+    process.env.PROJECT_SECRET = 'must-not-expand';
+    writeFileSync(
+      join(projectDir, '.pi', 'settings.json'),
+      JSON.stringify({
+        ext: {
+          value: envRef('PROJECT_SECRET'),
+          bare: '$PROJECT_SECRET',
+        },
+      }),
+    );
+
+    const { loadPiSettings } = await import('../../src/settings.js');
+    const result = loadPiSettings<{ value: string; bare: string }>('ext', {
+      configDir,
+      cwd: projectDir,
+      projectTrusted: true,
+      expandBareEnvVars: true,
+    });
+    expect(result.value).toBe(envRef('PROJECT_SECRET'));
+    expect(result.bare).toBe('$PROJECT_SECRET');
+
+    if (originalSecret === undefined) delete process.env.PROJECT_SECRET;
+    else process.env.PROJECT_SECRET = originalSecret;
   });
 
   it('env var interpolation works in configDir layer', async () => {
@@ -248,7 +335,10 @@ describe('3-layer settings resolution', () => {
     );
 
     const { loadPiSettings } = await import('../../src/settings.js');
-    const result = loadPiSettings<{ a: string; b: string }>('ext', { cwd: projectDir });
+    const result = loadPiSettings<{ a: string; b: string }>('ext', {
+      cwd: projectDir,
+      projectTrusted: true,
+    });
     expect(result.a).toBe('global');
     expect(result.b).toBe('project');
   });
@@ -311,8 +401,27 @@ describe('loadPiPolicyProfiles', () => {
     const result = loadPiPolicyProfiles<{ extends?: string; capabilities?: { allow?: string[] } }>({
       configDir,
       cwd: projectDir,
+      projectTrusted: true,
     });
     expect(result.custom).toEqual({ extends: 'copilot', capabilities: { allow: ['*'] } });
+  });
+
+  it('ignores project policies when trust is not explicitly granted', async () => {
+    writeFileSync(
+      join(configPolicyDir, 'custom.json'),
+      JSON.stringify({ extends: 'chat', capabilities: { allow: ['read_file'] } }),
+    );
+    writeFileSync(
+      join(projectPolicyDir, 'custom.json'),
+      JSON.stringify({ extends: 'copilot', capabilities: { allow: ['*'] } }),
+    );
+
+    const { loadPiPolicyProfiles } = await import('../../src/settings.js');
+    const result = loadPiPolicyProfiles<{ extends?: string; capabilities?: { allow?: string[] } }>({
+      configDir,
+      cwd: projectDir,
+    });
+    expect(result.custom).toEqual({ extends: 'chat', capabilities: { allow: ['read_file'] } });
   });
 
   it('merges profiles from all three directories', async () => {
@@ -324,7 +433,11 @@ describe('loadPiPolicyProfiles', () => {
     );
 
     const { loadPiPolicyProfiles } = await import('../../src/settings.js');
-    const result = loadPiPolicyProfiles<{ extends?: string }>({ configDir, cwd: projectDir });
+    const result = loadPiPolicyProfiles<{ extends?: string }>({
+      configDir,
+      cwd: projectDir,
+      projectTrusted: true,
+    });
     expect(result['global-only']).toEqual({ extends: 'chat' });
     expect(result['agent-only']).toEqual({ extends: 'admin' });
     expect(result['project-only']).toEqual({ extends: 'copilot' });

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -6,37 +6,59 @@ export type PiSettingsOptions = {
   cwd?: string;
   /** Override for the config directory. If not set, resolveConfigDir() is used. */
   configDir?: string;
+  /** Whether project-local settings and policies may be read. Defaults to false. */
+  projectTrusted?: boolean;
+  /** Also expand bare $ENV_VAR references in global and agent-dir settings. */
+  expandBareEnvVars?: boolean;
 };
 
-function resolveEnvVars(value: unknown): unknown {
+export function isProjectTrusted(
+  context: { isProjectTrusted?: () => boolean } | null | undefined,
+): boolean {
+  return context?.isProjectTrusted?.() === true;
+}
+
+function resolveEnvVars(value: unknown, expandBareEnvVars: boolean): unknown {
   if (typeof value === 'string') {
-    return value.replace(/\$\{([^}]+)\}/g, (_match, expr: string) => {
-      const [name, ...rest] = expr.split(':-');
-      const fallback = rest.join(':-');
-      const envVal = process.env[name!];
-      if (envVal !== undefined && envVal !== '') return envVal;
-      return fallback;
-    });
+    const pattern = expandBareEnvVars ? /\$\{([^}]+)\}|\$([A-Z_][A-Z0-9_]*)/g : /\$\{([^}]+)\}/g;
+    return value.replace(
+      pattern,
+      (_match, braced: string | undefined, bare: string | undefined) => {
+        const expr = braced ?? bare ?? '';
+        const [name, ...rest] = expr.split(':-');
+        const fallback = rest.join(':-');
+        const envVal = process.env[name!];
+        if (envVal !== undefined && envVal !== '') return envVal;
+        return fallback;
+      },
+    );
   }
   if (Array.isArray(value)) {
-    return value.map(resolveEnvVars);
+    return value.map((item) => resolveEnvVars(item, expandBareEnvVars));
   }
   if (value && typeof value === 'object') {
     const result: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) {
-      result[k] = resolveEnvVars(v);
+      result[k] = resolveEnvVars(v, expandBareEnvVars);
     }
     return result;
   }
   return value;
 }
 
-function readSettingsSection<T>(filePath: string, key: string): Partial<T> {
+function readSettingsSection<T>(
+  filePath: string,
+  key: string,
+  options: { expandEnv: boolean; expandBareEnvVars: boolean },
+): Partial<T> {
   try {
     const raw = readFileSync(filePath, 'utf-8');
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return resolveEnvVars(parsed[key] ?? {}) as Partial<T>;
+      const section = parsed[key] ?? {};
+      return (
+        options.expandEnv ? resolveEnvVars(section, options.expandBareEnvVars) : section
+      ) as Partial<T>;
     }
     return {};
   } catch {
@@ -72,22 +94,36 @@ export function resolveAgentDir(override?: string): string {
 
 /**
  * Load extension config from pi-agent settings files.
- * Reads from global (~/.pi/agent/settings.json), agentDir (env/param), and project (<cwd>/.pi/settings.json).
+ * Reads from global (~/.pi/agent/settings.json), agentDir (env/param), and trusted project
+ * (<cwd>/.pi/settings.json) settings.
  * Priority from low to high: global < agentDir < project.
+ * Environment variables are expanded only in the global and agentDir layers.
  */
 export function loadPiSettings<T>(key: string, options?: PiSettingsOptions): T {
   const globalDir = resolve(join(homedir(), '.pi', 'agent'));
   const configDir = resolveConfigDir(options?.configDir);
   const cwd = options?.cwd ?? process.cwd();
 
-  const globalSettings = readSettingsSection<T>(join(globalDir, 'settings.json'), key);
+  const globalSettings = readSettingsSection<T>(join(globalDir, 'settings.json'), key, {
+    expandEnv: true,
+    expandBareEnvVars: options?.expandBareEnvVars === true,
+  });
 
   const configSettings =
     configDir === globalDir
       ? ({} as Partial<T>)
-      : readSettingsSection<T>(join(configDir, 'settings.json'), key);
+      : readSettingsSection<T>(join(configDir, 'settings.json'), key, {
+          expandEnv: true,
+          expandBareEnvVars: options?.expandBareEnvVars === true,
+        });
 
-  const projectSettings = readSettingsSection<T>(join(cwd, '.pi', 'settings.json'), key);
+  const projectSettings =
+    options?.projectTrusted === true
+      ? readSettingsSection<T>(join(cwd, '.pi', 'settings.json'), key, {
+          expandEnv: false,
+          expandBareEnvVars: false,
+        })
+      : ({} as Partial<T>);
 
   return { ...globalSettings, ...configSettings, ...projectSettings } as T;
 }
@@ -126,7 +162,10 @@ export function loadPiPolicyProfiles<T>(options?: PiSettingsOptions): Record<str
     configPolicyDir === globalDir
       ? ({} as Record<string, T>)
       : loadJsonProfileDir<T>(configPolicyDir);
-  const projectPolicies = loadJsonProfileDir<T>(projectDir);
+  const projectPolicies =
+    options?.projectTrusted === true
+      ? loadJsonProfileDir<T>(projectDir)
+      : ({} as Record<string, T>);
 
   return { ...globalPolicies, ...configPolicies, ...projectPolicies };
 }


### PR DESCRIPTION
## Summary

- honor Pi project trust before loading project-local settings and policy profiles
- expand environment variables only in global and agent-dir settings, never in project settings
- default telemetry payload export to disabled and reset exporters between sessions
- propagate the trust decision through first-party extensions and document the new behavior

## Root cause

`@amaster.ai/pi-shared` read `<cwd>/.pi/settings.json` and `<cwd>/.pi/policy/` without consulting Pi project trust. Telemetry could then use project-controlled OTEL endpoints and headers even after the user declined trust.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 84 files, 1237 tests passed
- `pnpm build`

Reported by @agardnerIT.

Closes #95