### PR TITLE
ci: run Linux-hosted FFmpeg builds on the accelerated self-hosted runner

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,22 +34,39 @@ jobs:
     strategy:
       matrix:
         include:
+          # darwin targets need macOS hosts, so they stay on GitHub-hosted
+          # runners; the Linux-hosted builds (native + both cross targets)
+          # run on the accelerated self-hosted runner for reliable source
+          # downloads (ffmpeg.org, zlib.net, code.videolan.org).
           - target: darwin-arm64
             runner: macos-15
           - target: darwin-x64
             runner: macos-15-intel
           - target: linux-x64
-            runner: ubuntu-22.04
+            runner: [instance-hnpsq9go, linux, x64]
           - target: linux-arm64
-            runner: ubuntu-22.04
+            runner: [instance-hnpsq9go, linux, x64]
           - target: win32-x64
-            runner: ubuntu-24.04
+            runner: [instance-hnpsq9go, linux, x64]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+
+      # The self-hosted runner's distro is not pinned by the image, so guard
+      # the published glibc floor: linux-* binaries must be linked against
+      # the Ubuntu 22.04 baseline their SOURCE.md provenance declares.
+      # win32-x64 produces PE binaries via mingw and is host-glibc-agnostic.
+      - name: Check glibc baseline (linux targets)
+        if: startsWith(matrix.target, 'linux-')
+        run: |
+          . /etc/os-release
+          if [ "${ID:-}" != "ubuntu" ] || [ "${VERSION_ID:-}" != "22.04" ]; then
+            echo "linux-* builds must run on Ubuntu 22.04 (glibc baseline); got ${PRETTY_NAME:-unknown}" >&2
+            exit 1
+          fi
 
       - name: Install build dependencies
         run: |

--- a/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
+++ b/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
@@ -74,7 +74,13 @@ describe('pi-video-gen package artifacts', () => {
   });
 
   it('builds against declared platform baselines and verifies release binaries', () => {
-    expect(publishWorkflow).toContain('runner: ubuntu-22.04');
+    // darwin builds stay on GitHub-hosted macOS images; the Linux-hosted
+    // builds use the self-hosted runner, whose Ubuntu 22.04 glibc baseline
+    // is enforced by the guard step above the build.
+    expect(publishWorkflow).toContain('runner: macos-15');
+    expect(publishWorkflow).toContain('runner: [instance-hnpsq9go, linux, x64]');
+    expect(publishWorkflow).toContain('Check glibc baseline (linux targets)');
+    expect(publishWorkflow).toContain('${VERSION_ID:-}');
     expect(publishWorkflow).toContain('Verify FFmpeg binary');
     expect(publishWorkflow).toContain('vtool -show-build');
     expect(publishWorkflow).not.toContain('vars.X264_SHA256');


### PR DESCRIPTION
## Motivation

Source downloads (ffmpeg.org, zlib.net, code.videolan.org) have been the flakiest part of the publish pipeline — most recently a darwin-arm64 GitHub runner died on a 75s connect timeout to ffmpeg.org while its four siblings connected at the same minute ([run](https://github.com/TGYD-helige/pi/actions/runs/30621106460)). The self-hosted runner sits behind an accelerating proxy (`http://192.168.3.3:18000`, seen in its job logs), so moving the builds there makes the downloads fast and reliable.

## Change

- `linux-x64`, `linux-arm64`, `win32-x64` matrix jobs → `runs-on: [instance-hnpsq9go, linux, x64]` (same labels the publish job already uses)
- `darwin-arm64` / `darwin-x64` stay on GitHub-hosted `macos-15` / `macos-15-intel` — they require macOS hosts and cannot move; #111's download retry remains their resilience
- New guard step **Check glibc baseline (linux targets)**: fails fast unless `linux-*` builds run on Ubuntu 22.04. The self-hosted runner's distro is not pinned by any image, and the published binaries' SOURCE.md declares an Ubuntu 22.04 glibc baseline — building on a newer distro would silently raise the glibc floor for users. `win32-x64` is exempt (PE binaries via mingw; host glibc is irrelevant)
- `package-artifacts.test.ts` updated: it pinned the old `runner: ubuntu-22.04` labels and now asserts the self-hosted labels + the baseline guard

## Notes

- If the self-hosted machine is not Ubuntu 22.04, the linux-* jobs will fail fast at the guard with a clear message — say the word and we can revisit (e.g. `container: ubuntu:22.04`)
- The three Linux jobs will serialize if the runner is a single machine; wall time goes up a few minutes in exchange for download reliability
- Complements, does not replace, #111 (retry) and #109 (zlib mirror failover)

## Verification

- Workflow YAML parses; matrix resolves to the intended runner labels
- `package-artifacts.test.ts` green (9/9); pre-commit gate (lint + typecheck + full tests + build) green