### PR TITLE
fix(pi-image-gen): emit markdown-safe image URLs for generated images

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -333,6 +333,8 @@ The `alt` text is the filename without its extension — i.e. whatever you passe
 > revised prompt: a cute beaver, photorealistic, water droplets
 ```
 
+The markdown URL is platform-shaped so any CommonMark host (desktop, TUI, CLI) keeps it intact: on macOS/Linux a bare absolute path — byte-identical unless it contains markdown-unsafe characters (whitespace, `#`, `?`, `%`, `()`, `<>`), which are percent-escaped; on Windows a percent-encoded `file:///…` URL (`![result](file:///C:/Users/.../result.png)`) — sanitizers such as react-markdown's `defaultUrlTransform` read `C:` as an unknown URI scheme and strip the img `src`. Independently of the markdown, `details.images[].path` always carries the raw filesystem path.
+
 ### Image-to-image / edit
 
 `image` is always an array — pass `["path"]` for a single image, `["a", "b"]` for multi-image conditioning. Each entry must be:

--- a/packages/pi-image-gen/src/__tests__/format.test.ts
+++ b/packages/pi-image-gen/src/__tests__/format.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { altFromPath, formatCommandSummary, formatToolResultText } from '../index.js';
+import {
+  altFromPath,
+  formatCommandSummary,
+  formatToolResultText,
+  markdownImageUrl,
+} from '../index.js';
 import type { ImageGenResult } from '../types.js';
 
 describe('altFromPath', () => {
@@ -92,6 +97,51 @@ describe('formatToolResultText', () => {
       }),
     );
     expect(text).toContain('Generated 2 image(s) via amaster (custom) (qwen-image-2.0)');
+  });
+
+  it('rewrites Windows paths as file:/// URLs (regression: raw C:\\… loses the img src)', () => {
+    const text = formatToolResultText(
+      makeResult({
+        images: [
+          { path: 'C:\\Users\\tester\\workspace\\images\\result.png', mimeType: 'image/png' },
+        ],
+      }),
+    );
+    expect(text).toContain('![result](file:///C:/Users/tester/workspace/images/result.png)');
+    expect(text).not.toContain('C:\\Users');
+  });
+});
+
+describe('markdownImageUrl', () => {
+  it('rewrites Windows drive paths as file:/// URLs', () => {
+    expect(markdownImageUrl('C:\\Users\\tester\\images\\result.png')).toBe(
+      'file:///C:/Users/tester/images/result.png',
+    );
+    expect(markdownImageUrl('C:/Users/tester/images/result.png')).toBe(
+      'file:///C:/Users/tester/images/result.png',
+    );
+  });
+
+  it('percent-encodes spaces, CJK, # and parens', () => {
+    expect(markdownImageUrl('D:\\我的 图片\\cat (1)#v2.png')).toBe(
+      'file:///D:/%E6%88%91%E7%9A%84%20%E5%9B%BE%E7%89%87/cat%20%281%29%23v2.png',
+    );
+  });
+
+  it('leaves clean POSIX absolute paths byte-identical (they already render inline)', () => {
+    expect(markdownImageUrl('/Users/me/.pi/images/white.png')).toBe(
+      '/Users/me/.pi/images/white.png',
+    );
+  });
+
+  it('escapes markdown-unsafe chars in POSIX paths but leaves CJK untouched', () => {
+    expect(markdownImageUrl('/Users/me/my 图/cat (1)#v2.png')).toBe(
+      '/Users/me/my%20图/cat%20%281%29%23v2.png',
+    );
+  });
+
+  it('pads control-char escapes to two hex digits', () => {
+    expect(markdownImageUrl('/tmp/a\tb.png')).toBe('/tmp/a%09b.png');
   });
 });
 

--- a/packages/pi-image-gen/src/index.ts
+++ b/packages/pi-image-gen/src/index.ts
@@ -66,7 +66,7 @@ export default function piImageGenExtension(pi: ExtensionAPI): void {
       name: 'image_generate',
       label: 'ImageGen',
       description:
-        'Generate or edit images. The image model is fixed by pi-image-gen.defaultModel in settings (this tool does not accept a model parameter). Pass `image` to do image-to-image / edit / style transfer / character preservation: a file path (absolute or relative to cwd) or an http(s) URL. To iterate on a previous result, pass its file path back. Do NOT pass base64 or data: URIs — write bytes to a file first. Saves the output to disk and returns the absolute path(s). When reporting the result to the user, render each generated image as inline markdown `![alt](absolute_path)` (the tool result already includes a copy-pasteable line) so the UI can display it; do not just paste the bare path. Run /image-gen list to see the active model.',
+        'Generate or edit images. The image model is fixed by pi-image-gen.defaultModel in settings (this tool does not accept a model parameter). Pass `image` to do image-to-image / edit / style transfer / character preservation: a file path (absolute or relative to cwd) or an http(s) URL. To iterate on a previous result, pass its file path back. Do NOT pass base64 or data: URIs — write bytes to a file first. Saves the output to disk and returns the absolute path(s). When reporting the result to the user, render each generated image as inline markdown — copy the `![alt](…)` line(s) from the tool result verbatim so the UI can display it; do not just paste the bare path. Run /image-gen list to see the active model.',
       promptSnippet:
         'Generate or edit raster images (photos, illustrations, textures, mockups). Not for icons/logos/diagrams that should be repo-native SVG/CSS/canvas.',
       promptGuidelines: buildImageGuidelines(caps),
@@ -313,11 +313,56 @@ export function formatToolResultText(result: ImageGenResult): string {
     '',
     ...result.images.flatMap((img) => {
       const alt = altFromPath(img.path);
-      const md = `![${alt}](${img.path})`;
+      const md = `![${alt}](${markdownImageUrl(img.path)})`;
       return img.revisedPrompt ? [md, `> revised prompt: ${img.revisedPrompt}`] : [md];
     }),
   ];
   return lines.join('\n');
+}
+
+/**
+ * Markdown-safe image URL for a saved absolute path — valid CommonMark for
+ * any host renderer (desktop, TUI, CLI alike):
+ * - Windows drive-letter paths (`C:\…`) become percent-encoded
+ *   `file:///C:/…` URLs — markdown URL sanitizers read `C:` as an unknown
+ *   URI scheme and strip the img `src` otherwise.
+ * - POSIX paths stay bare absolute paths; only markdown/URL-unsafe
+ *   characters are percent-escaped, so clean paths stay byte-identical.
+ * Hand-rolled (not pathToFileURL) so the Windows case behaves the same on
+ * every OS and stays testable off-Windows.
+ */
+export function markdownImageUrl(absolutePath: string): string {
+  const drive = /^([A-Za-z]:)[\\/]/.exec(absolutePath)?.[1];
+  if (!drive) return escapeMarkdownUnsafe(absolutePath);
+  const segments = absolutePath
+    .slice(3)
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .map(encodeUrlSegment);
+  return `file:///${drive}/${segments.join('/')}`;
+}
+
+/**
+ * file:// URLs must be ASCII, so Windows path segments get full
+ * percent-encoding; ( ) additionally need escaping (encodeURIComponent
+ * leaves them) or they unbalance the markdown link destination.
+ */
+function encodeUrlSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(/[()]/g, hexEscape);
+}
+
+/**
+ * Escape just the characters that break a bare path inside a markdown link
+ * destination or a URL parse: whitespace, # ? % < > and ( ). Everything else
+ * — including CJK — passes through byte-identical, so POSIX paths that render
+ * inline today keep their exact current output.
+ */
+function escapeMarkdownUnsafe(path: string): string {
+  return path.replace(/[\s#%()?<>]/g, hexEscape);
+}
+
+function hexEscape(ch: string): string {
+  return `%${ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`;
 }
 
 /**


### PR DESCRIPTION
## Problem

On the Windows desktop, `image_generate` succeeds and the file lands on disk, but the image never renders inline: the tool embeds the raw absolute path into `![alt](path)`, and markdown URL sanitizers (react-markdown's `defaultUrlTransform`) read `C:` as an unknown URI scheme and strip the `<img>` `src`.

Closes #104

## Fix

Adds `markdownImageUrl()` (`packages/pi-image-gen/src/index.ts`), which shapes the saved path into a markdown URL that stays valid CommonMark for any host renderer (desktop / TUI / CLI alike):

- **Windows** drive-letter paths become percent-encoded `file:///C:/…` URLs (spaces, CJK, `#`, parens all correctly encoded)
- **POSIX** paths stay bare absolute paths — byte-identical for clean paths; only markdown/URL-unsafe characters (whitespace, `#`, `?`, `%`, `()`, `<>`) are percent-escaped, CJK is left unencoded
- Deliberately not `pathToFileURL`: its Windows branch only runs on Windows, so the Windows regression test required by the issue could not run on non-Windows CI. The conversion is hand-rolled and platform-independent instead.
- Tool `description` now says to copy the `![alt](…)` line(s) from the tool result verbatim — the old `![alt](absolute_path)` wording could lead the model to "correct" a `file:///` URL back into a raw path and bypass the fix
- `details.images[].path` always carries the raw filesystem path; the README documents the cross-platform output contract

## Tests

New regression coverage: Windows backslash/forward-slash drive paths, Windows special-character encoding, POSIX clean-path passthrough (byte-identical), POSIX unsafe-char escaping (CJK untouched), two-digit hex padding for control characters, and an end-to-end `formatToolResultText` Windows case.

`pnpm pr-check` is green (ran via the pre-commit hook): biome on 259 files, repo-wide typecheck, 104 test files / 1562 tests, build.

## Out of scope (follow-ups)

- Issue suggestion #2 (structured image content in tool results, avoiding reliance on the model copying markdown) — evolves separately, per the issue itself
- UNC (`\\server\share`) and drive-relative (`C:foo`) paths are not handled
- `pi-attachments` has the same raw-path markdown pattern; attachment images have the same latent issue on Windows