### PR TITLE
fix(pi-video-gen): pass --cross-prefix to x264 configure for cross builds

### DIFF
--- a/packages/pi-video-gen/scripts/build-ffmpeg.sh
+++ b/packages/pi-video-gen/scripts/build-ffmpeg.sh
@@ -121,9 +121,16 @@ if [ "${GPL_VARIANT:-}" = "1" ]; then
   curl -fsSL "$X264_URL" -o "$WORK/x264.tar.gz"
   verify_sha256 "$X264_SHA256" "$WORK/x264.tar.gz"
   tar -xzf "$WORK/x264.tar.gz" -C "$WORK"
+  # x264 derives its toolchain (CC/AR/RANLIB/...) from --cross-prefix; --host
+  # alone only sets the target arch and would build with the HOST compiler.
+  X264_CROSS_FLAGS=
+  if [ -n "$CROSS_FLAGS" ]; then
+    X264_CROSS_PREFIX=$(echo "$CROSS_FLAGS" | sed -n 's/.*--cross-prefix=\([^ ]*\).*/\1/p')
+    X264_CROSS_FLAGS="--host=${X264_CROSS_PREFIX%-} --cross-prefix=$X264_CROSS_PREFIX"
+  fi
   (cd "$WORK/x264-$X264_VERSION" && \
     ./configure --prefix="$WORK/x264-install" --enable-static --disable-cli --disable-opencl --bit-depth=8 \
-      ${CROSS_FLAGS:+--host=$(echo "$CROSS_FLAGS" | sed -n 's/.*--cross-prefix=\([^ ]*\)-.*/\1/p')} && \
+      $X264_CROSS_FLAGS && \
     make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)" && \
     make install)
   # ffmpeg's configure discovers x264 via pkg-config, not raw cflags.


### PR DESCRIPTION
## Problem

After #107 fixed the win32-x64 make targets, the next [Publish npm Packages run](https://github.com/TGYD-helige/pi/actions/runs/30618185970) got further — all five platforms passed the base LGPL build — but the GPL variant step failed on linux-arm64 while configuring x264:

```
no NEON support, try adding -mfpu=neon to CFLAGS
If you really want to run on such a CPU, configure with --disable-asm.
```

## Root cause

The script passed only `--host=aarch64-linux-gnu` to x264's configure. x264 derives its entire toolchain from `--cross-prefix`:

```sh
CC="${CC-${cross_prefix}gcc}"
AR="${AR-${cross_prefix}ar}"   # etc.
```

Without it, configure uses the **host** x86_64 gcc. The C compiler sanity checks pass, but the AARCH64 assembly probe (`as_check "cmeq v0.8h, v0.8h, #0"`, which goes through `$CC`) cannot assemble a NEON instruction with the host compiler, so configure bails out. NEON is baseline on aarch64 — the probe failing is a toolchain mix-up, not a CPU feature gap.

win32-x64 had the same latent bug: it would have compiled x264 into Linux ELF objects with the host gcc and failed later when FFmpeg's mingw linker consumed `libx264.a`. linux-arm64 simply failed first.

## Fix

Derive both `--host` and `--cross-prefix` once from the FFmpeg `$CROSS_FLAGS` and pass them to x264's configure. Native targets (darwin-*) keep passing neither, so their behavior is unchanged.

## Verification

- `sh -n` passes
- Flag expansion checked for all three cases: linux-arm64 → `--host=aarch64-linux-gnu --cross-prefix=aarch64-linux-gnu-`, win32-x64 → `--host=x86_64-w64-mingw32 --cross-prefix=x86_64-w64-mingw32-`, native → no extra flags
- Native x264 configure (the unchanged path) run end-to-end on an arm64 Mac: detects AARCH64 + NEON and completes
- The cross-compile paths can only be exercised on the CI runners; merge and re-trigger **Publish npm Packages** to verify