### PR TITLE
feat(pi-web-access): use Kimi Formula web search

### DIFF
--- a/packages/pi-web-access/README.md
+++ b/packages/pi-web-access/README.md
@@ -47,7 +47,7 @@ Search X (Twitter) for posts and social media content. Only registered when xai 
 | `tavily` | ✓ | ✓ | ✗ | `https://api.tavily.com` | `TAVILY_API_KEY` | - |
 | `brave` | ✓ | ✗ | ✗ | `https://api.search.brave.com` | `BRAVE_API_KEY` | - |
 | `firecrawl` | ✓ | ✓ | ✗ | `https://api.firecrawl.dev` | `FIRECRAWL_API_KEY` | - |
-| `kimi` | ✓ | ✗ | ✗ | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` | `kimi-k2.6` |
+| `kimi` | ✓ | ✗ | ✗ | `https://api.moonshot.cn/v1` | `MOONSHOT_API_KEY` | `kimi-k3` |
 | `mimo` | ✓ | ✗ | ✗ | `https://api.xiaomimimo.com/v1` | `MIMO_API_KEY` | `mimo-v2.5-pro` |
 | `zai` | ✓ | ✓ | ✗ | `https://api.z.ai` | `ZAI_API_KEY` | - |
 | `gemini` | ✓ | ✗ | ✗ | `https://generativelanguage.googleapis.com/v1beta` | `GEMINI_API_KEY` | `gemini-2.5-flash` |
@@ -56,6 +56,8 @@ Search X (Twitter) for posts and social media content. Only registered when xai 
 | `xai` | ✓ | ✗ | ✓ | `https://api.x.ai/v1` | `XAI_API_KEY` | `grok-4.3` |
 | `openai` | ✓ | ✗ | ✗ | `https://api.openai.com/v1` | `OPENAI_API_KEY` | `gpt-5.5` |
 | `anthropic` | ✓ | ✓ | ✗ | `https://api.anthropic.com/v1` | `ANTHROPIC_API_KEY` | `claude-sonnet-4-6` |
+
+Custom Kimi base URLs must support both `/chat/completions` and `/formulas/*`.
 
 **Fetch fallback** (when `fetch.provider` is not set): Jina Reader (`r.jina.ai`, free, JS-rendered) → local HTTP GET + turndown.
 

--- a/packages/pi-web-access/src/__tests__/config.test.ts
+++ b/packages/pi-web-access/src/__tests__/config.test.ts
@@ -43,7 +43,7 @@ describe('resolveProvider', () => {
       expect(result.id).toBe('kimi');
       expect(result.baseUrl).toBe('https://api.moonshot.cn/v1');
       expect(result.apiKey).toBe('test-kimi-key');
-      expect(result.model).toBe('kimi-k2.6');
+      expect(result.model).toBe('kimi-k3');
     }
   });
 

--- a/packages/pi-web-access/src/__tests__/providers-system-prompt.test.ts
+++ b/packages/pi-web-access/src/__tests__/providers-system-prompt.test.ts
@@ -34,16 +34,31 @@ describe('LLM providers include system prompt and environment context', () => {
       search: { provider: 'kimi' },
       providers: { kimi: { apiKey: 'kimi-key' } },
     };
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'answer' } }],
-      }),
-    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'web_search',
+                parameters: { type: 'object', properties: {} },
+              },
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          choices: [{ finish_reason: 'stop', message: { role: 'assistant', content: 'answer' } }],
+        }),
+      });
 
     await search({ query: 'test query' }, settings);
 
-    const body = JSON.parse(mockFetch.mock.calls[0]![1].body);
+    const body = JSON.parse(mockFetch.mock.calls[1]![1].body);
     expect(body.messages[0].role).toBe('system');
     expect(body.messages[0].content).toBe(SEARCH_SYSTEM_PROMPT);
     expect(body.messages[1].role).toBe('user');

--- a/packages/pi-web-access/src/__tests__/search.test.ts
+++ b/packages/pi-web-access/src/__tests__/search.test.ts
@@ -6,6 +6,49 @@ const mockFetch = vi.fn();
 
 vi.stubGlobal('fetch', mockFetch);
 
+const KIMI_FORMULA_TOOLS = [
+  {
+    type: 'function',
+    function: {
+      name: 'web_search',
+      description: 'Search the web for information',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+      },
+    },
+  },
+];
+
+function okJson(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+function kimiToolCalls(
+  toolCalls: Array<{
+    id: string;
+    type: 'function';
+    function: { name: string; arguments: string };
+  }>,
+  message: Record<string, unknown> = {},
+) {
+  return okJson({
+    choices: [
+      {
+        finish_reason: 'tool_calls',
+        message: { role: 'assistant', ...message, tool_calls: toolCalls },
+      },
+    ],
+  });
+}
+
+function kimiAnswer(content: string) {
+  return okJson({
+    choices: [{ finish_reason: 'stop', message: { role: 'assistant', content } }],
+  });
+}
+
 describe('search', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
@@ -46,49 +89,192 @@ describe('search', () => {
     expect(opts.headers.Authorization).toBe('Bearer tavily-key');
   });
 
-  it('uses search.provider kimi with two-round flow', async () => {
+  it('uses search.provider kimi through the Formula web search tool', async () => {
     const settings: WebToolSettings = {
       search: { provider: 'kimi' },
       providers: { kimi: { apiKey: 'kimi-key' } },
     };
     mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          choices: [
-            {
-              finish_reason: 'tool_calls',
-              message: {
-                role: 'assistant',
-                tool_calls: [
-                  {
-                    id: 'call_1',
-                    type: 'function',
-                    function: { name: '$web_search', arguments: '{"query":"test"}' },
-                  },
-                ],
-              },
-            },
-          ],
+      .mockResolvedValueOnce(okJson({ tools: KIMI_FORMULA_TOOLS }))
+      .mockResolvedValueOnce(
+        kimiToolCalls([
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'web_search', arguments: '{"query":"test"}' },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        okJson({
+          status: 'succeeded',
+          context: { output: '', encrypted_output: 'encrypted search result' },
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          choices: [
-            {
-              finish_reason: 'stop',
-              message: { role: 'assistant', content: 'Kimi answer' },
-            },
-          ],
-        }),
-      });
+      )
+      .mockResolvedValueOnce(kimiAnswer('Kimi answer'));
 
     const result = await search({ query: 'test' }, settings);
 
     expect(result.provider).toBe('kimi');
     expect(result.answer).toBe('Kimi answer');
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls.map(([url]) => url)).toEqual([
+      'https://api.moonshot.cn/v1/formulas/moonshot/web-search:latest/tools',
+      'https://api.moonshot.cn/v1/chat/completions',
+      'https://api.moonshot.cn/v1/formulas/moonshot/web-search:latest/fibers',
+      'https://api.moonshot.cn/v1/chat/completions',
+    ]);
+
+    const firstChatBody = JSON.parse(mockFetch.mock.calls[1]![1].body);
+    expect(firstChatBody.model).toBe('kimi-k3');
+    expect(firstChatBody.tools).toEqual(KIMI_FORMULA_TOOLS);
+    expect(firstChatBody).not.toHaveProperty('thinking');
+
+    const fiberBody = JSON.parse(mockFetch.mock.calls[2]![1].body);
+    expect(fiberBody).toEqual({ name: 'web_search', arguments: '{"query":"test"}' });
+
+    const finalChatBody = JSON.parse(mockFetch.mock.calls[3]![1].body);
+    expect(finalChatBody.messages.at(-1)).toEqual({
+      role: 'tool',
+      tool_call_id: 'call_1',
+      content: 'encrypted search result',
+    });
+  });
+
+  it('handles every Formula tool call across multiple rounds', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'kimi' },
+      providers: { kimi: { apiKey: 'kimi-key' } },
+    };
+    mockFetch
+      .mockResolvedValueOnce(okJson({ tools: KIMI_FORMULA_TOOLS }))
+      .mockResolvedValueOnce(
+        kimiToolCalls(
+          [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'web_search', arguments: '{"query":"one"}' },
+            },
+            {
+              id: 'call_2',
+              type: 'function',
+              function: { name: 'web_search', arguments: '{"query":"two"}' },
+            },
+          ],
+          { content: '', reasoning_content: 'search twice' },
+        ),
+      )
+      .mockResolvedValueOnce(okJson({ status: 'succeeded', context: { output: 'result one' } }))
+      .mockResolvedValueOnce(
+        okJson({
+          status: 'succeeded',
+          context: { encrypted_output: 'result two' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        kimiToolCalls([
+          {
+            id: 'call_3',
+            type: 'function',
+            function: { name: 'web_search', arguments: '{"query":"three"}' },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(okJson({ status: 'succeeded', context: { output: 'result three' } }))
+      .mockResolvedValueOnce(kimiAnswer('Combined answer'));
+
+    const result = await search({ query: 'test' }, settings);
+
+    expect(result.answer).toBe('Combined answer');
+    const secondChatBody = JSON.parse(mockFetch.mock.calls[4]![1].body);
+    expect(secondChatBody.messages.slice(-3)).toEqual([
+      expect.objectContaining({ role: 'assistant', reasoning_content: 'search twice' }),
+      { role: 'tool', tool_call_id: 'call_1', content: 'result one' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'result two' },
+    ]);
+  });
+
+  it('rejects an unsuccessful Formula web search', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'kimi' },
+      providers: { kimi: { apiKey: 'kimi-key' } },
+    };
+    mockFetch
+      .mockResolvedValueOnce(okJson({ tools: KIMI_FORMULA_TOOLS }))
+      .mockResolvedValueOnce(
+        kimiToolCalls([
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'web_search', arguments: '{"query":"test"}' },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(okJson({ status: 'failed', context: { error: 'internal details' } }));
+
+    await expect(search({ query: 'test' }, settings)).rejects.toThrow(
+      'Kimi Formula web search failed',
+    );
+  });
+
+  it('rejects an empty Formula tool declaration', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'kimi' },
+      providers: { kimi: { apiKey: 'kimi-key' } },
+    };
+    mockFetch.mockResolvedValueOnce(okJson({ tools: [] }));
+
+    await expect(search({ query: 'test' }, settings)).rejects.toThrow(
+      'Kimi Formula web search returned no tools',
+    );
+  });
+
+  it('rejects a successful Formula web search without output', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'kimi' },
+      providers: { kimi: { apiKey: 'kimi-key' } },
+    };
+    mockFetch
+      .mockResolvedValueOnce(okJson({ tools: KIMI_FORMULA_TOOLS }))
+      .mockResolvedValueOnce(
+        kimiToolCalls([
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'web_search', arguments: '{"query":"test"}' },
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(okJson({ status: 'succeeded', context: {} }));
+
+    await expect(search({ query: 'test' }, settings)).rejects.toThrow(
+      'Kimi Formula web search returned no output',
+    );
+  });
+
+  it('stops after eight Formula tool rounds', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'kimi' },
+      providers: { kimi: { apiKey: 'kimi-key' } },
+    };
+    mockFetch.mockResolvedValueOnce(okJson({ tools: KIMI_FORMULA_TOOLS }));
+    for (let round = 0; round < 8; round++) {
+      mockFetch
+        .mockResolvedValueOnce(
+          kimiToolCalls([
+            {
+              id: `call_${round}`,
+              type: 'function',
+              function: { name: 'web_search', arguments: '{"query":"test"}' },
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(okJson({ status: 'succeeded', context: { output: 'result' } }));
+    }
+
+    await expect(search({ query: 'test' }, settings)).rejects.toThrow(
+      'Kimi Formula web search exceeded 8 tool rounds',
+    );
   });
 
   it('uses search.provider mimo and extracts annotations', async () => {
@@ -154,17 +340,9 @@ describe('search', () => {
     const settings: WebToolSettings = {
       providers: { kimi: { apiKey: 'kimi-key' } },
     };
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        choices: [
-          {
-            finish_reason: 'stop',
-            message: { role: 'assistant', content: 'auto kimi' },
-          },
-        ],
-      }),
-    });
+    mockFetch
+      .mockResolvedValueOnce(okJson({ tools: KIMI_FORMULA_TOOLS }))
+      .mockResolvedValueOnce(kimiAnswer('auto kimi'));
 
     const result = await search({ query: 'test' }, settings);
     expect(result.provider).toBe('kimi');

--- a/packages/pi-web-access/src/config.ts
+++ b/packages/pi-web-access/src/config.ts
@@ -37,7 +37,7 @@ const ENV_VARS: Record<BuiltInProviderId, string> = {
 };
 
 const DEFAULT_MODEL: Partial<Record<BuiltInProviderId, string>> = {
-  kimi: 'kimi-k2.6',
+  kimi: 'kimi-k3',
   mimo: 'mimo-v2.5-pro',
   gemini: 'gemini-2.5-flash',
   perplexity: 'openai/gpt-5.5',

--- a/packages/pi-web-access/src/providers/kimi.ts
+++ b/packages/pi-web-access/src/providers/kimi.ts
@@ -2,10 +2,13 @@ import { BaseProvider, getEnvironmentContext, SEARCH_SYSTEM_PROMPT } from './bas
 import type { ResolvedProvider, SearchParams, SearchResponse } from './index.js';
 
 const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_TOOL_ROUNDS = 8;
+const WEB_SEARCH_FORMULA = 'moonshot/web-search:latest';
 
 interface KimiMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
   content?: string;
+  reasoning_content?: string;
   tool_calls?: Array<{
     id: string;
     type: 'function';
@@ -17,6 +20,23 @@ interface KimiMessage {
 
 interface KimiResponse {
   choices: Array<{ finish_reason: string; message: KimiMessage }>;
+}
+
+interface KimiTool {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+}
+
+interface FormulaFiberResponse {
+  status: string;
+  context?: {
+    output?: string;
+    encrypted_output?: string;
+  };
 }
 
 export class KimiProvider extends BaseProvider {
@@ -34,60 +54,101 @@ export class KimiProvider extends BaseProvider {
       { role: 'user', content: `${getEnvironmentContext()}\n\n${params.query}` },
     ];
 
-    const firstResponse = await this.callApi(messages, provider);
-    const firstChoice = firstResponse.choices[0];
-    if (!firstChoice) throw new Error('Kimi API returned empty response');
+    const tools = await this.loadTools(provider);
+    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
+      const response = await this.callApi(messages, tools, provider);
+      const choice = response.choices[0];
+      if (!choice) throw new Error('Kimi API returned empty response');
 
-    if (firstChoice.finish_reason === 'tool_calls' && firstChoice.message.tool_calls?.length) {
-      const toolCall = firstChoice.message.tool_calls[0]!;
-      messages.push(firstChoice.message);
-      messages.push({
-        role: 'tool',
-        tool_call_id: toolCall.id,
-        name: toolCall.function.name,
-        content: toolCall.function.arguments,
-      });
+      const toolCalls = choice.message.tool_calls ?? [];
+      if (choice.finish_reason !== 'tool_calls' || toolCalls.length === 0) {
+        return {
+          provider: provider.id,
+          query: params.query,
+          answer: choice.message.content ?? '',
+          results: [],
+        };
+      }
 
-      const secondResponse = await this.callApi(messages, provider);
-      const answer = secondResponse.choices[0]?.message.content ?? '';
-      return { provider: provider.id, query: params.query, answer, results: [] };
+      messages.push(choice.message);
+      for (const toolCall of toolCalls) {
+        const fiber = await this.executeFormula(toolCall.function, provider);
+        const content = fiber.context?.output || fiber.context?.encrypted_output;
+        if (!content) throw new Error('Kimi Formula web search returned no output');
+        messages.push({
+          role: 'tool',
+          tool_call_id: toolCall.id,
+          content,
+        });
+      }
     }
-
-    return {
-      provider: provider.id,
-      query: params.query,
-      answer: firstChoice.message.content ?? '',
-      results: [],
-    };
+    throw new Error(`Kimi Formula web search exceeded ${MAX_TOOL_ROUNDS} tool rounds`);
   }
 
   private async callApi(
     messages: KimiMessage[],
+    tools: KimiTool[],
     provider: ResolvedProvider,
   ): Promise<KimiResponse> {
     const url = `${provider.baseUrl.replace(/\/$/, '')}/chat/completions`;
     const body = {
-      model: provider.model ?? 'kimi-k2.6',
+      model: provider.model ?? 'kimi-k3',
       messages,
-      tools: [{ type: 'builtin_function', function: { name: '$web_search' } }],
-      thinking: { type: 'disabled' },
-    };
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${provider.apiKey}`,
-      ...provider.headers,
+      tools,
     };
 
     const response = await fetch(url, {
       method: 'POST',
-      headers,
+      headers: this.headers(provider),
       body: JSON.stringify(body),
       signal: AbortSignal.timeout(provider.timeoutMs ?? DEFAULT_TIMEOUT_MS),
     });
     if (!response.ok) {
-      const text = await response.text().catch(() => '');
-      throw new Error(`Kimi API error ${response.status}: ${text}`);
+      throw new Error(`Kimi API error ${response.status}`);
     }
     return (await response.json()) as KimiResponse;
+  }
+
+  private async loadTools(provider: ResolvedProvider): Promise<KimiTool[]> {
+    const baseUrl = provider.baseUrl.replace(/\/$/, '');
+    const response = await fetch(`${baseUrl}/formulas/${WEB_SEARCH_FORMULA}/tools`, {
+      headers: this.headers(provider),
+      signal: AbortSignal.timeout(provider.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`Kimi API error ${response.status}`);
+    }
+    const data = (await response.json()) as { tools: KimiTool[] };
+    if (!Array.isArray(data.tools) || data.tools.length === 0) {
+      throw new Error('Kimi Formula web search returned no tools');
+    }
+    return data.tools;
+  }
+
+  private async executeFormula(
+    toolCall: { name: string; arguments: string },
+    provider: ResolvedProvider,
+  ): Promise<FormulaFiberResponse> {
+    const baseUrl = provider.baseUrl.replace(/\/$/, '');
+    const response = await fetch(`${baseUrl}/formulas/${WEB_SEARCH_FORMULA}/fibers`, {
+      method: 'POST',
+      headers: this.headers(provider),
+      body: JSON.stringify(toolCall),
+      signal: AbortSignal.timeout(provider.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new Error(`Kimi API error ${response.status}`);
+    }
+    const fiber = (await response.json()) as FormulaFiberResponse;
+    if (fiber.status !== 'succeeded') throw new Error('Kimi Formula web search failed');
+    return fiber;
+  }
+
+  private headers(provider: ResolvedProvider): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${provider.apiKey}`,
+      ...provider.headers,
+    };
   }
 }


### PR DESCRIPTION
## Summary

- migrate the Kimi search provider from the legacy `$web_search` builtin flow to the official `moonshot/web-search:latest` Formula API
- load Formula tool declarations, execute every returned tool call, and continue until Kimi produces a final answer
- support both `context.output` and protected `context.encrypted_output`, with bounded tool rounds and sanitized failures
- change the default Kimi search model to `kimi-k3`
- update focused coverage and the package README compatibility note

## Why

Kimi now recommends the Formula API official-tool channel for `kimi-k3`. The previous adapter used the legacy builtin tool flow, echoed tool arguments back to the model, handled only the first tool call, and assumed a fixed two-request exchange. That no longer matches the recommended four-step Formula workflow or multi-round tool-call contract.

## Impact

Kimi search now follows the current official protocol. Custom Kimi base URLs must expose both `/chat/completions` and `/formulas/*`.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 1556 tests passed
- `pnpm build`
- `git diff --check`