### PR TITLE
fix(computer-use): stop daemon after owner exit

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -538,6 +538,10 @@ jobs:
           fi
           pi list
 
+      - name: Verify computer-use daemon follows abrupt owner exit
+        if: matrix.extension == 'pi-computer-use'
+        run: node tests/computer-use-owner-exit.mjs
+
       - name: Compose preview video (pi-video-gen only)
         if: matrix.extension == 'pi-video-gen'
         run: |

--- a/packages/pi-computer-use/README.md
+++ b/packages/pi-computer-use/README.md
@@ -95,7 +95,9 @@ schemas.
 
 Driver startup, reconnect, and the first macOS permission probe are session-owned.
 Cancelling a tool stops only that caller's wait or MCP request; session shutdown
-aborts the shared work.
+aborts the shared work. macOS and Linux also use a transient pipe-backed lease to
+stop the owned daemon after an abrupt host exit; no persistent service or system
+scheduler is installed.
 
 - **Bundled macOS:** launches the signed `CuaDriver.app` through LaunchServices,
   so Accessibility and Screen Recording grants belong to `com.trycua.driver`.

--- a/packages/pi-computer-use/src/__tests__/index.test.ts
+++ b/packages/pi-computer-use/src/__tests__/index.test.ts
@@ -107,7 +107,10 @@ vi.mock('node:child_process', () => ({
     };
     child.stderr = new EventEmitter();
     child.kill = vi.fn();
-    queueMicrotask(() => child.emit('exit', 0));
+    queueMicrotask(() => {
+      child.emit('spawn');
+      child.emit('exit', 0);
+    });
     return child;
   }),
   execFile: vi.fn((...args: unknown[]) => {

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -16,6 +16,15 @@ import type { McpToolResult } from './tool-result.js';
 
 const MCP_TIMEOUT_MS = 60_000;
 const DAEMON_START_TIMEOUT_MS = 10_000;
+const DAEMON_LEASE_SCRIPT = `
+if IFS= read -r _; then exit 0; fi
+attempt=0
+while [ "$attempt" -lt 100 ]; do
+  if [ -S "$2" ]; then exec "$1" stop --socket "$2"; fi
+  attempt=$((attempt + 1))
+  sleep 0.1
+done
+`;
 const execFileAsync = promisify(execFile);
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -124,6 +133,7 @@ export type ConnectionState =
 export class CuaDriverClient {
   private client: Client | null = null;
   private daemonProcess: ChildProcess | null = null;
+  private daemonLease: ChildProcess | null = null;
   private daemonSocket: string | null = null;
   private activeLayout: DriverLayout | null = null;
   private state: ConnectionState = 'disconnected';
@@ -231,6 +241,38 @@ export class CuaDriverClient {
     if (this.daemonSocket) return this.daemonSocket;
     const socket = this.createSocketPath();
     this.daemonSocket = socket;
+
+    if (process.platform !== 'win32') {
+      // This anonymous pipe is the lease: owner death closes it even after SIGKILL.
+      const lease = spawn(
+        '/bin/sh',
+        ['-c', DAEMON_LEASE_SCRIPT, 'pi-computer-use-lease', layout.binaryPath, socket],
+        {
+          env: this.daemonEnvironment(layout.embedded),
+          stdio: ['pipe', 'ignore', 'ignore'],
+        },
+      );
+      this.daemonLease = lease;
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => {
+          lease.removeListener('spawn', onSpawn);
+          reject(error);
+        };
+        const onSpawn = () => {
+          lease.removeListener('error', onError);
+          resolve();
+        };
+        lease.once('error', onError);
+        lease.once('spawn', onSpawn);
+      });
+      lease.unref?.();
+      (lease.stdin as (typeof lease.stdin & { unref?: () => void }) | null)?.unref?.();
+      lease.once('error', () => {
+        if (this.daemonLease !== lease) return;
+        console.error('[pi-computer-use] failed to start daemon lease');
+        void this.stopDaemon();
+      });
+    }
 
     if (process.platform === 'darwin' && layout.appPath && !layout.embedded) {
       const launcher = spawn(
@@ -421,9 +463,14 @@ export class CuaDriverClient {
     const socket = this.daemonSocket;
     const layout = this.activeLayout;
     const daemonProcess = this.daemonProcess;
+    const daemonLease = this.daemonLease;
     this.daemonSocket = null;
     this.activeLayout = null;
     this.daemonProcess = null;
+    this.daemonLease = null;
+
+    if (daemonLease?.stdin?.writable) daemonLease.stdin.end('cancel\n');
+    else daemonLease?.kill();
 
     if (socket && layout) {
       try {
@@ -432,7 +479,7 @@ export class CuaDriverClient {
           timeout: 3_000,
         });
       } catch {
-        // The daemon may already be gone; the owned process is killed below.
+        console.error('[pi-computer-use] failed to stop owned daemon');
       }
     }
     daemonProcess?.kill();

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -20,7 +20,14 @@ const DAEMON_LEASE_SCRIPT = `
 if IFS= read -r _; then exit 0; fi
 attempt=0
 while [ "$attempt" -lt 100 ]; do
-  if [ -S "$2" ]; then exec "$1" stop --socket "$2"; fi
+  if [ -S "$2" ]; then
+    "$1" stop --socket "$2" >/dev/null 2>&1
+    status=$("$1" status --socket "$2" 2>&1)
+    if [ -S "$2" ] && [ "$status" = "Cua Driver daemon is not running" ]; then
+      /bin/rm -f -- "$2"
+    fi
+    exit 0
+  fi
   attempt=$((attempt + 1))
   sleep 0.1
 done

--- a/tests/computer-use-owner-exit.mjs
+++ b/tests/computer-use-owner-exit.mjs
@@ -1,0 +1,130 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readdir, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+if (process.platform !== 'linux') {
+  throw new Error('computer-use owner-exit integration test requires Linux');
+}
+
+const execFileAsync = promisify(execFile);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const packageRoot = path.join(repoRoot, 'packages', 'pi-computer-use');
+const binaryPath = path.join(packageRoot, 'bin', `linux-${process.arch}`, 'cua-driver');
+const extensionUrl = pathToFileURL(path.join(packageRoot, 'dist', 'index.js')).href;
+
+const owner = execFile(
+  process.execPath,
+  [
+    '--input-type=module',
+    '--eval',
+    `
+      import { CuaDriverClient } from ${JSON.stringify(extensionUrl)};
+      const client = new CuaDriverClient({ mode: 'bundled' });
+      await client.connect();
+      process.stdout.write('ready\\n');
+      setInterval(() => {}, 1_000);
+    `,
+  ],
+  { cwd: repoRoot, maxBuffer: 8_192 },
+);
+let ownerStderr = '';
+owner.stderr?.on('data', (chunk) => {
+  ownerStderr = `${ownerStderr}${chunk}`.slice(-8_192);
+});
+
+let socketPath;
+let daemonPid;
+let leasePid;
+let proxyPid;
+
+try {
+  socketPath = await waitForSocket(owner);
+  ({ daemonPid, leasePid, proxyPid } = await findDriverProcesses(socketPath));
+  if (!daemonPid || !leasePid || !proxyPid) {
+    throw new Error(`Cua Driver processes not found for ${socketPath}`);
+  }
+
+  owner.kill('SIGKILL');
+  await waitFor(() => owner.exitCode !== null || owner.signalCode !== null, 5_000);
+  await waitFor(
+    () =>
+      !existsSync(socketPath) &&
+      !existsSync(`/proc/${daemonPid}`) &&
+      !existsSync(`/proc/${leasePid}`) &&
+      !existsSync(`/proc/${proxyPid}`),
+    5_000,
+  );
+
+  console.log('Cua Driver lease, daemon, and proxy exited after their owner was killed.');
+} finally {
+  if (owner.exitCode === null && owner.signalCode === null) owner.kill('SIGKILL');
+  if (socketPath && existsSync(socketPath)) {
+    await execFileAsync(binaryPath, ['stop', '--socket', socketPath], { timeout: 3_000 }).catch(
+      () => undefined,
+    );
+  }
+  for (const pid of [daemonPid, leasePid, proxyPid]) {
+    if (!pid || !(await processMatchesSocket(pid, socketPath))) continue;
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // The exact test-owned process may have exited between the check and kill.
+    }
+  }
+  if (socketPath) await rm(socketPath, { force: true }).catch(() => undefined);
+}
+
+async function waitForSocket(ownerProcess) {
+  const ownerPid = ownerProcess.pid;
+  const pattern = new RegExp(`^pi-cua-${ownerPid}-[0-9a-f]{8}\\.sock$`);
+  let socket;
+  await waitFor(async () => {
+    if (ownerProcess.exitCode !== null || ownerProcess.signalCode !== null) {
+      throw new Error(`Owner exited before its daemon started:\n${ownerStderr}`);
+    }
+    for (const directory of new Set([tmpdir(), '/tmp'])) {
+      const entries = await readdir(directory).catch(() => []);
+      const filename = entries.find((entry) => pattern.test(entry));
+      if (filename) {
+        socket = path.join(directory, filename);
+        return true;
+      }
+    }
+    return false;
+  }, 15_000);
+  return socket;
+}
+
+async function findDriverProcesses(socket) {
+  let daemonPid;
+  let leasePid;
+  let proxyPid;
+  for (const entry of await readdir('/proc', { withFileTypes: true })) {
+    if (!entry.isDirectory() || !/^\d+$/.test(entry.name)) continue;
+    const command = await readFile(`/proc/${entry.name}/cmdline`, 'utf8').catch(() => '');
+    if (!command.includes(socket)) continue;
+    if (command.includes('\0serve\0')) daemonPid = Number(entry.name);
+    if (command.includes('pi-computer-use-lease')) leasePid = Number(entry.name);
+    if (command.includes('\0mcp\0')) proxyPid = Number(entry.name);
+  }
+  return { daemonPid, leasePid, proxyPid };
+}
+
+async function processMatchesSocket(pid, socket) {
+  if (!socket) return false;
+  const command = await readFile(`/proc/${pid}/cmdline`, 'utf8').catch(() => '');
+  return command.includes(socket);
+}
+
+async function waitFor(check, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await check()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Condition not met within ${timeoutMs}ms`);
+}

--- a/tests/computer-use-owner-exit.mjs
+++ b/tests/computer-use-owner-exit.mjs
@@ -50,14 +50,15 @@ try {
 
   owner.kill('SIGKILL');
   await waitFor(() => owner.exitCode !== null || owner.signalCode !== null, 5_000);
-  await waitFor(
-    () =>
-      !existsSync(socketPath) &&
-      !existsSync(`/proc/${daemonPid}`) &&
-      !existsSync(`/proc/${leasePid}`) &&
-      !existsSync(`/proc/${proxyPid}`),
-    5_000,
-  );
+  let cleanupStatus;
+  try {
+    await waitFor(async () => {
+      cleanupStatus = await inspectCleanup(socketPath, { daemonPid, leasePid, proxyPid });
+      return cleanupStatus.complete;
+    }, 5_000);
+  } catch {
+    throw new Error(`Cua Driver cleanup timed out: ${JSON.stringify(cleanupStatus)}`);
+  }
 
   console.log('Cua Driver lease, daemon, and proxy exited after their owner was killed.');
 } finally {
@@ -118,6 +119,37 @@ async function processMatchesSocket(pid, socket) {
   if (!socket) return false;
   const command = await readFile(`/proc/${pid}/cmdline`, 'utf8').catch(() => '');
   return command.includes(socket);
+}
+
+async function inspectCleanup(socket, { daemonPid, leasePid, proxyPid }) {
+  const [daemon, lease, proxy] = await Promise.all([
+    inspectProcess(daemonPid, socket),
+    inspectProcess(leasePid, socket),
+    inspectProcess(proxyPid, socket),
+  ]);
+  const socketExists = existsSync(socket);
+  return {
+    complete: !socketExists && !daemon.running && !lease.running && !proxy.running,
+    socketExists,
+    daemon,
+    lease,
+    proxy,
+  };
+}
+
+async function inspectProcess(pid, socket) {
+  const stat = await readFile(`/proc/${pid}/stat`, 'utf8').catch(() => '');
+  if (!stat) return { pid, state: 'missing', matchesSocket: false, running: false };
+
+  const command = await readFile(`/proc/${pid}/cmdline`, 'utf8').catch(() => '');
+  const state = stat.slice(stat.lastIndexOf(')') + 2).charAt(0) || 'unknown';
+  const matchesSocket = command.includes(socket);
+  return {
+    pid,
+    state,
+    matchesSocket,
+    running: matchesSocket && state !== 'Z' && state !== 'X',
+  };
 }
 
 async function waitFor(check, timeoutMs) {


### PR DESCRIPTION
## Summary

- add a transient pipe-backed lease for each macOS/Linux CUA daemon
- preserve graceful session shutdown while stopping the daemon after abrupt owner exits
- add a Linux SIGKILL regression check to the existing computer-use integration job
- document that no persistent service or system scheduler is installed

## Root cause

The session owned a CUA daemon but an abrupt Pi exit could prevent the normal shutdown hook from sending `cua-driver stop`. The daemon and its socket could therefore outlive the owning Pi process.

The lease keeps an anonymous pipe open from the owner. Normal shutdown cancels the lease; owner death closes the pipe in the kernel, causing the short-lived helper to stop only the daemon associated with that session socket.

## Impact

New macOS and Linux sessions clean up their owned daemon after both graceful and abrupt exits. This does not install launchd, systemd, cron, or another persistent scheduler, and it does not scan for old-version orphaned processes.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (1562 tests)
- `pnpm build`
- pi-computer-use package tests (44 tests)
- workflow YAML and Linux integration script syntax checks

Refs #110
