### PR TITLE
fix(shared): re-export settings helpers from root entry (fixes #117)

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -475,3 +475,20 @@ export type SandboxFileEntry = {
   size?: number;
   modifiedAt?: string;
 };
+
+// Re-export the runtime helpers from the settings module via the root entry.
+// Some module loaders do not honour the "./settings" subpath in package
+// "exports" and resolve `@amaster.ai/pi-shared/settings` to this root entry
+// (which previously held only type exports), leaving `isProjectTrusted`,
+// `loadPiSettings`, etc. as `undefined` at runtime. Re-exporting them here
+// makes every consumer resilient to that mis-resolution.
+// See https://github.com/TGYD-helige/pi/issues/117
+export {
+  isProjectTrusted,
+  resolveHome,
+  resolveConfigDir,
+  resolveAgentDir,
+  loadPiSettings,
+  loadJsonProfileDir,
+  loadPiPolicyProfiles,
+} from './settings.js';


### PR DESCRIPTION
## What

Re-export the runtime settings helpers (`isProjectTrusted`, `loadPiSettings`, `resolveHome`, `resolveConfigDir`, `resolveAgentDir`, `loadJsonProfileDir`, `loadPiPolicyProfiles`) from the package **root entry** (`packages/shared/src/index.ts`).

## Why

Under `pi` (`@earendil-works/pi-coding-agent`) `0.83.0`, every `@amaster.ai/*` extension fails to load with, e.g.:

```
(0 , _settings.isProjectTrusted) is not a function
  at .../pi-web-access/dist/index.js:15:89
```

`pi` loads extensions through `jiti`, which resolves the `@amaster.ai/pi-shared/settings` subpath to the package **root entry** (`dist/index.js`) instead of `dist/settings.js`. Since `src/index.ts` is a type-only barrel (`export {};` in `dist/index.js`), every imported runtime helper is `undefined`.

This is not specific to `pi-web-access`: **all** `@amaster.ai` extensions import `isProjectTrusted` / `loadPiSettings` / `resolveHome` / … from `@amaster.ai/pi-shared/settings` (15+ packages), so they are all affected.

## Fix

Re-export the runtime helpers from the root entry. Then, even when a loader ignores the `./settings` subpath and resolves the specifier to the root entry, the bindings are present and the extensions load correctly. No consumer code changes required; behaviour is unchanged for loaders that do honour the subpath.

```ts
export {
  isProjectTrusted,
  resolveHome,
  resolveConfigDir,
  resolveAgentDir,
  loadPiSettings,
  loadJsonProfileDir,
  loadPiPolicyProfiles,
} from './settings.js';
```

The underlying loader behaviour is arguably a `pi`/`jiti` issue (not honouring `package.exports` subpaths), but this makes `@amaster.ai/pi-shared` robust against it regardless.

Fixes #117.

generated by glm 5.2
