### PR TITLE
fix(ci): grant PR labeler write permission

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -36,6 +36,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 env:
   # Run JavaScript actions (checkout, setup-node, pnpm/action-setup, etc.) on


### PR DESCRIPTION
## What

Grant the PR labeler `pull-requests: write` in addition to `issues: write`.

## Why

The labeler can create repository labels with `issues: write`, but adding existing labels to a pull request requires `pull-requests: write`. Runs currently fail with `403 Resource not accessible by integration` at `issues.addLabels`.

## Verification

- Reproduced the missing permission with a focused workflow assertion before the change
- The same assertion passes after the change
- YAML parses successfully
- `git diff --check` passes

After this merges, rerun or manually dispatch `PR Labeler` for #100 so it uses the updated workflow from `master`.