### PR TITLE
feat: resolve plugin provider auth per session

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -100,13 +100,19 @@ That's it. From the agent: `image_generate({ prompt: "a cyberpunk cat" })`.
 | ----------------- | ---------------------------------------------------------------------------------------- |
 | `defaultModel`    | Model id or alias the tool will use. **Required.**                                       |
 | `outputDir`       | Where to write generated images. Relative paths resolve against the session cwd. Default `.pi/images`. |
-| `providers`       | Per-built-in-provider override. Set `apiKey`, `baseUrl`, or `headers` to point at a proxy or non-standard env var. |
+| `providers`       | Per-built-in-provider override. Set `apiKey`, `baseUrl`, `headers`, or `runtimeAuthProvider`. |
 | `customProviders` | User-defined providers — see below.                                                      |
 
 In global and agent settings, `apiKey`, `baseUrl`, and `headers` values support
 `$VAR` and `${VAR}` environment interpolation. Fallbacks require the braced
 form (for example, `${FOO:-default}`); `$FOO:-default` is not supported.
 Project settings keep all of these placeholders literal.
+
+Set `runtimeAuthProvider` on a built-in or custom provider to resolve its API
+key, base URL, and auth headers from `ctx.modelRegistry` in the current Pi
+session. Runtime auth is kept in memory, replaces static authentication fields,
+and fails closed when unavailable; resolved credentials are never written back
+to settings.
 
 ## Built-in setup walkthrough
 
@@ -201,10 +207,11 @@ Each custom provider declares:
 | Field      | Required | Notes                                                                                |
 | ---------- | -------- | ------------------------------------------------------------------------------------ |
 | `api` | yes      | One of `openai`, `gemini`, `dashscope`, `openrouter`, `ark`. Picks the image-API wire shape. |
-| `baseUrl`  | yes      | API endpoint URL. `$VAR` syntax supported.                                           |
-| `apiKey`   | usually  | API key string. `$VAR` syntax supported.                                             |
+| `baseUrl`  | yes, unless runtime auth | API endpoint URL. `$VAR` syntax supported.                              |
+| `apiKey`   | usually, unless runtime auth | API key string. `$VAR` syntax supported.                          |
 | `name`     | no       | Display name shown in `/image-gen list`.                                             |
 | `headers`  | no       | Extra headers merged into every request.                                             |
+| `runtimeAuthProvider` | no | Pi model-registry provider used for session-scoped API credentials and endpoint. |
 | `models`   | no       | Optional model id/alias list. Omit to make this a **catch-all** — the provider will accept any unknown model id (passed through as the remote id). Provide a list only when you want aliases or want to route specific ids elsewhere. Each entry is a string or `{ id, alias?, name? }`. |
 
 > Note: pi.dev custom providers also have an `api` field, but its values (`openai-completions`, `anthropic-messages`, …) are LLM streaming formats that don't apply to image generation. The values here (`openai`, `gemini`, `dashscope`, `openrouter`, `ark`) are image-API wire shapes — same field name, different namespace.

--- a/packages/pi-image-gen/src/__tests__/runtime-auth.test.ts
+++ b/packages/pi-image-gen/src/__tests__/runtime-auth.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveModel } from '../config.js';
+import { openaiAdapter } from '../providers/openai.js';
+import { materializeImageGenSettings } from '../runtime-auth.js';
+import type { ImageGenSettings } from '../types.js';
+
+function registry(apiKey: string, baseUrl: string) {
+  const model = { provider: 'amaster', baseUrl };
+  return {
+    getAll: vi.fn(() => [model]),
+    getApiKeyAndHeaders: vi.fn(async () => ({
+      ok: true as const,
+      apiKey,
+      headers: { 'x-company': apiKey },
+    })),
+  };
+}
+
+const settings: ImageGenSettings = {
+  defaultModel: 'gpt-image-1',
+  customProviders: {
+    amaster: {
+      api: 'openai',
+      apiKey: 'stale-shared-key',
+      baseUrl: 'https://stale.example/v1',
+      headers: {
+        authorization: 'Bearer stale-shared-key',
+        'x-static': 'kept',
+      },
+      runtimeAuthProvider: 'amaster',
+      models: ['gpt-image-1'],
+    },
+  },
+};
+
+describe('image provider runtime auth', () => {
+  it('materializes a session-local provider configuration', async () => {
+    const result = await materializeImageGenSettings(
+      settings,
+      registry('company-a-key', 'https://company-a.example/v1'),
+    );
+
+    expect(result.customProviders?.amaster).toEqual({
+      api: 'openai',
+      apiKey: 'company-a-key',
+      baseUrl: 'https://company-a.example/v1',
+      headers: {
+        'x-static': 'kept',
+        'x-company': 'company-a-key',
+      },
+      runtimeAuthProvider: 'amaster',
+      models: ['gpt-image-1'],
+    });
+    expect(settings.customProviders?.amaster?.apiKey).toBe('stale-shared-key');
+  });
+
+  it('removes static credentials when session auth is unavailable', async () => {
+    const result = await materializeImageGenSettings(settings, {
+      getAll: () => [],
+      getApiKeyAndHeaders: vi.fn(),
+    });
+
+    expect(result.customProviders?.amaster).toEqual({
+      api: 'openai',
+      headers: { 'x-static': 'kept' },
+      runtimeAuthProvider: 'amaster',
+      models: ['gpt-image-1'],
+    });
+  });
+
+  it('keeps concurrent session configurations isolated', async () => {
+    const [companyA, companyB] = await Promise.all([
+      materializeImageGenSettings(
+        settings,
+        registry('company-a-key', 'https://company-a.example/v1'),
+      ),
+      materializeImageGenSettings(
+        settings,
+        registry('company-b-key', 'https://company-b.example/v1'),
+      ),
+    ]);
+
+    expect(companyA.customProviders?.amaster?.apiKey).toBe('company-a-key');
+    expect(companyB.customProviders?.amaster?.apiKey).toBe('company-b-key');
+  });
+
+  it('uses session auth in the outbound image request', async () => {
+    const materialized = await materializeImageGenSettings(
+      settings,
+      registry('company-a-key', 'https://company-a.example/v1'),
+    );
+    const resolved = resolveModel('gpt-image-1', materialized);
+    if ('error' in resolved) throw new Error(resolved.error);
+    const fetchMock = vi.fn(async () =>
+      Response.json({ data: [{ b64_json: 'aW1hZ2U=' }] }),
+    ) as unknown as typeof fetch;
+
+    await openaiAdapter.generate(
+      resolved.provider,
+      resolved.remoteId,
+      { prompt: 'runtime auth' },
+      fetchMock,
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = vi.mocked(fetchMock).mock.calls[0]!;
+    expect(url).toBe('https://company-a.example/v1/images/generations');
+    expect(init?.headers).toMatchObject({
+      authorization: 'Bearer company-a-key',
+      'x-company': 'company-a-key',
+      'x-static': 'kept',
+    });
+  });
+});

--- a/packages/pi-image-gen/src/config.ts
+++ b/packages/pi-image-gen/src/config.ts
@@ -34,7 +34,9 @@ function buildBuiltInProvider(
   settings: ImageGenSettings,
 ): ResolvedProvider | null {
   const override = settings.providers?.[id] ?? {};
-  const apiKey = override.apiKey || process.env[ENV_VARS[id]];
+  const apiKey = override.runtimeAuthProvider
+    ? override.apiKey
+    : override.apiKey || process.env[ENV_VARS[id]];
   const provider: ResolvedProvider = {
     id,
     api: DEFAULT_API_STYLE[id],

--- a/packages/pi-image-gen/src/index.ts
+++ b/packages/pi-image-gen/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from './config.js';
 import { errorMessageForUser, toLogSummary } from './errors.js';
 import { generateImage } from './generate.js';
+import { materializeImageGenSettings } from './runtime-auth.js';
 import type { ApiStyle, GenerateImageParams, ImageGenResult, ImageGenSettings } from './types.js';
 
 export { loadImageGenSettings, resolveModel } from './config.js';
@@ -103,7 +104,10 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
 
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
     sessionCwd = ctx.cwd;
-    settings = loadImageGenSettings(ctx.cwd, isProjectTrusted(ctx));
+    settings = await materializeImageGenSettings(
+      loadImageGenSettings(ctx.cwd, isProjectTrusted(ctx)),
+      ctx.modelRegistry,
+    );
     registerImageTool();
   });
 
@@ -113,7 +117,10 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
       const raw = (args ?? '').trim();
       const tokens = raw.split(/\s+/).filter(Boolean);
       if (tokens[0] === 'reload') {
-        settings = loadImageGenSettings(ctx.cwd, isProjectTrusted(ctx));
+        settings = await materializeImageGenSettings(
+          loadImageGenSettings(ctx.cwd, isProjectTrusted(ctx)),
+          ctx.modelRegistry,
+        );
         // Re-register so the schema (e.g. whether `quality` is exposed) tracks
         // the newly loaded model, not just the settings read at execute time.
         registerImageTool();

--- a/packages/pi-image-gen/src/runtime-auth.ts
+++ b/packages/pi-image-gen/src/runtime-auth.ts
@@ -1,0 +1,69 @@
+import {
+  mergeRuntimeAuthHeaders,
+  type RuntimeAuthRegistry,
+  resolveRuntimeProviderAuth,
+} from '@amaster.ai/pi-shared/runtime-auth';
+import type {
+  BuiltInProviderId,
+  BuiltInProviderOverride,
+  CustomImageProvider,
+  ImageGenSettings,
+} from './types.js';
+
+type RuntimeProviderConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  headers?: Record<string, string>;
+  runtimeAuthProvider?: string;
+};
+
+async function materializeProvider<T extends RuntimeProviderConfig>(
+  config: T,
+  registry: RuntimeAuthRegistry,
+): Promise<T> {
+  const runtimeProvider = config.runtimeAuthProvider?.trim();
+  if (!runtimeProvider) return { ...config };
+
+  const headers = mergeRuntimeAuthHeaders(config.headers);
+  const {
+    apiKey: _staticApiKey,
+    baseUrl: _staticBaseUrl,
+    headers: _staticHeaders,
+    ...provider
+  } = config;
+  const materialized = {
+    ...provider,
+    ...(headers ? { headers } : {}),
+  } as T;
+  const runtimeAuth = await resolveRuntimeProviderAuth(runtimeProvider, registry);
+  if (!runtimeAuth.ok) return materialized;
+
+  const runtimeHeaders = mergeRuntimeAuthHeaders(headers, runtimeAuth.headers);
+  return {
+    ...materialized,
+    apiKey: runtimeAuth.apiKey,
+    baseUrl: runtimeAuth.baseUrl,
+    ...(runtimeHeaders ? { headers: runtimeHeaders } : {}),
+  };
+}
+
+export async function materializeImageGenSettings(
+  settings: ImageGenSettings,
+  registry: RuntimeAuthRegistry,
+): Promise<ImageGenSettings> {
+  const providers: Partial<Record<BuiltInProviderId, BuiltInProviderOverride>> = {};
+  for (const [name, config] of Object.entries(settings.providers ?? {})) {
+    providers[name as BuiltInProviderId] = await materializeProvider(config, registry);
+  }
+
+  const customProviders: Record<string, CustomImageProvider> = {};
+  for (const [name, config] of Object.entries(settings.customProviders ?? {})) {
+    customProviders[name] = await materializeProvider(config, registry);
+  }
+
+  return {
+    ...settings,
+    ...(settings.providers ? { providers } : {}),
+    ...(settings.customProviders ? { customProviders } : {}),
+  };
+}

--- a/packages/pi-image-gen/src/types.ts
+++ b/packages/pi-image-gen/src/types.ts
@@ -25,6 +25,8 @@ export type CustomImageProvider = {
   name?: string;
   /** Extra headers merged into every outbound request. */
   headers?: Record<string, string>;
+  /** Resolve API credentials and endpoint from this provider in the current Pi session. */
+  runtimeAuthProvider?: string;
   /** Models routed through this provider. Each entry is a model id (string) or an object. */
   models?: Array<string | CustomImageModel>;
 };
@@ -43,6 +45,8 @@ export type BuiltInProviderOverride = {
   apiKey?: string;
   baseUrl?: string;
   headers?: Record<string, string>;
+  /** Resolve API credentials and endpoint from this provider in the current Pi session. */
+  runtimeAuthProvider?: string;
 };
 
 export type ImageGenSettings = {

--- a/packages/pi-web-access/README.md
+++ b/packages/pi-web-access/README.md
@@ -123,8 +123,12 @@ Per-provider configuration. Each provider supports:
 | `baseUrl` | Override the default API endpoint. |
 | `model` | Override the default model. |
 | `headers` | Extra headers merged into every request. |
+| `runtimeAuthProvider` | Resolve the API key, base URL, and auth headers from this provider in the current Pi session. Runtime auth replaces static auth and fails closed when unavailable. |
 
 Environment variables serve as fallbacks when `apiKey` is not set in config.
+When `runtimeAuthProvider` is set, the extension resolves auth from
+`ctx.modelRegistry` for that session instead; it does not write the resolved
+credential back to settings or fall back to a configured static key.
 
 ## Architecture
 

--- a/packages/pi-web-access/src/__tests__/extension.test.ts
+++ b/packages/pi-web-access/src/__tests__/extension.test.ts
@@ -27,8 +27,8 @@ function createMockPi() {
     on(event: string, handler: Function) {
       listeners[event] = handler;
     },
-    async triggerSessionStart(cwd = '/test') {
-      const ctx = { cwd } as any;
+    async triggerSessionStart(cwd = '/test', context: Record<string, unknown> = {}) {
+      const ctx = { cwd, ...context } as any;
       await listeners.session_start!({}, ctx);
     },
   };
@@ -71,6 +71,47 @@ describe('piWebToolExtension - tool registration', () => {
     const pi = createMockPi();
     piWebToolExtension(pi as any);
     await pi.triggerSessionStart();
+
+    expect(pi.tools.map((t) => t.name)).not.toContain('web_search');
+  });
+
+  it('registers web_search with runtime auth from the session model registry', async () => {
+    mockLoadSettings.mockReturnValue({
+      search: { provider: 'kimi' },
+      providers: { kimi: { runtimeAuthProvider: 'amaster' } },
+    });
+
+    const pi = createMockPi();
+    piWebToolExtension(pi as any);
+    await pi.triggerSessionStart('/test', {
+      modelRegistry: {
+        getAll: () => [{ provider: 'amaster', baseUrl: 'https://company-a.example/v1' }],
+        getApiKeyAndHeaders: async () => ({ ok: true, apiKey: 'company-a-key' }),
+      },
+    });
+
+    expect(pi.tools.map((t) => t.name)).toContain('web_search');
+  });
+
+  it('does not register runtime-auth search when session auth is unavailable', async () => {
+    mockLoadSettings.mockReturnValue({
+      search: { provider: 'kimi' },
+      providers: {
+        kimi: {
+          apiKey: 'stale-shared-key',
+          runtimeAuthProvider: 'amaster',
+        },
+      },
+    });
+
+    const pi = createMockPi();
+    piWebToolExtension(pi as any);
+    await pi.triggerSessionStart('/test', {
+      modelRegistry: {
+        getAll: () => [],
+        getApiKeyAndHeaders: vi.fn(),
+      },
+    });
 
     expect(pi.tools.map((t) => t.name)).not.toContain('web_search');
   });

--- a/packages/pi-web-access/src/__tests__/runtime-auth.test.ts
+++ b/packages/pi-web-access/src/__tests__/runtime-auth.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveProviderForSession, resolveSearchProviderForSession } from '../runtime-auth.js';
+import { search } from '../search.js';
+import type { WebToolSettings } from '../types.js';
+
+function registry(apiKey: string, baseUrl: string) {
+  const model = { provider: 'amaster', baseUrl };
+  return {
+    getAll: vi.fn(() => [model]),
+    getApiKeyAndHeaders: vi.fn(async () => ({
+      ok: true as const,
+      apiKey,
+      headers: { 'x-company': apiKey },
+    })),
+  };
+}
+
+const settings: WebToolSettings = {
+  search: { provider: 'kimi' },
+  providers: {
+    kimi: {
+      apiKey: 'stale-shared-key',
+      baseUrl: 'https://stale.example/v1',
+      headers: {
+        Authorization: 'Bearer stale-shared-key',
+        'x-static': 'kept',
+      },
+      runtimeAuthProvider: 'amaster',
+    },
+  },
+};
+
+describe('web provider runtime auth', () => {
+  it('materializes the provider with session auth and endpoint', async () => {
+    const result = await resolveSearchProviderForSession(
+      settings,
+      registry('company-a-key', 'https://company-a.example/v1'),
+    );
+
+    expect(result).toEqual({
+      id: 'kimi',
+      apiKey: 'company-a-key',
+      baseUrl: 'https://company-a.example/v1',
+      model: 'kimi-k2.6',
+      headers: {
+        'x-static': 'kept',
+        'x-company': 'company-a-key',
+      },
+    });
+  });
+
+  it('does not fall back to a static key when runtime auth fails', async () => {
+    const result = await resolveProviderForSession('kimi', settings, {
+      getAll: () => [],
+      getApiKeyAndHeaders: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      error: 'Runtime auth provider "amaster" is not available in this session.',
+    });
+  });
+
+  it('resolves the same provider independently for concurrent sessions', async () => {
+    const [companyA, companyB] = await Promise.all([
+      resolveSearchProviderForSession(
+        settings,
+        registry('company-a-key', 'https://company-a.example/v1'),
+      ),
+      resolveSearchProviderForSession(
+        settings,
+        registry('company-b-key', 'https://company-b.example/v1'),
+      ),
+    ]);
+
+    expect(companyA).toMatchObject({ apiKey: 'company-a-key' });
+    expect(companyB).toMatchObject({ apiKey: 'company-b-key' });
+  });
+
+  it('auto-selects a provider backed only by session auth', async () => {
+    const result = await resolveSearchProviderForSession(
+      { providers: settings.providers! },
+      registry('company-a-key', 'https://company-a.example/v1'),
+    );
+
+    expect(result).toMatchObject({
+      id: 'kimi',
+      apiKey: 'company-a-key',
+    });
+  });
+
+  it('uses session auth in the outbound search request', async () => {
+    const provider = await resolveSearchProviderForSession(
+      settings,
+      registry('company-a-key', 'https://company-a.example/v1'),
+    );
+    if ('error' in provider) throw new Error(provider.error);
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'done' } }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    try {
+      await search({ query: 'runtime auth' }, settings, provider);
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, init] = fetchMock.mock.calls[0]!;
+      expect(url).toBe('https://company-a.example/v1/chat/completions');
+      expect(init?.headers).toMatchObject({
+        Authorization: 'Bearer company-a-key',
+        'x-company': 'company-a-key',
+        'x-static': 'kept',
+      });
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+});

--- a/packages/pi-web-access/src/config.ts
+++ b/packages/pi-web-access/src/config.ts
@@ -95,7 +95,7 @@ export function resolveProvider(
   return provider;
 }
 
-const ALL_SEARCH_PROVIDER_IDS: BuiltInProviderId[] = [
+export const SEARCH_PROVIDER_IDS: BuiltInProviderId[] = [
   'tavily',
   'brave',
   'firecrawl',
@@ -116,7 +116,7 @@ export function resolveSearchProvider(
   if (settings.search?.provider) {
     return resolveProvider(settings.search.provider, settings);
   }
-  for (const id of ALL_SEARCH_PROVIDER_IDS) {
+  for (const id of SEARCH_PROVIDER_IDS) {
     const resolved = resolveProvider(id, settings);
     if (!('error' in resolved) && resolved.apiKey) return resolved;
   }

--- a/packages/pi-web-access/src/fetch.ts
+++ b/packages/pi-web-access/src/fetch.ts
@@ -1,6 +1,6 @@
 import TurndownService from 'turndown';
 import { resolveFetchProvider } from './config.js';
-import type { FetchResponse } from './providers/index.js';
+import type { FetchResponse, ResolvedProvider } from './providers/index.js';
 import { getProvider } from './providers/index.js';
 import type { WebToolSettings } from './types.js';
 
@@ -81,9 +81,11 @@ async function fetchWithFallback(url: string, timeoutMs: number): Promise<FetchR
 export async function webFetch(
   params: WebFetchParams,
   settings: WebToolSettings,
+  resolvedProvider?: ResolvedProvider | null,
 ): Promise<FetchResponse> {
   const timeoutMs = settings.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const resolved = resolveFetchProvider(settings);
+  const resolved =
+    resolvedProvider === undefined ? resolveFetchProvider(settings) : resolvedProvider;
   if (resolved) {
     const provider = getProvider(resolved.id);
     if (!provider) {

--- a/packages/pi-web-access/src/index.ts
+++ b/packages/pi-web-access/src/index.ts
@@ -1,11 +1,16 @@
 import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
-import { loadWebToolSettings, resolveProvider, resolveSearchProvider } from './config.js';
+import { loadWebToolSettings } from './config.js';
 import { webFetch } from './fetch.js';
 import type { SearchParams } from './providers/index.js';
 import { getProvider } from './providers/index.js';
 import type { XaiProvider } from './providers/xai.js';
+import {
+  resolveFetchProviderForSession,
+  resolveProviderForSession,
+  resolveSearchProviderForSession,
+} from './runtime-auth.js';
 import { search } from './search.js';
 import { summarizeContent } from './summary.js';
 import type { WebToolSettings } from './types.js';
@@ -38,9 +43,15 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
     settings = loadWebToolSettings(ctx.cwd, isProjectTrusted(ctx));
 
-    const searchResolved = resolveSearchProvider(settings);
+    const searchResolved = await resolveSearchProviderForSession(settings, ctx.modelRegistry);
     const hasSearch = !('error' in searchResolved) && Boolean(searchResolved.apiKey);
-    const hasFetch = Boolean(settings.fetch?.provider) || Boolean(settings.fetch?.summary);
+    const fetchResolved = await resolveFetchProviderForSession(settings, ctx.modelRegistry);
+    const fetchRuntimeProvider = settings.fetch?.provider
+      ? settings.providers?.[settings.fetch.provider]?.runtimeAuthProvider
+      : undefined;
+    const hasFetch = fetchRuntimeProvider
+      ? fetchResolved !== null && !('error' in fetchResolved) && Boolean(fetchResolved.apiKey)
+      : Boolean(settings.fetch?.provider) || Boolean(settings.fetch?.summary);
 
     if (hasSearch) {
       pi.registerTool({
@@ -97,7 +108,7 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
           _ctx: ExtensionContext,
         ) {
           const searchParams = params as unknown as SearchParams;
-          const response = await search(searchParams, settings);
+          const response = await search(searchParams, settings, searchResolved);
 
           const lines: string[] = [];
           lines.push(`## Web Search Results (${response.provider})`);
@@ -158,7 +169,11 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
           fetchCtx: ExtensionContext,
         ) {
           const fetchParams = params as unknown as { url: string; prompt: string };
-          const result = await webFetch({ url: fetchParams.url }, settings);
+          const result = await webFetch(
+            { url: fetchParams.url },
+            settings,
+            fetchResolved && !('error' in fetchResolved) ? fetchResolved : null,
+          );
 
           let content = result.content;
           if (settings.fetch?.summary) {
@@ -183,7 +198,7 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
     }
 
     // x_search: only register when xai provider has an API key
-    const xaiResolved = resolveProvider('xai', settings);
+    const xaiResolved = await resolveProviderForSession('xai', settings, ctx.modelRegistry);
     const hasXai = !('error' in xaiResolved) && Boolean(xaiResolved.apiKey);
     if (hasXai) {
       pi.registerTool({

--- a/packages/pi-web-access/src/runtime-auth.ts
+++ b/packages/pi-web-access/src/runtime-auth.ts
@@ -1,0 +1,61 @@
+import {
+  mergeRuntimeAuthHeaders,
+  type RuntimeAuthRegistry,
+  resolveRuntimeProviderAuth,
+} from '@amaster.ai/pi-shared/runtime-auth';
+import { resolveProvider, SEARCH_PROVIDER_IDS } from './config.js';
+import type { ResolvedProvider } from './providers/index.js';
+import type { BuiltInProviderId, WebToolSettings } from './types.js';
+
+type ProviderResolution = ResolvedProvider | { error: string };
+
+export async function resolveProviderForSession(
+  name: BuiltInProviderId,
+  settings: WebToolSettings,
+  registry: RuntimeAuthRegistry,
+): Promise<ProviderResolution> {
+  const resolved = resolveProvider(name, settings);
+  if ('error' in resolved) return resolved;
+
+  const runtimeProvider = settings.providers?.[name]?.runtimeAuthProvider?.trim();
+  if (!runtimeProvider) return resolved;
+
+  const runtimeAuth = await resolveRuntimeProviderAuth(runtimeProvider, registry);
+  if (!runtimeAuth.ok) return { error: runtimeAuth.error };
+
+  const headers = mergeRuntimeAuthHeaders(resolved.headers, runtimeAuth.headers);
+  const { headers: _staticHeaders, ...provider } = resolved;
+  return {
+    ...provider,
+    apiKey: runtimeAuth.apiKey,
+    baseUrl: runtimeAuth.baseUrl,
+    ...(headers ? { headers } : {}),
+  };
+}
+
+export async function resolveSearchProviderForSession(
+  settings: WebToolSettings,
+  registry: RuntimeAuthRegistry,
+): Promise<ProviderResolution> {
+  if (settings.search?.provider) {
+    return resolveProviderForSession(settings.search.provider, settings, registry);
+  }
+
+  for (const provider of SEARCH_PROVIDER_IDS) {
+    const resolved = await resolveProviderForSession(provider, settings, registry);
+    if (!('error' in resolved) && resolved.apiKey) return resolved;
+  }
+  return {
+    error:
+      'No search provider configured. Set search.provider or configure a provider with an API key.',
+  };
+}
+
+export async function resolveFetchProviderForSession(
+  settings: WebToolSettings,
+  registry: RuntimeAuthRegistry,
+): Promise<ProviderResolution | null> {
+  const provider = settings.fetch?.provider;
+  if (!provider) return null;
+  return resolveProviderForSession(provider, settings, registry);
+}

--- a/packages/pi-web-access/src/search.ts
+++ b/packages/pi-web-access/src/search.ts
@@ -1,13 +1,14 @@
 import { resolveSearchProvider } from './config.js';
-import type { SearchParams, SearchResponse } from './providers/index.js';
+import type { ResolvedProvider, SearchParams, SearchResponse } from './providers/index.js';
 import { getProvider } from './providers/index.js';
 import type { WebToolSettings } from './types.js';
 
 export async function search(
   params: SearchParams,
   settings: WebToolSettings,
+  resolvedProvider?: ResolvedProvider,
 ): Promise<SearchResponse> {
-  const resolved = resolveSearchProvider(settings);
+  const resolved = resolvedProvider ?? resolveSearchProvider(settings);
   if ('error' in resolved) {
     throw new Error(resolved.error);
   }

--- a/packages/pi-web-access/src/types.ts
+++ b/packages/pi-web-access/src/types.ts
@@ -20,6 +20,8 @@ export interface ProviderConfig {
   baseUrl?: string;
   model?: string;
   headers?: Record<string, string>;
+  /** Resolve API credentials and endpoint from this provider in the current Pi session. */
+  runtimeAuthProvider?: string;
 }
 
 export interface SummaryModelConfig {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/settings.d.ts",
       "default": "./dist/settings.js"
     },
+    "./runtime-auth": {
+      "types": "./dist/runtime-auth.d.ts",
+      "default": "./dist/runtime-auth.js"
+    },
     "./package.json": {
       "default": "./package.json"
     }

--- a/packages/shared/src/__tests__/runtime-auth.test.ts
+++ b/packages/shared/src/__tests__/runtime-auth.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveRuntimeProviderAuth } from '../runtime-auth.js';
+
+function registry(apiKey: string, baseUrl: string) {
+  const model = {
+    provider: 'amaster',
+    baseUrl,
+    headers: { 'x-model-header': 'model' },
+  };
+  return {
+    getAll: vi.fn(() => [model]),
+    getApiKeyAndHeaders: vi.fn(async () => ({
+      ok: true as const,
+      apiKey,
+      headers: { 'x-runtime-header': 'runtime' },
+    })),
+  };
+}
+
+describe('resolveRuntimeProviderAuth', () => {
+  it('resolves credentials from the current session registry', async () => {
+    const result = await resolveRuntimeProviderAuth(
+      'amaster',
+      registry('company-a-key', 'https://company-a.example/v1'),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      apiKey: 'company-a-key',
+      baseUrl: 'https://company-a.example/v1',
+      headers: {
+        'x-model-header': 'model',
+        'x-runtime-header': 'runtime',
+      },
+    });
+  });
+
+  it('keeps concurrent session credentials isolated', async () => {
+    const [companyA, companyB] = await Promise.all([
+      resolveRuntimeProviderAuth(
+        'amaster',
+        registry('company-a-key', 'https://company-a.example/v1'),
+      ),
+      resolveRuntimeProviderAuth(
+        'amaster',
+        registry('company-b-key', 'https://company-b.example/v1'),
+      ),
+    ]);
+
+    expect(companyA).toMatchObject({ ok: true, apiKey: 'company-a-key' });
+    expect(companyB).toMatchObject({ ok: true, apiKey: 'company-b-key' });
+  });
+
+  it('fails closed when the provider has no model in the session registry', async () => {
+    const result = await resolveRuntimeProviderAuth('amaster', {
+      getAll: () => [],
+      getApiKeyAndHeaders: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Runtime auth provider "amaster" is not available in this session.',
+    });
+  });
+});

--- a/packages/shared/src/runtime-auth.ts
+++ b/packages/shared/src/runtime-auth.ts
@@ -1,0 +1,91 @@
+export type RuntimeAuthModel = {
+  provider: string;
+  baseUrl: string;
+  headers?: Record<string, string>;
+};
+
+export type RuntimeAuthResult =
+  | {
+      ok: true;
+      apiKey: string;
+      baseUrl: string;
+      headers?: Record<string, string>;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+export type RuntimeAuthRegistry<TModel extends RuntimeAuthModel = RuntimeAuthModel> = {
+  getAll(): TModel[];
+  getApiKeyAndHeaders(
+    model: TModel,
+  ): Promise<
+    { ok: true; apiKey?: string; headers?: Record<string, string> } | { ok: false; error: string }
+  >;
+};
+
+const AUTH_HEADER_NAMES = new Set([
+  'api-key',
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'x-goog-api-key',
+]);
+
+export function mergeRuntimeAuthHeaders(
+  staticHeaders?: Record<string, string>,
+  runtimeHeaders?: Record<string, string>,
+): Record<string, string> | undefined {
+  const merged: Record<string, string> = {};
+  for (const [name, value] of Object.entries(staticHeaders ?? {})) {
+    if (!AUTH_HEADER_NAMES.has(name.toLowerCase())) merged[name] = value;
+  }
+  Object.assign(merged, runtimeHeaders);
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+export async function resolveRuntimeProviderAuth<TModel extends RuntimeAuthModel>(
+  provider: string,
+  registry: RuntimeAuthRegistry<TModel>,
+): Promise<RuntimeAuthResult> {
+  const requested = provider.trim();
+  const model = registry.getAll().find((candidate) => candidate.provider === requested);
+  if (!model) {
+    return {
+      ok: false,
+      error: `Runtime auth provider "${requested}" is not available in this session.`,
+    };
+  }
+
+  try {
+    const auth = await registry.getApiKeyAndHeaders(model);
+    if (!auth.ok) {
+      return {
+        ok: false,
+        error: `Runtime auth provider "${requested}" failed: ${auth.error}`,
+      };
+    }
+    if (!auth.apiKey) {
+      return {
+        ok: false,
+        error: `Runtime auth provider "${requested}" did not provide an API key.`,
+      };
+    }
+
+    const headers = mergeRuntimeAuthHeaders(model.headers, auth.headers);
+    return {
+      ok: true,
+      apiKey: auth.apiKey,
+      baseUrl: model.baseUrl,
+      ...(headers ? { headers } : {}),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `Runtime auth provider "${requested}" failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
+}


### PR DESCRIPTION
## 问题

`pi-web-access` 和 `pi-image-gen` 目前只从共享 `settings.json` / 环境变量读取 provider 的 `apiKey` 与 `baseUrl`。在 Pi Agent 同一进程并发运行多个 Company 会话时，这种进程级配置无法表达“同一个 `amaster` provider、不同 Company 使用不同 new-api key”，也存在共享凭据串用风险。

## 修改

- 在 `@amaster.ai/pi-shared/runtime-auth` 增加通用的会话 provider 认证解析器，通过当前扩展上下文的 `modelRegistry` 获取 API key、base URL 和 headers。
- `pi-web-access` provider 新增 `runtimeAuthProvider`：Web Search、Web Fetch、X Search 在 `session_start` 时解析当前会话认证；认证不可用时 fail closed，不回退静态 key。
- `pi-image-gen` 的 built-in/custom provider 新增 `runtimeAuthProvider`：仅在内存中物化当前会话配置，`/image-gen reload` 也重新绑定当前会话；不写回 settings。
- 运行时认证会替换静态认证 header，并保留非认证自定义 header，避免旧 Authorization 覆盖当前会话 key。
- 保持未配置 `runtimeAuthProvider` 的原有静态 provider 行为不变，并补充 README 配置说明。

## 影响

- 插件本身不感知 Platform、Organization 或 Company，仅依赖 Pi 通用的 session `modelRegistry`，不会与上层产品形态耦合。
- 同一个 provider id 可以在不同并发会话中使用不同凭据和 endpoint。
- 配置运行时认证后，认证缺失只会关闭对应能力，不会使用 settings 中残留的静态 key。
- 新增 `@amaster.ai/pi-shared/runtime-auth` 公开子路径；消费方需要同时升级 `pi-shared`、`pi-web-access` 和 `pi-image-gen`。

## 验证

- `pnpm run pr-check`
- 87 个测试文件通过，共 1251 条测试通过。
- 覆盖两个并发 session 使用不同 Company key、运行时认证缺失 fail closed、静态认证 header 清理。
- 覆盖 Kimi Web Search 与 OpenAI-compatible Image API 的实际出站 URL 和 Authorization 断言。
