### PR TITLE
fix(pi-video-gen): use EXESUF-aware make targets in FFmpeg build

### DIFF
--- a/packages/pi-video-gen/scripts/build-ffmpeg.sh
+++ b/packages/pi-video-gen/scripts/build-ffmpeg.sh
@@ -134,7 +134,7 @@ if [ "${GPL_VARIANT:-}" = "1" ]; then
 else
   ./configure $FF_CONFIGURE_BASE $ZLIB_FLAGS $CROSS_FLAGS
 fi
-make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)" ffmpeg ffprobe
+make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)" "ffmpeg${EXECUTABLE#ffmpeg}" "ffprobe${EXECUTABLE#ffmpeg}"
 
 mkdir -p "$PACKAGE_ROOT/bin" "$PACKAGE_ROOT/source"
 cp "$WORK/zlib.tar.gz" "$PACKAGE_ROOT/source/zlib-${ZLIB_VERSION}.tar.gz"


### PR DESCRIPTION
## Problem

The `win32-x64` FFmpeg build in the [Publish npm Packages](https://github.com/TGYD-helige/pi/actions/runs/30616153512) workflow failed with:

```
make: *** No rule to make target 'ffmpeg'.  Stop.
```

The failure also canceled the four in-flight platform jobs via matrix fail-fast, blocking the whole publish.

## Root cause

`build-ffmpeg.sh` invoked `make ffmpeg ffprobe`, but FFmpeg's Makefile defines program goals as `%$(PROGSSUF)$(EXESUF)`. On the win32-x64 mingw cross build `EXESUF=.exe`, so the only valid goals are `ffmpeg.exe` / `ffprobe.exe` and the bare names have no rule. POSIX targets are unaffected because `EXESUF` is empty there — which is why this only surfaced on the first run of the new FFmpeg build matrix.

## Fix

Derive the make goal names from `$EXECUTABLE` using the same `${EXECUTABLE#ffmpeg}` suffix idiom the script's copy steps already use: `ffmpeg.exe` / `ffprobe.exe` on win32, `ffmpeg` / `ffprobe` elsewhere. This also fixes the GPL variant pass, which shares the same line.

## Verification

- `sh -n` syntax check passes
- Parameter expansion verified for both `EXECUTABLE=ffmpeg` (→ `ffmpeg ffprobe`) and `EXECUTABLE=ffmpeg.exe` (→ `ffmpeg.exe ffprobe.exe`)
- Pre-commit gate green: lint + typecheck + 1556 tests + build

The end-to-end mingw build itself can only be exercised on the CI runner; after merge, re-trigger **Publish npm Packages** (a retry of the old run would reuse the broken commit and fail again).