### PR TITLE
[codex] add governed source read capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ product-specific UI.
 | Extension | `@amaster.ai/pi-telemetry` | Runtime telemetry with Langfuse and OpenTelemetry exporters. |
 | Extension | `@amaster.ai/pi-task-scheduler` | Cron-based scheduled task management with LLM-callable tools. |
 | Extension | `@amaster.ai/pi-goal` | Derives a goal from the conversation and keeps the agent working until the condition is met, with iteration/token backstops. |
-| Extension | `@amaster.ai/pi-browser-use` | Browser automation wrapping chrome-devtools-mcp with `browser_`-prefixed tools. |
-| Extension | `@amaster.ai/pi-web-access` | Web search and URL content extraction across configurable providers. |
+| Extension | `@amaster.ai/pi-browser-use` | Browser automation wrapping chrome-devtools-mcp, including an optional runtime-enforced read policy. |
+| Extension | `@amaster.ai/pi-web-access` | Web search and URL extraction with provider/Jina/local or hard local-only fetch modes. |
 | Extension | `@amaster.ai/pi-computer-use` | Cross-platform computer-use tools for desktop automation. |
 | Extension | `@amaster.ai/pi-channels` | Native messaging channels: Feishu, WeCom, and webhooks. |
 | Extension | `@amaster.ai/pi-memory` | Persistent curated memory (`MEMORY.md` + `USER.md`) injected into the system prompt as a refreshed prompt snapshot. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/pi-attachments/package.json
+++ b/packages/pi-attachments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-attachments",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for attachment processing — classifies, parses, and renders file attachments into LLM-visible prompt context",
   "keywords": ["pi-package", "pi", "extension", "attachments", "files", "documents"],
   "license": "Apache-2.0",

--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -12,6 +12,7 @@ pi-coding-agent extension that wraps [chrome-devtools-mcp](https://github.com/Ch
 - **Page-scoped routing** — routes page tools by explicit `pageId` instead of shared selected-page state
 - **Connection recovery** — detects closed or unhealthy MCP transports and reconnects before the next call
 - **Navigation safety** — supports URL allow/block patterns and redacts sensitive network headers by default
+- **Runtime read policy** — a managed browser can enforce exact top-level navigation, public-or-same-origin subresources, denied popups/downloads/new targets, and content-free observation receipts before requests leave Chrome
 - **Tool description augmentation** — adds usage hints for key tools (click, fill, press_key, etc.)
 - **Result post-processing** — strips embedded snapshots, detects overlay/stale element issues
 - **Optional visual analysis** — `browser_analyze_screenshot` via configurable vision model
@@ -132,6 +133,22 @@ npx @amaster.ai/pi-browser-use --config path/to/config.json
 | `blockedUrlPattern` | `string[]` | — | Block matching navigation and subresource URLPattern values |
 
 `allowedUrlPattern` and `blockedUrlPattern` are mutually exclusive. Page ID routing is disabled automatically in `slim` mode because upstream slim tools do not expose `pageId`.
+
+### Runtime-managed read policy
+
+Hosts may set `PI_BROWSER_USE_RUNTIME_READ_POLICY=required` and provide a
+`readPolicy` in the isolated agent settings. In that mode project settings are
+ignored, arbitrary browser endpoints/arguments are rejected, and the package
+owns the Chromium session so request interception and DNS-pinning policy are
+installed before navigation. Public policies require `sessionMode: "isolated"`;
+authenticated policies require `sessionMode: "existing"` plus an
+adapter-resolved `userDataDir`.
+
+The read-policy surface registers only list, navigate, snapshot, screenshot and
+wait tools. Top-level navigation must match a declared locator and origin;
+third-party subresources must resolve publicly, while an authenticated signed
+origin may resolve privately. Tool `details` contain only a
+`source_observation_v1` receipt when an observation profile is configured.
 
 ### Page-scoped Tool Calls
 

--- a/packages/pi-browser-use/package.json
+++ b/packages/pi-browser-use/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@amaster.ai/pi-browser-use",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for browser automation via chrome-devtools-mcp with browser_ prefixed tools",
-  "keywords": ["pi-package", "pi", "extension", "browser", "automation", "chrome-devtools", "mcp"],
+  "keywords": [
+    "pi-package",
+    "pi",
+    "extension",
+    "browser",
+    "automation",
+    "chrome-devtools",
+    "mcp"
+  ],
   "license": "Apache-2.0",
   "type": "module",
   "engines": {
@@ -50,7 +58,8 @@
   "dependencies": {
     "@amaster.ai/pi-shared": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "chrome-devtools-mcp": "^1.6.0"
+    "chrome-devtools-mcp": "^1.6.0",
+    "puppeteer-core": "25.3.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": ">=0.80.10",

--- a/packages/pi-browser-use/src/__tests__/browser-read-enforcer.test.ts
+++ b/packages/pi-browser-use/src/__tests__/browser-read-enforcer.test.ts
@@ -1,0 +1,105 @@
+import type { DnsLookup } from '@amaster.ai/pi-shared';
+import { describe, expect, it, vi } from 'vitest';
+import { installBrowserReadPagePolicy } from '../browser-read-enforcer.js';
+import type { BrowserReadPolicyV1 } from '../config.js';
+
+const publicLookup: DnsLookup = async (hostname) => [
+  {
+    address: hostname === 'private.example' ? '10.0.0.8' : '93.184.216.34',
+    family: 4,
+  },
+];
+
+const policy: BrowserReadPolicyV1 = {
+  version: 'browser_read_policy_v1',
+  accessMode: 'authenticated',
+  allowedTopLevelLocators: ['https://app.example/source'],
+  allowedTopLevelOrigins: ['https://app.example'],
+  subresources: 'public_or_same_origin',
+  privateCrossOriginSubresources: 'deny',
+  popups: 'deny',
+  downloads: 'deny',
+  newTargets: 'deny',
+};
+
+function fakePage() {
+  const handlers = new Map<string, (...args: any[]) => unknown>();
+  const mainFrame = {};
+  return {
+    page: {
+      url: vi.fn(() => 'https://app.example/source'),
+      mainFrame: vi.fn(() => mainFrame),
+      setBypassServiceWorker: vi.fn(() => Promise.resolve()),
+      setRequestInterception: vi.fn(() => Promise.resolve()),
+      evaluateOnNewDocument: vi.fn(() => Promise.resolve()),
+      on: vi.fn((name: string, handler: (...args: any[]) => unknown) => {
+        handlers.set(name, handler);
+      }),
+      off: vi.fn(),
+    },
+    handlers,
+    mainFrame,
+  };
+}
+
+function fakeRequest(url: string, frame: unknown, navigation = false) {
+  return {
+    url: vi.fn(() => url),
+    frame: vi.fn(() => frame),
+    isNavigationRequest: vi.fn(() => navigation),
+    continue: vi.fn(() => Promise.resolve()),
+    abort: vi.fn(() => Promise.resolve()),
+  };
+}
+
+describe('installBrowserReadPagePolicy', () => {
+  it('continues a public third-party subresource from an authenticated page', async () => {
+    const { page, handlers, mainFrame } = fakePage();
+    await installBrowserReadPagePolicy(page as any, policy, publicLookup);
+    const request = fakeRequest('https://cdn.example/image.png', mainFrame);
+
+    await handlers.get('request')!(request);
+
+    expect(request.continue).toHaveBeenCalledOnce();
+    expect(request.abort).not.toHaveBeenCalled();
+  });
+
+  it('aborts a private cross-origin subresource before it is continued', async () => {
+    const { page, handlers, mainFrame } = fakePage();
+    await installBrowserReadPagePolicy(page as any, policy, publicLookup);
+    const request = fakeRequest('https://private.example/metadata', mainFrame);
+
+    await handlers.get('request')!(request);
+
+    expect(request.abort).toHaveBeenCalledWith('blockedbyclient');
+    expect(request.continue).not.toHaveBeenCalled();
+  });
+
+  it('allows same-origin private subresources for the signed authenticated origin', async () => {
+    const { page, handlers, mainFrame } = fakePage();
+    const privatePolicy = {
+      ...policy,
+      allowedTopLevelLocators: ['https://private.example/source'],
+      allowedTopLevelOrigins: ['https://private.example'],
+    };
+    page.url.mockReturnValue('https://private.example/source');
+    await installBrowserReadPagePolicy(page as any, privatePolicy, publicLookup);
+    const request = fakeRequest('https://private.example/image.png', mainFrame);
+
+    await handlers.get('request')!(request);
+
+    expect(request.continue).toHaveBeenCalledOnce();
+    expect(request.abort).not.toHaveBeenCalled();
+  });
+
+  it('aborts an undeclared top-level redirect before it is continued', async () => {
+    const { page, handlers, mainFrame } = fakePage();
+    await installBrowserReadPagePolicy(page as any, policy, publicLookup);
+    const request = fakeRequest('https://other.example/redirected', mainFrame, true);
+
+    await handlers.get('request')!(request);
+
+    expect(request.abort).toHaveBeenCalledWith('blockedbyclient');
+    expect(request.continue).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pi-browser-use/src/__tests__/browser-read-session.test.ts
+++ b/packages/pi-browser-use/src/__tests__/browser-read-session.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserReadPolicyV1 } from '../config.js';
+
+const mockProxyClose = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const mockStartProxy = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve({ url: 'http://127.0.0.1:43123', close: mockProxyClose })),
+);
+const mockPagePolicyClose = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const mockInstallPagePolicy = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve({ close: mockPagePolicyClose })),
+);
+const mockBrowserClose = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const mockBrowserOn = vi.hoisted(() => vi.fn());
+const mockBrowserOff = vi.hoisted(() => vi.fn());
+const mockPage = vi.hoisted(() => ({ target: vi.fn(() => ({ id: 'bound' })) }));
+const mockBrowser = vi.hoisted(() => ({
+  wsEndpoint: vi.fn(() => 'ws://127.0.0.1:43124/devtools/browser/opaque'),
+  pages: vi.fn(() => Promise.resolve([mockPage])),
+  on: mockBrowserOn,
+  off: mockBrowserOff,
+  close: mockBrowserClose,
+}));
+const mockLaunch = vi.hoisted(() => vi.fn((_options: unknown) => Promise.resolve(mockBrowser)));
+
+vi.mock('../policy-proxy.js', () => ({ startBrowserPolicyProxy: mockStartProxy }));
+vi.mock('../browser-read-enforcer.js', () => ({
+  installBrowserReadPagePolicy: mockInstallPagePolicy,
+}));
+vi.mock('puppeteer-core', () => ({ default: { launch: mockLaunch } }));
+
+const { startBrowserReadSession } = await import('../browser-read-session.js');
+
+const publicPolicy: BrowserReadPolicyV1 = {
+  version: 'browser_read_policy_v1',
+  accessMode: 'public',
+  allowedTopLevelLocators: ['https://public.example/source'],
+  allowedTopLevelOrigins: ['https://public.example'],
+  subresources: 'public_or_same_origin',
+  privateCrossOriginSubresources: 'deny',
+  popups: 'deny',
+  downloads: 'deny',
+  newTargets: 'deny',
+};
+
+describe('startBrowserReadSession', () => {
+  beforeEach(() => {
+    mockStartProxy.mockClear();
+    mockInstallPagePolicy.mockClear();
+    mockLaunch.mockClear();
+    mockBrowserClose.mockClear();
+    mockProxyClose.mockClear();
+    mockPagePolicyClose.mockClear();
+    mockBrowserOn.mockClear();
+    mockBrowserOff.mockClear();
+  });
+
+  it('launches one ephemeral browser behind the pinning proxy and gives MCP its endpoint', async () => {
+    const session = await startBrowserReadSession({
+      sessionMode: 'isolated',
+      headless: true,
+      readPolicy: publicPolicy,
+    });
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        downloadBehavior: { policy: 'deny' },
+        args: expect.arrayContaining([
+          '--proxy-server=http://127.0.0.1:43123',
+          '--proxy-bypass-list=<-loopback>',
+        ]),
+      }),
+    );
+    expect(mockLaunch.mock.calls[0]![0]).not.toHaveProperty('userDataDir');
+    expect(mockInstallPagePolicy).toHaveBeenCalledWith(mockPage, publicPolicy);
+    expect(session?.mcpConfig).toMatchObject({
+      sessionMode: 'existing',
+      wsEndpoint: 'ws://127.0.0.1:43124/devtools/browser/opaque',
+    });
+    expect(session?.mcpConfig.readPolicy).toBeUndefined();
+  });
+
+  it('reuses only the adapter-resolved authenticated profile', async () => {
+    await startBrowserReadSession({
+      sessionMode: 'existing',
+      userDataDir: '/opaque/browser-profile',
+      readPolicy: { ...publicPolicy, accessMode: 'authenticated' },
+    });
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({ userDataDir: '/opaque/browser-profile' }),
+    );
+  });
+
+  it('closes policy interception, browser and proxy in order at shutdown', async () => {
+    const session = await startBrowserReadSession({
+      sessionMode: 'isolated',
+      readPolicy: publicPolicy,
+    });
+
+    await session?.close();
+
+    expect(mockPagePolicyClose).toHaveBeenCalledOnce();
+    expect(mockBrowserClose).toHaveBeenCalledOnce();
+    expect(mockProxyClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/pi-browser-use/src/__tests__/config.test.ts
+++ b/packages/pi-browser-use/src/__tests__/config.test.ts
@@ -85,6 +85,104 @@ describe('configToArgs', () => {
     ).toThrow('allowedUrlPattern and blockedUrlPattern cannot be used together');
   });
 
+  it('requires isolated browser mode for public read policy', () => {
+    expect(() =>
+      resolveConfig({
+        sessionMode: 'existing',
+        readPolicy: {
+          version: 'browser_read_policy_v1',
+          accessMode: 'public',
+          allowedTopLevelLocators: ['https://example.com/'],
+          allowedTopLevelOrigins: ['https://example.com'],
+          subresources: 'public_or_same_origin',
+          privateCrossOriginSubresources: 'deny',
+          popups: 'deny',
+          downloads: 'deny',
+          newTargets: 'deny',
+        },
+      }),
+    ).toThrow('public browser read policy requires isolated session mode');
+  });
+
+  it('requires existing browser mode for authenticated read policy', () => {
+    expect(() =>
+      resolveConfig({
+        sessionMode: 'isolated',
+        readPolicy: {
+          version: 'browser_read_policy_v1',
+          accessMode: 'authenticated',
+          allowedTopLevelLocators: ['https://private.example/page'],
+          allowedTopLevelOrigins: ['https://private.example'],
+          subresources: 'public_or_same_origin',
+          privateCrossOriginSubresources: 'deny',
+          popups: 'deny',
+          downloads: 'deny',
+          newTargets: 'deny',
+        },
+      }),
+    ).toThrow('authenticated browser read policy requires existing session mode');
+  });
+
+  it('requires a package-managed ephemeral profile for public policy', () => {
+    expect(() =>
+      resolveConfig({
+        sessionMode: 'isolated',
+        userDataDir: '/tmp/not-ephemeral',
+        readPolicy: {
+          version: 'browser_read_policy_v1',
+          accessMode: 'public',
+          allowedTopLevelLocators: ['https://example.com/'],
+          allowedTopLevelOrigins: ['https://example.com'],
+          subresources: 'public_or_same_origin',
+          privateCrossOriginSubresources: 'deny',
+          popups: 'deny',
+          downloads: 'deny',
+          newTargets: 'deny',
+        },
+      }),
+    ).toThrow('ephemeral profile');
+  });
+
+  it('requires an adapter-resolved profile for authenticated policy', () => {
+    expect(() =>
+      resolveConfig({
+        sessionMode: 'existing',
+        readPolicy: {
+          version: 'browser_read_policy_v1',
+          accessMode: 'authenticated',
+          allowedTopLevelLocators: ['https://private.example/page'],
+          allowedTopLevelOrigins: ['https://private.example'],
+          subresources: 'public_or_same_origin',
+          privateCrossOriginSubresources: 'deny',
+          popups: 'deny',
+          downloads: 'deny',
+          newTargets: 'deny',
+        },
+      }),
+    ).toThrow('adapter-resolved profile');
+  });
+
+  it('rejects externally managed browser endpoints under read policy', () => {
+    expect(() =>
+      resolveConfig({
+        sessionMode: 'existing',
+        userDataDir: '/opaque/browser-profile',
+        browserUrl: 'http://127.0.0.1:9222',
+        readPolicy: {
+          version: 'browser_read_policy_v1',
+          accessMode: 'authenticated',
+          allowedTopLevelLocators: ['https://private.example/page'],
+          allowedTopLevelOrigins: ['https://private.example'],
+          subresources: 'public_or_same_origin',
+          privateCrossOriginSubresources: 'deny',
+          popups: 'deny',
+          downloads: 'deny',
+          newTargets: 'deny',
+        },
+      }),
+    ).toThrow('package-managed browser session');
+  });
+
   it('disables page ID routing automatically in slim mode', () => {
     expect(configToArgs({ slim: true })).not.toContain('--experimental-page-id-routing');
   });

--- a/packages/pi-browser-use/src/__tests__/index.test.ts
+++ b/packages/pi-browser-use/src/__tests__/index.test.ts
@@ -3,8 +3,12 @@ import { beforeEach, describe, expect, it, test, vi } from 'vitest';
 // --- Mocks ---
 
 const mockPrepareBrowserProfile = vi.hoisted(() => vi.fn());
+const mockStartBrowserReadSession = vi.hoisted(() => vi.fn(() => Promise.resolve(undefined)));
 
 vi.mock('../profile.js', () => ({ prepareBrowserProfile: mockPrepareBrowserProfile }));
+vi.mock('../browser-read-session.js', () => ({
+  startBrowserReadSession: mockStartBrowserReadSession,
+}));
 
 const mockListAllTools = vi.fn(() =>
   Promise.resolve([
@@ -149,6 +153,7 @@ async function shutdownExtension() {
 
 describe('browserUseExtension', () => {
   beforeEach(() => {
+    delete process.env.PI_BROWSER_USE_RUNTIME_READ_POLICY;
     registeredTools.clear();
     sessionStartHandlers.length = 0;
     sessionShutdownHandlers.length = 0;
@@ -160,6 +165,7 @@ describe('browserUseExtension', () => {
     mockComplete.mockClear();
     mockListAllTools.mockClear();
     mockPrepareBrowserProfile.mockClear();
+    mockStartBrowserReadSession.mockClear();
   });
 
   test('registers session_start and session_shutdown handlers', () => {
@@ -187,6 +193,13 @@ describe('browserUseExtension', () => {
       expect(mockPrepareBrowserProfile).toHaveBeenCalledWith(
         expect.objectContaining({ sessionMode: 'persistent', userDataDir: '/tmp/test-profile' }),
       );
+    });
+
+    it('fails closed when runtime read policy is required but absent', async () => {
+      process.env.PI_BROWSER_USE_RUNTIME_READ_POLICY = 'required';
+
+      await expect(startExtension()).rejects.toThrow('runtime browser read policy is required');
+      expect(mockConnect).not.toHaveBeenCalled();
     });
   });
 
@@ -349,6 +362,74 @@ describe('browserUseExtension', () => {
       };
 
       expect(result.content[0]!.text).toBe('Tool result');
+    });
+
+    it('rejects browser navigation outside the signed read policy before MCP', async () => {
+      await startExtension({
+        sessionMode: 'existing',
+        userDataDir: '/opaque/browser-profile',
+        readPolicy: {
+          version: 'browser_read_policy_v1',
+          accessMode: 'authenticated',
+          allowedTopLevelLocators: ['https://private.example/page'],
+          allowedTopLevelOrigins: ['https://private.example'],
+          subresources: 'public_or_same_origin',
+          privateCrossOriginSubresources: 'deny',
+          popups: 'deny',
+          downloads: 'deny',
+          newTargets: 'deny',
+        },
+      });
+      const navTool = registeredTools.get('browser_navigate_page')!;
+
+      await expect(
+        navTool.execute(
+          'call-1',
+          { type: 'url', url: 'https://other.example/' },
+          undefined,
+          undefined,
+          {},
+        ),
+      ).rejects.toThrow('outside the signed browser read scope');
+      expect(mockCallTool).not.toHaveBeenCalled();
+    });
+
+    it('attaches a content-free observation receipt to source read results', async () => {
+      mockCallTool.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'sensitive page snapshot' }],
+      });
+      await startExtension({
+        sessionMode: 'existing',
+        userDataDir: '/opaque/browser-profile',
+        readPolicy: {
+          version: 'browser_read_policy_v1',
+          accessMode: 'authenticated',
+          allowedTopLevelLocators: ['https://private.example/page'],
+          allowedTopLevelOrigins: ['https://private.example'],
+          subresources: 'public_or_same_origin',
+          privateCrossOriginSubresources: 'deny',
+          popups: 'deny',
+          downloads: 'deny',
+          newTargets: 'deny',
+          observation: { runId: 'run-1', retention: 'source_summary_only_v1' },
+        },
+      });
+      const snapshotTool = registeredTools.get('browser_take_snapshot')!;
+
+      const result = (await snapshotTool.execute(
+        'call-1',
+        { pageId: 1 },
+        undefined,
+        undefined,
+        {},
+      )) as { details: Record<string, unknown> };
+
+      expect(result.details).toMatchObject({
+        version: 'source_observation_v1',
+        runId: 'run-1',
+        toolName: 'browser_take_snapshot',
+      });
+      expect(JSON.stringify(result.details)).not.toContain('sensitive page snapshot');
     });
 
     test('strips embedded page snapshot from non-snapshot results', async () => {

--- a/packages/pi-browser-use/src/__tests__/policy-proxy.test.ts
+++ b/packages/pi-browser-use/src/__tests__/policy-proxy.test.ts
@@ -1,0 +1,47 @@
+import type { DnsLookup } from '@amaster.ai/pi-shared';
+import { describe, expect, it } from 'vitest';
+import type { BrowserReadPolicyV1 } from '../config.js';
+import { resolveBrowserProxyTarget } from '../policy-proxy.js';
+
+const lookup: DnsLookup = async (hostname) => [
+  {
+    address: hostname === 'private.example' ? '10.0.0.9' : '93.184.216.34',
+    family: 4,
+  },
+];
+
+const authenticatedPolicy: BrowserReadPolicyV1 = {
+  version: 'browser_read_policy_v1',
+  accessMode: 'authenticated',
+  allowedTopLevelLocators: ['https://private.example/source'],
+  allowedTopLevelOrigins: ['https://private.example'],
+  subresources: 'public_or_same_origin',
+  privateCrossOriginSubresources: 'deny',
+  popups: 'deny',
+  downloads: 'deny',
+  newTargets: 'deny',
+};
+
+describe('resolveBrowserProxyTarget', () => {
+  it('pins a public third-party host to its validated address', async () => {
+    await expect(
+      resolveBrowserProxyTarget('https://cdn.example/image.png', authenticatedPolicy, lookup),
+    ).resolves.toMatchObject({ hostname: 'cdn.example', address: '93.184.216.34', port: 443 });
+  });
+
+  it('allows the signed authenticated origin even when it resolves privately', async () => {
+    await expect(
+      resolveBrowserProxyTarget('https://private.example/source', authenticatedPolicy, lookup),
+    ).resolves.toMatchObject({ hostname: 'private.example', address: '10.0.0.9', port: 443 });
+  });
+
+  it('rejects a private cross-origin host before opening a socket', async () => {
+    await expect(
+      resolveBrowserProxyTarget(
+        'https://other-private.example/resource',
+        authenticatedPolicy,
+        async () => [{ address: '192.168.1.8', family: 4 }],
+      ),
+    ).rejects.toThrow('public HTTP(S) destination');
+  });
+});

--- a/packages/pi-browser-use/src/__tests__/read-policy.test.ts
+++ b/packages/pi-browser-use/src/__tests__/read-policy.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { BrowserReadPolicyV1 } from '../config.js';
+import { assertBrowserReadNavigation, assertBrowserReadSubresource } from '../read-policy.js';
+
+const publicPolicy: BrowserReadPolicyV1 = {
+  version: 'browser_read_policy_v1',
+  accessMode: 'public',
+  allowedTopLevelLocators: ['https://example.com/page'],
+  allowedTopLevelOrigins: ['https://example.com'],
+  subresources: 'public_or_same_origin',
+  privateCrossOriginSubresources: 'deny',
+  popups: 'deny',
+  downloads: 'deny',
+  newTargets: 'deny',
+};
+
+describe('assertBrowserReadNavigation', () => {
+  it('allows only a declared public top-level locator', async () => {
+    await expect(
+      assertBrowserReadNavigation('https://example.com/page', publicPolicy, async () => [
+        { address: '93.184.216.34', family: 4 },
+      ]),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertBrowserReadNavigation('https://example.com/other', publicPolicy, async () => [
+        { address: '93.184.216.34', family: 4 },
+      ]),
+    ).rejects.toThrow('outside the signed browser read scope');
+  });
+
+  it('rejects a declared public locator when DNS resolves privately', async () => {
+    await expect(
+      assertBrowserReadNavigation('https://example.com/page', publicPolicy, async () => [
+        { address: '192.168.1.5', family: 4 },
+      ]),
+    ).rejects.toThrow(/public HTTP/i);
+  });
+
+  it('allows the exact authenticated locator without sending it to a public reader', async () => {
+    await expect(
+      assertBrowserReadNavigation('https://private.example/page', {
+        ...publicPolicy,
+        accessMode: 'authenticated',
+        allowedTopLevelLocators: ['https://private.example/page'],
+        allowedTopLevelOrigins: ['https://private.example'],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('assertBrowserReadSubresource', () => {
+  it('allows public third-party resources without expanding top-level navigation', async () => {
+    await expect(
+      assertBrowserReadSubresource(
+        'https://cdn.example.net/image.png',
+        'https://example.com',
+        publicPolicy,
+        async () => [{ address: '93.184.216.35', family: 4 }],
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects private cross-origin resources before the request is continued', async () => {
+    await expect(
+      assertBrowserReadSubresource(
+        'https://internal.example/image.png',
+        'https://example.com',
+        publicPolicy,
+        async () => [{ address: '10.0.0.8', family: 4 }],
+      ),
+    ).rejects.toThrow(/public HTTP/i);
+  });
+
+  it('allows the signed authenticated origin but still rejects another private origin', async () => {
+    const authenticatedPolicy: BrowserReadPolicyV1 = {
+      ...publicPolicy,
+      accessMode: 'authenticated',
+      allowedTopLevelLocators: ['https://private.example/page'],
+      allowedTopLevelOrigins: ['https://private.example'],
+    };
+    await expect(
+      assertBrowserReadSubresource(
+        'https://private.example/image.png',
+        'https://private.example',
+        authenticatedPolicy,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertBrowserReadSubresource(
+        'https://other-private.example/image.png',
+        'https://private.example',
+        authenticatedPolicy,
+        async () => [{ address: '10.0.0.9', family: 4 }],
+      ),
+    ).rejects.toThrow(/public HTTP/i);
+  });
+});

--- a/packages/pi-browser-use/src/browser-read-enforcer.ts
+++ b/packages/pi-browser-use/src/browser-read-enforcer.ts
@@ -1,0 +1,81 @@
+import type { DnsLookup } from '@amaster.ai/pi-shared';
+import type { BrowserReadPolicyV1 } from './config.js';
+import { assertBrowserReadNavigation, assertBrowserReadSubresource } from './read-policy.js';
+
+type InterceptedRequest = {
+  url(): string;
+  frame(): unknown;
+  isNavigationRequest(): boolean;
+  continue(): Promise<void>;
+  abort(errorCode?: string): Promise<void>;
+};
+
+export type BrowserReadPage = {
+  url(): string;
+  mainFrame(): unknown;
+  setBypassServiceWorker(value: boolean): Promise<void>;
+  setRequestInterception(value: boolean): Promise<void>;
+  evaluateOnNewDocument(pageFunction: () => void): Promise<unknown>;
+  on(event: 'request', handler: (request: InterceptedRequest) => void): unknown;
+  off(event: 'request', handler: (request: InterceptedRequest) => void): unknown;
+};
+
+export type InstalledBrowserReadPagePolicy = {
+  close(): Promise<void>;
+};
+
+function topLevelOrigin(page: BrowserReadPage, policy: BrowserReadPolicyV1): string {
+  try {
+    return new URL(page.url()).origin;
+  } catch {
+    return policy.allowedTopLevelOrigins[0] ?? 'null';
+  }
+}
+
+/**
+ * Pause every request from a bound page before Chrome transmits it. Top-level
+ * navigations keep exact signed scope; subresources may use the signed origin
+ * or a public destination. The policy proxy independently re-resolves and pins
+ * the destination address before opening the outbound socket.
+ */
+export async function installBrowserReadPagePolicy(
+  page: BrowserReadPage,
+  policy: BrowserReadPolicyV1,
+  lookup?: DnsLookup,
+): Promise<InstalledBrowserReadPagePolicy> {
+  await page.setBypassServiceWorker(true);
+  await page.setRequestInterception(true);
+  await page.evaluateOnNewDocument(() => {
+    Object.defineProperty(globalThis, 'open', {
+      configurable: false,
+      value: () => null,
+      writable: false,
+    });
+  });
+
+  const onRequest = async (request: InterceptedRequest) => {
+    try {
+      if (request.isNavigationRequest() && request.frame() === page.mainFrame()) {
+        await assertBrowserReadNavigation(request.url(), policy, lookup);
+      } else {
+        await assertBrowserReadSubresource(
+          request.url(),
+          topLevelOrigin(page, policy),
+          policy,
+          lookup,
+        );
+      }
+      await request.continue();
+    } catch {
+      await request.abort('blockedbyclient');
+    }
+  };
+  page.on('request', onRequest);
+
+  return {
+    async close() {
+      page.off('request', onRequest);
+      await page.setRequestInterception(false).catch(() => {});
+    },
+  };
+}

--- a/packages/pi-browser-use/src/browser-read-session.ts
+++ b/packages/pi-browser-use/src/browser-read-session.ts
@@ -1,0 +1,140 @@
+import type { Browser, ChromeReleaseChannel, LaunchOptions, Page, Target } from 'puppeteer-core';
+import puppeteer from 'puppeteer-core';
+import {
+  type InstalledBrowserReadPagePolicy,
+  installBrowserReadPagePolicy,
+} from './browser-read-enforcer.js';
+import type { BrowserUseConfig } from './config.js';
+import { type BrowserPolicyProxy, startBrowserPolicyProxy } from './policy-proxy.js';
+
+export type BrowserReadSession = {
+  mcpConfig: BrowserUseConfig;
+  close(): Promise<void>;
+};
+
+function chromeChannel(channel: BrowserUseConfig['channel']): ChromeReleaseChannel {
+  switch (channel) {
+    case 'beta':
+      return 'chrome-beta';
+    case 'canary':
+      return 'chrome-canary';
+    case 'dev':
+      return 'chrome-dev';
+    default:
+      return 'chrome';
+  }
+}
+
+function parseViewport(value: string | undefined): { width: number; height: number } | null {
+  if (!value) return null;
+  const match = /^(\d+)x(\d+)$/.exec(value);
+  if (!match) return null;
+  return { width: Number(match[1]), height: Number(match[2]) };
+}
+
+function mcpConnectionConfig(config: BrowserUseConfig, browser: Browser): BrowserUseConfig {
+  const result: BrowserUseConfig = {
+    ...config,
+    sessionMode: 'existing',
+    wsEndpoint: browser.wsEndpoint(),
+    autoConnect: false,
+    isolated: false,
+  };
+  delete result.browserUrl;
+  delete result.wsHeaders;
+  delete result.userDataDir;
+  delete result.readPolicy;
+  delete result.allowedUrlPattern;
+  delete result.blockedUrlPattern;
+  delete result.extraArgs;
+  return result;
+}
+
+async function selectBoundPage(browser: Browser): Promise<Page> {
+  const pages = await browser.pages();
+  if (pages.length !== 1) {
+    throw new Error('Browser read policy requires exactly one dedicated page.');
+  }
+  return pages[0]!;
+}
+
+async function closeNewTarget(target: Target, boundTarget: Target): Promise<void> {
+  if (target === boundTarget) return;
+  try {
+    const page = await target.page();
+    if (page) {
+      await page.close({ runBeforeUnload: false });
+      return;
+    }
+    const worker = await target.worker();
+    if (worker) await worker.close();
+  } catch {
+    // The target may already have disappeared after being denied.
+  }
+}
+
+/**
+ * Launch one dedicated Chromium through pi-browser-use, attach the pre-request
+ * policy, then let chrome-devtools-mcp connect to that same browser. Public
+ * runs use an ephemeral profile; authenticated runs reuse only the adapter-
+ * resolved profile directory and never attach to an arbitrary live browser.
+ */
+export async function startBrowserReadSession(
+  config: BrowserUseConfig,
+): Promise<BrowserReadSession | undefined> {
+  const policy = config.readPolicy;
+  if (!policy) return undefined;
+
+  let proxy: BrowserPolicyProxy | undefined;
+  let browser: Browser | undefined;
+  let pagePolicy: InstalledBrowserReadPagePolicy | undefined;
+  let targetHandler: ((target: Target) => void) | undefined;
+  try {
+    proxy = await startBrowserPolicyProxy(policy);
+    const launchOptions: LaunchOptions = {
+      defaultViewport: parseViewport(config.viewport),
+      downloadBehavior: { policy: 'deny' },
+      args: [
+        `--proxy-server=${proxy.url}`,
+        '--proxy-bypass-list=<-loopback>',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-sync',
+        '--no-first-run',
+      ],
+    };
+    if (config.executablePath) launchOptions.executablePath = config.executablePath;
+    else launchOptions.channel = chromeChannel(config.channel);
+    if (config.headless !== undefined) launchOptions.headless = config.headless;
+    if (config.acceptInsecureCerts !== undefined) {
+      launchOptions.acceptInsecureCerts = config.acceptInsecureCerts;
+    }
+    if (policy.accessMode === 'authenticated' && config.userDataDir) {
+      launchOptions.userDataDir = config.userDataDir;
+    }
+    browser = await puppeteer.launch(launchOptions);
+    const page = await selectBoundPage(browser);
+    pagePolicy = await installBrowserReadPagePolicy(page, policy);
+    const boundTarget = page.target();
+    targetHandler = (target) => {
+      void closeNewTarget(target, boundTarget);
+    };
+    browser.on('targetcreated', targetHandler);
+
+    return {
+      mcpConfig: mcpConnectionConfig(config, browser),
+      async close() {
+        if (targetHandler) browser?.off('targetcreated', targetHandler);
+        await pagePolicy?.close();
+        await browser?.close();
+        await proxy?.close();
+      },
+    };
+  } catch {
+    if (targetHandler) browser?.off('targetcreated', targetHandler);
+    await pagePolicy?.close().catch(() => {});
+    await browser?.close().catch(() => {});
+    await proxy?.close().catch(() => {});
+    throw new Error('Browser read policy session could not be established.');
+  }
+}

--- a/packages/pi-browser-use/src/config.ts
+++ b/packages/pi-browser-use/src/config.ts
@@ -9,6 +9,22 @@ export interface VisionModelConfig {
 
 export type BrowserSessionMode = 'persistent' | 'isolated' | 'existing';
 
+export type BrowserReadPolicyV1 = {
+  version: 'browser_read_policy_v1';
+  accessMode: 'public' | 'authenticated';
+  allowedTopLevelLocators: string[];
+  allowedTopLevelOrigins: string[];
+  subresources: 'public_or_same_origin';
+  privateCrossOriginSubresources: 'deny';
+  popups: 'deny';
+  downloads: 'deny';
+  newTargets: 'deny';
+  observation?: {
+    runId: string;
+    retention: 'source_summary_only_v1';
+  };
+};
+
 /** Configuration for the chrome-devtools-mcp upstream process. */
 export interface BrowserUseConfig {
   sessionMode?: BrowserSessionMode;
@@ -41,6 +57,7 @@ export interface BrowserUseConfig {
   acceptInsecureCerts?: boolean;
   allowedUrlPattern?: string[];
   blockedUrlPattern?: string[];
+  readPolicy?: BrowserReadPolicyV1;
 
   slim?: boolean;
   extraArgs?: string[];
@@ -72,6 +89,33 @@ export function resolveConfig(config?: BrowserUseConfig): BrowserUseConfig {
     throw new Error('allowedUrlPattern and blockedUrlPattern cannot be used together');
   }
 
+  if (resolved.readPolicy) {
+    if (resolved.readPolicy.accessMode === 'public' && resolved.sessionMode !== 'isolated') {
+      throw new Error('public browser read policy requires isolated session mode');
+    }
+    if (resolved.readPolicy.accessMode === 'authenticated' && resolved.sessionMode !== 'existing') {
+      throw new Error('authenticated browser read policy requires existing session mode');
+    }
+    if (resolved.allowedUrlPattern?.length || resolved.blockedUrlPattern?.length) {
+      throw new Error('browser read policy owns URL filtering configuration');
+    }
+    if (
+      resolved.browserUrl ||
+      resolved.wsEndpoint ||
+      resolved.wsHeaders ||
+      resolved.autoConnect ||
+      resolved.extraArgs?.length
+    ) {
+      throw new Error('browser read policy requires a package-managed browser session');
+    }
+    if (resolved.readPolicy.accessMode === 'public' && resolved.userDataDir) {
+      throw new Error('public browser read policy requires an ephemeral profile');
+    }
+    if (resolved.readPolicy.accessMode === 'authenticated' && !resolved.userDataDir) {
+      throw new Error('authenticated browser read policy requires an adapter-resolved profile');
+    }
+  }
+
   if (resolved.slim) {
     if (config?.experimentalPageIdRouting === true) {
       throw new Error('experimentalPageIdRouting cannot be used with slim mode');
@@ -81,7 +125,12 @@ export function resolveConfig(config?: BrowserUseConfig): BrowserUseConfig {
 
   switch (resolved.sessionMode) {
     case 'existing':
-      if (!resolved.autoConnect && !resolved.browserUrl && !resolved.wsEndpoint) {
+      if (
+        !resolved.readPolicy &&
+        !resolved.autoConnect &&
+        !resolved.browserUrl &&
+        !resolved.wsEndpoint
+      ) {
         resolved.autoConnect = true;
       }
       break;

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+import { createSourceObservationReceipt } from '@amaster.ai/pi-shared';
 import {
   isProjectTrusted,
   loadPiSettings,
@@ -17,7 +18,9 @@ import {
   VISUAL_SYSTEM_PROMPT,
   type VisionCaller,
 } from './analyze-screenshot.js';
+import { type BrowserReadSession, startBrowserReadSession } from './browser-read-session.js';
 import {
+  type BrowserReadPolicyV1,
   type BrowserSessionMode,
   type BrowserUseConfig,
   configToArgs,
@@ -25,13 +28,15 @@ import {
   type VisionModelConfig,
 } from './config.js';
 import { prepareBrowserProfile } from './profile.js';
+import { assertBrowserReadNavigation } from './read-policy.js';
 import {
   augmentToolDescription,
   extractTextContent,
   postProcessToolResult,
 } from './tool-augment.js';
 
-export type { BrowserSessionMode, BrowserUseConfig, VisionModelConfig };
+export { assertBrowserReadNavigation, assertBrowserReadSubresource } from './read-policy.js';
+export type { BrowserReadPolicyV1, BrowserSessionMode, BrowserUseConfig, VisionModelConfig };
 export { configToArgs, resolveConfig };
 
 // All upstream tools are re-exported with this prefix to avoid name collisions with other extensions.
@@ -50,6 +55,13 @@ const EXCLUDED_TOOLS = new Set([
   'reload_extension',
   'trigger_extension_action',
   'uninstall_extension',
+]);
+const READ_POLICY_TOOLS = new Set([
+  'list_pages',
+  'navigate_page',
+  'take_snapshot',
+  'take_screenshot',
+  'wait_for',
 ]);
 
 const MCP_TIMEOUT_MS = 60_000;
@@ -338,9 +350,17 @@ export class DevToolsClient {
 
 /** Read pi-browser-use settings, including the project layer only when trusted. */
 function loadConfigFromFile(options?: PiSettingsOptions): BrowserUseConfig {
-  return loadPiSettings<BrowserUseConfig>('pi-browser-use', {
-    ...options,
-  });
+  const runtimePolicy = process.env.PI_BROWSER_USE_RUNTIME_READ_POLICY;
+  if (runtimePolicy !== undefined && runtimePolicy !== 'required') {
+    throw new Error('PI_BROWSER_USE_RUNTIME_READ_POLICY is invalid.');
+  }
+  const settingsOptions: PiSettingsOptions = { ...options };
+  if (runtimePolicy === 'required') settingsOptions.projectTrusted = false;
+  const config = loadPiSettings<BrowserUseConfig>('pi-browser-use', settingsOptions);
+  if (runtimePolicy === 'required' && !config.readPolicy) {
+    throw new Error('A runtime browser read policy is required.');
+  }
+  return config;
 }
 
 /** Convert upstream MCP result into pi-agent content, applying text post-processing. */
@@ -406,6 +426,7 @@ function toToolContent(
 export default function browserUseExtension(pi: ExtensionAPI): void {
   let config: BrowserUseConfig | undefined;
   let client: DevToolsClient | undefined;
+  let readSession: BrowserReadSession | undefined;
 
   async function ensureConnected(signal?: AbortSignal): Promise<void> {
     if (!client) throw new Error('browser-use: session not started');
@@ -418,6 +439,7 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
 
     for (const tool of upstreamTools) {
       if (EXCLUDED_TOOLS.has(tool.name)) continue;
+      if (config?.readPolicy && !READ_POLICY_TOOLS.has(tool.name)) continue;
 
       const prefixedName = `${TOOL_PREFIX}${tool.name}`;
       const originalName = tool.name;
@@ -439,10 +461,42 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
           _onUpdate: unknown,
           _ctx: ExtensionContext,
         ) {
+          if (config?.readPolicy && originalName === 'navigate_page') {
+            if (
+              params.type !== 'url' ||
+              typeof params.url !== 'string' ||
+              params.initScript !== undefined ||
+              params.handleBeforeUnload !== undefined
+            ) {
+              throw new Error('Browser read policy allows only explicit URL navigation.');
+            }
+            await assertBrowserReadNavigation(params.url, config.readPolicy);
+          }
           await ensureConnected(signal);
           const result = await client!.callTool(originalName, params, signal);
           const toolContent = toToolContent(result, originalName);
-          return { ...toolContent, details: undefined };
+          const observation = config?.readPolicy?.observation;
+          const locator =
+            typeof params.url === 'string'
+              ? params.url
+              : (config?.readPolicy?.allowedTopLevelLocators[0] ?? '[browser-page]');
+          const rawContent = (result.content ?? [])
+            .map((item) => item.text ?? item.data ?? '')
+            .join('');
+          const details = observation
+            ? createSourceObservationReceipt({
+                runId: observation.runId,
+                toolName: prefixedName,
+                requestedLocator: locator,
+                finalLocator: locator,
+                mediaType: result.content?.some((item) => item.type === 'image')
+                  ? 'image/png'
+                  : 'text/plain',
+                content: rawContent,
+                truncated: false,
+              })
+            : undefined;
+          return { ...toolContent, details };
         },
       });
     }
@@ -571,10 +625,19 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       }),
     );
     prepareBrowserProfile(config);
-    client = new DevToolsClient(config);
-    await registerUpstreamTools();
-    if (config.visionModel) {
-      await registerVisionTool(config.visionModel);
+    try {
+      readSession = await startBrowserReadSession(config);
+      client = new DevToolsClient(readSession?.mcpConfig ?? config);
+      await registerUpstreamTools();
+      if (config.visionModel) {
+        await registerVisionTool(config.visionModel);
+      }
+    } catch (error) {
+      await client?.close().catch(() => {});
+      client = undefined;
+      await readSession?.close().catch(() => {});
+      readSession = undefined;
+      throw error;
     }
   });
 
@@ -582,6 +645,10 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
     if (client) {
       await client.close();
       client = undefined;
+    }
+    if (readSession) {
+      await readSession.close();
+      readSession = undefined;
     }
   });
 }

--- a/packages/pi-browser-use/src/policy-proxy.ts
+++ b/packages/pi-browser-use/src/policy-proxy.ts
@@ -1,0 +1,151 @@
+import { lookup as nodeLookup } from 'node:dns/promises';
+import { createServer, request as httpRequest, type IncomingMessage } from 'node:http';
+import { isIP, connect as netConnect, type Socket } from 'node:net';
+import type { Duplex } from 'node:stream';
+import type { DnsLookup } from '@amaster.ai/pi-shared';
+import { resolvePublicHttpUrl } from '@amaster.ai/pi-shared';
+import type { BrowserReadPolicyV1 } from './config.js';
+
+const defaultLookup: DnsLookup = async (hostname) =>
+  nodeLookup(hostname, { all: true, verbatim: true });
+
+export type BrowserProxyTarget = {
+  hostname: string;
+  address: string;
+  family: number;
+  port: number;
+};
+
+function defaultPort(url: URL): number {
+  if (url.port) return Number(url.port);
+  return url.protocol === 'https:' ? 443 : 80;
+}
+
+async function resolveAnyAddress(
+  hostname: string,
+  lookup: DnsLookup,
+): Promise<{
+  address: string;
+  family: number;
+}> {
+  const family = isIP(hostname);
+  const addresses = family ? [{ address: hostname, family }] : await lookup(hostname);
+  const target = addresses[0];
+  if (!target) throw new Error('Browser policy proxy could not resolve the destination.');
+  return target;
+}
+
+export async function resolveBrowserProxyTarget(
+  locator: string | URL,
+  policy: BrowserReadPolicyV1,
+  lookup: DnsLookup = defaultLookup,
+): Promise<BrowserProxyTarget> {
+  const url = locator instanceof URL ? new URL(locator) : new URL(locator);
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.username || url.password) {
+    throw new Error('Browser policy proxy requires an HTTP(S) destination.');
+  }
+
+  const signedPrivateOrigin =
+    policy.accessMode === 'authenticated' && policy.allowedTopLevelOrigins.includes(url.origin);
+  const target = signedPrivateOrigin
+    ? await resolveAnyAddress(url.hostname, lookup)
+    : (await resolvePublicHttpUrl(url, lookup)).addresses[0];
+  if (!target) throw new Error('Browser policy proxy could not resolve the destination.');
+  return {
+    hostname: url.hostname,
+    address: target.address,
+    family: target.family,
+    port: defaultPort(url),
+  };
+}
+
+function safeProxyFailure(socket: Socket | Duplex): void {
+  if (!socket.destroyed) socket.end('HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n');
+}
+
+function absoluteHttpUrl(request: IncomingMessage): URL {
+  const url = new URL(request.url ?? '');
+  if (url.protocol !== 'http:') {
+    throw new Error('Browser policy proxy accepts HTTPS only through CONNECT.');
+  }
+  return url;
+}
+
+export type BrowserPolicyProxy = {
+  url: string;
+  close(): Promise<void>;
+};
+
+export async function startBrowserPolicyProxy(
+  policy: BrowserReadPolicyV1,
+  lookup: DnsLookup = defaultLookup,
+): Promise<BrowserPolicyProxy> {
+  const server = createServer((request, response) => {
+    void (async () => {
+      try {
+        const url = absoluteHttpUrl(request);
+        const target = await resolveBrowserProxyTarget(url, policy, lookup);
+        const headers = { ...request.headers };
+        delete headers['proxy-connection'];
+        const outgoing = httpRequest(
+          {
+            host: target.address,
+            family: target.family,
+            port: target.port,
+            method: request.method,
+            path: `${url.pathname}${url.search}`,
+            headers,
+          },
+          (incoming) => {
+            response.writeHead(incoming.statusCode ?? 502, incoming.headers);
+            incoming.pipe(response);
+          },
+        );
+        outgoing.once('error', () => response.destroy());
+        request.pipe(outgoing);
+      } catch {
+        response.writeHead(502, { connection: 'close' });
+        response.end();
+      }
+    })();
+  });
+
+  server.on('connect', (request, clientSocket, head) => {
+    void (async () => {
+      try {
+        const connectUrl = new URL(`https://${request.url ?? ''}/`);
+        const target = await resolveBrowserProxyTarget(connectUrl, policy, lookup);
+        const upstream = netConnect({
+          host: target.address,
+          family: target.family,
+          port: target.port,
+        });
+        upstream.once('connect', () => {
+          clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+          if (head.length > 0) upstream.write(head);
+          upstream.pipe(clientSocket);
+          clientSocket.pipe(upstream);
+        });
+        upstream.once('error', () => safeProxyFailure(clientSocket));
+        clientSocket.once('error', () => upstream.destroy());
+      } catch {
+        safeProxyFailure(clientSocket);
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('Browser policy proxy failed to bind a local port.');
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}

--- a/packages/pi-browser-use/src/read-policy.ts
+++ b/packages/pi-browser-use/src/read-policy.ts
@@ -1,0 +1,63 @@
+import { assertPublicHttpUrl, type DnsLookup } from '@amaster.ai/pi-shared';
+import type { BrowserReadPolicyV1 } from './config.js';
+
+function canonicalLocator(value: string): string {
+  const url = new URL(value);
+  url.hash = '';
+  return url.toString();
+}
+
+export async function assertBrowserReadNavigation(
+  locator: string,
+  policy: BrowserReadPolicyV1,
+  lookup?: DnsLookup,
+): Promise<void> {
+  let canonical: string;
+  try {
+    canonical = canonicalLocator(locator);
+  } catch {
+    throw new Error('Browser navigation is outside the signed browser read scope.');
+  }
+  const allowed = policy.allowedTopLevelLocators.some((candidate) => {
+    try {
+      return canonicalLocator(candidate) === canonical;
+    } catch {
+      return false;
+    }
+  });
+  if (!allowed) {
+    throw new Error('Browser navigation is outside the signed browser read scope.');
+  }
+  const origin = new URL(canonical).origin;
+  if (!policy.allowedTopLevelOrigins.includes(origin)) {
+    throw new Error('Browser navigation is outside the signed browser read scope.');
+  }
+  if (policy.accessMode === 'public') {
+    await assertPublicHttpUrl(canonical, lookup);
+  }
+}
+
+export async function assertBrowserReadSubresource(
+  locator: string,
+  topLevelOrigin: string,
+  policy: BrowserReadPolicyV1,
+  lookup?: DnsLookup,
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(locator);
+  } catch {
+    throw new Error('Browser subresource is outside the signed browser read scope.');
+  }
+  if ((url.protocol !== 'http:' && url.protocol !== 'https:') || url.username || url.password) {
+    throw new Error('Browser subresource is outside the signed browser read scope.');
+  }
+  if (
+    policy.accessMode === 'authenticated' &&
+    url.origin === topLevelOrigin &&
+    policy.allowedTopLevelOrigins.includes(url.origin)
+  ) {
+    return;
+  }
+  await assertPublicHttpUrl(url, lookup);
+}

--- a/packages/pi-channels/package.json
+++ b/packages/pi-channels/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-channels",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for native messaging channels including Feishu, DingTalk, WeCom, and webhooks.",
   "keywords": [
     "pi-package",

--- a/packages/pi-computer-use/package.json
+++ b/packages/pi-computer-use/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-computer-use",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Cross-platform computer-use tools for Pi desktop automation",
   "keywords": ["pi-package", "pi", "extension", "computer-use", "desktop", "automation", "cua-driver", "mcp"],
   "license": "Apache-2.0",

--- a/packages/pi-image-gen/package.json
+++ b/packages/pi-image-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-image-gen",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for image generation via OpenAI gpt-image, Google Nano Banana (Gemini), Alibaba Qwen-Image, OpenRouter, and custom providers.",
   "keywords": [
     "pi-package",

--- a/packages/pi-memory-mem0/package.json
+++ b/packages/pi-memory-mem0/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-memory-mem0",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Explicit Mem0 semantic memory tools for pi — Platform cloud or local SQLite.",
   "keywords": ["pi-package", "pi", "extension", "memory", "mem0", "semantic-search", "sqlite"],
   "license": "Apache-2.0",

--- a/packages/pi-memory/package.json
+++ b/packages/pi-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-memory",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension providing persistent curated memory (MEMORY.md + USER.md) injected into the system prompt as a frozen snapshot.",
   "keywords": ["pi-package", "pi", "extension", "memory", "persistence"],
   "license": "Apache-2.0",

--- a/packages/pi-security/package.json
+++ b/packages/pi-security/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-security",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for resource-aware security policy engine and tool authorization",
   "keywords": ["pi-package", "pi", "extension", "security", "policy", "authorization", "access-control"],
   "license": "Apache-2.0",

--- a/packages/pi-task-scheduler/package.json
+++ b/packages/pi-task-scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-task-scheduler",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for cron-based scheduled task management with LLM-callable tools",
   "keywords": ["pi-package", "pi", "extension", "scheduler", "cron", "tasks"],
   "license": "Apache-2.0",

--- a/packages/pi-teamwork/package.json
+++ b/packages/pi-teamwork/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-teamwork",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for team collaboration and issue management via Multica",
   "keywords": ["pi-package", "pi", "extension", "teamwork", "issues", "project-management", "multica"],
   "license": "Apache-2.0",

--- a/packages/pi-telemetry/package.json
+++ b/packages/pi-telemetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-telemetry",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for runtime telemetry with Langfuse and OpenTelemetry exporters",
   "keywords": ["pi-package", "pi", "extension", "telemetry", "observability", "langfuse", "opentelemetry", "tracing"],
   "license": "Apache-2.0",

--- a/packages/pi-web-access/README.md
+++ b/packages/pi-web-access/README.md
@@ -60,7 +60,7 @@ Search X (Twitter) for posts and social media content. Only registered when xai 
 
 Custom Kimi base URLs must support both `/chat/completions` and `/formulas/*`.
 
-**Fetch fallback** (when `fetch.provider` is not set): Jina Reader (`r.jina.ai`, free, JS-rendered) → local HTTP GET + turndown.
+**Fetch fallback** (when `fetch.provider` is not set): Jina Reader (`r.jina.ai`, free, JS-rendered) → local HTTP GET + turndown. A managed runtime can force `local_only` so neither a configured provider nor Jina is contacted.
 
 ## Configuration
 
@@ -110,11 +110,22 @@ environment interpolation.
 | Field | Description |
 |-------|-------------|
 | `provider` | Which provider to use for URL fetching. Not set = Jina Reader → local fallback. |
+| `mode` | `provider_jina_or_local` (default) or `local_only`. Runtime-managed callers should lock this with `PI_WEB_ACCESS_RUNTIME_FETCH_MODE`. |
 | `summary` | Model config for summarizing fetched content. |
 | `summary.provider` | Model provider name (resolved via pi model registry). |
 | `summary.model` | Model id. |
 
 If neither `fetch.provider` nor `fetch.summary` is configured, `web_fetch` is not registered.
+
+### Runtime-managed source reads
+
+`PI_WEB_ACCESS_RUNTIME_FETCH_MODE=local_only` is a hard runtime override: it
+ignores project settings and calls the pinned local safe-fetch path before any
+provider or Jina request. `PI_WEB_ACCESS_RUNTIME_OBSERVATION=required` likewise
+ignores project settings and requires an isolated agent setting with
+`fetch.observation.runId` and `retention: "source_summary_only_v1"`. Successful
+fetches then include a content-free `source_observation_v1` receipt in tool
+details; the fetched body remains only in the model-visible tool result.
 
 ### `providers`
 

--- a/packages/pi-web-access/package.json
+++ b/packages/pi-web-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-web-access",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "description": "Pi extension for web search (Tavily, Kimi, DeepSeek, Mimo, Z.AI) and URL content extraction",
   "keywords": [
     "pi-package",

--- a/packages/pi-web-access/src/__tests__/config.test.ts
+++ b/packages/pi-web-access/src/__tests__/config.test.ts
@@ -1,5 +1,13 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { resolveFetchProvider, resolveProvider, resolveSearchProvider } from '../config.js';
+import {
+  loadWebToolSettings,
+  resolveFetchProvider,
+  resolveProvider,
+  resolveSearchProvider,
+} from '../config.js';
 import type { WebToolSettings } from '../types.js';
 
 describe('resolveProvider', () => {
@@ -355,5 +363,56 @@ describe('resolveFetchProvider', () => {
     const result = resolveFetchProvider(settings);
     expect(result).not.toBeNull();
     expect(result!.id).toBe('firecrawl');
+  });
+});
+
+describe('loadWebToolSettings', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  let root: string;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    root = mkdtempSync(join(tmpdir(), 'pi-web-access-config-'));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('locks local_only mode after trusted project settings are merged', () => {
+    const configDir = join(root, 'agent');
+    const cwd = join(root, 'project');
+    mkdirSync(configDir, { recursive: true });
+    mkdirSync(join(cwd, '.pi'), { recursive: true });
+    writeFileSync(
+      join(configDir, 'settings.json'),
+      JSON.stringify({
+        'pi-web-access': {
+          fetch: {
+            mode: 'local_only',
+            observation: { runId: 'run-1', retention: 'source_summary_only_v1' },
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(cwd, '.pi', 'settings.json'),
+      JSON.stringify({
+        'pi-web-access': {
+          fetch: { mode: 'provider_jina_or_local', provider: 'zai' },
+          providers: { zai: { apiKey: 'project-key' } },
+        },
+      }),
+    );
+    process.env.PI_CODING_AGENT_DIR = configDir;
+    process.env.PI_WEB_ACCESS_RUNTIME_FETCH_MODE = 'local_only';
+    process.env.PI_WEB_ACCESS_RUNTIME_OBSERVATION = 'required';
+
+    expect(loadWebToolSettings(cwd, true).fetch).toMatchObject({
+      mode: 'local_only',
+      observation: { runId: 'run-1', retention: 'source_summary_only_v1' },
+    });
+    expect(loadWebToolSettings(cwd, true).fetch?.provider).toBeUndefined();
   });
 });

--- a/packages/pi-web-access/src/__tests__/extension.test.ts
+++ b/packages/pi-web-access/src/__tests__/extension.test.ts
@@ -1,6 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import piWebToolExtension from '../index.js';
 
+const mockWebFetch = vi.hoisted(() =>
+  vi.fn(async ({ url }: { url: string }) => ({
+    url,
+    title: 'Private Page',
+    content: 'sensitive source body',
+  })),
+);
+
+vi.mock('../fetch.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../fetch.js')>()),
+  webFetch: mockWebFetch,
+}));
+
 vi.mock('../config.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../config.js')>();
   return {
@@ -14,7 +27,10 @@ import { loadWebToolSettings } from '../config.js';
 const mockLoadSettings = vi.mocked(loadWebToolSettings);
 
 function createMockPi() {
-  const tools: Array<{ name: string }> = [];
+  const tools: Array<{
+    name: string;
+    execute?: (...args: any[]) => Promise<unknown>;
+  }> = [];
   // biome-ignore lint/complexity/noBannedTypes: mock helper
   const listeners: Record<string, Function> = {};
   return {
@@ -86,6 +102,37 @@ describe('piWebToolExtension - tool registration', () => {
     await pi.triggerSessionStart();
 
     expect(pi.tools.map((t) => t.name)).toContain('web_fetch');
+  });
+
+  it('returns a content-free observation receipt for source retention mode', async () => {
+    mockLoadSettings.mockReturnValue({
+      fetch: {
+        mode: 'local_only',
+        provider: 'zai',
+        observation: { runId: 'run-1', retention: 'source_summary_only_v1' },
+      },
+      providers: { zai: { apiKey: 'configured' } },
+    });
+
+    const pi = createMockPi();
+    piWebToolExtension(pi as any);
+    await pi.triggerSessionStart();
+    const fetchTool = pi.tools.find((tool) => tool.name === 'web_fetch')!;
+    const result = (await fetchTool.execute!(
+      'call-1',
+      { url: 'https://example.com/private?token=secret', prompt: 'summarize' },
+      undefined,
+      undefined,
+      {},
+    )) as { details: Record<string, unknown> };
+
+    expect(result.details).toMatchObject({
+      version: 'source_observation_v1',
+      runId: 'run-1',
+      toolName: 'web_fetch',
+      requestedLocator: 'https://example.com/private',
+    });
+    expect(JSON.stringify(result.details)).not.toContain('secret');
   });
 
   it('registers web_fetch when fetch.summary is configured (no fetch.provider)', async () => {

--- a/packages/pi-web-access/src/__tests__/fetch.test.ts
+++ b/packages/pi-web-access/src/__tests__/fetch.test.ts
@@ -153,6 +153,28 @@ describe('webFetch', () => {
     expect(mockFetch.mock.calls[1]![0]).toBe('https://example.com/');
   });
 
+  it('uses only the local safe fetch path in local_only mode', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers([['content-type', 'text/html']]),
+      text: async () =>
+        '<html><head><title>Private Page</title></head><body>Authenticated content</body></html>',
+    });
+
+    const result = await webFetch(
+      { url: 'https://example.com/private?token=secret' },
+      {
+        fetch: { mode: 'local_only', provider: 'zai' },
+        providers: { zai: { apiKey: 'configured-but-forbidden' } },
+      },
+      publicLookup,
+    );
+
+    expect(result.title).toBe('Private Page');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch.mock.calls[0]![0]).toBe('https://example.com/private?token=secret');
+  });
+
   it('blocks loopback URLs before either fetch path runs', async () => {
     const { safeFetch } =
       await vi.importActual<typeof import('@amaster.ai/pi-shared')>('@amaster.ai/pi-shared');

--- a/packages/pi-web-access/src/config.ts
+++ b/packages/pi-web-access/src/config.ts
@@ -52,14 +52,32 @@ const DEFAULT_MODEL: Partial<Record<BuiltInProviderId, string>> = {
 // ─── Settings loading ────────────────────────────────────────────────────────
 
 export function loadWebToolSettings(cwd: string, projectTrusted = false): WebToolSettings {
+  const runtimeMode = process.env.PI_WEB_ACCESS_RUNTIME_FETCH_MODE;
+  const runtimeObservation = process.env.PI_WEB_ACCESS_RUNTIME_OBSERVATION;
+  if (runtimeObservation !== undefined && runtimeObservation !== 'required') {
+    throw new Error('PI_WEB_ACCESS_RUNTIME_OBSERVATION is invalid.');
+  }
+  const runtimeLocked = runtimeMode !== undefined || runtimeObservation === 'required';
+  let settings: WebToolSettings;
   try {
-    return loadPiSettings<WebToolSettings>(SETTINGS_KEY, {
+    settings = loadPiSettings<WebToolSettings>(SETTINGS_KEY, {
       cwd,
-      projectTrusted,
+      projectTrusted: runtimeLocked ? false : projectTrusted,
     });
   } catch {
-    return {};
+    settings = {};
   }
+
+  if (runtimeMode !== undefined) {
+    if (runtimeMode !== 'provider_jina_or_local' && runtimeMode !== 'local_only') {
+      throw new Error('PI_WEB_ACCESS_RUNTIME_FETCH_MODE is invalid.');
+    }
+    settings.fetch = { ...settings.fetch, mode: runtimeMode };
+  }
+  if (runtimeObservation === 'required' && !settings.fetch?.observation) {
+    throw new Error('A runtime web observation profile is required.');
+  }
+  return settings;
 }
 
 // ─── Provider resolution ─────────────────────────────────────────────────────

--- a/packages/pi-web-access/src/fetch.ts
+++ b/packages/pi-web-access/src/fetch.ts
@@ -97,6 +97,9 @@ export async function webFetch(
   lookup?: DnsLookup,
 ): Promise<FetchResponse> {
   const timeoutMs = settings.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (settings.fetch?.mode === 'local_only') {
+    return fetchLocal(params.url, timeoutMs, lookup);
+  }
   const resolved = resolveFetchProvider(settings);
   if (resolved) {
     if (lookup) await assertPublicHttpUrl(params.url, lookup);

--- a/packages/pi-web-access/src/index.ts
+++ b/packages/pi-web-access/src/index.ts
@@ -1,3 +1,4 @@
+import { createSourceObservationReceipt } from '@amaster.ai/pi-shared';
 import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
@@ -177,7 +178,19 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
           lines.push(content);
 
           const text = lines.join('\n');
-          return { content: [{ type: 'text' as const, text }], details: undefined };
+          const observation = settings.fetch?.observation;
+          const details = observation
+            ? createSourceObservationReceipt({
+                runId: observation.runId,
+                toolName: 'web_fetch',
+                requestedLocator: fetchParams.url,
+                finalLocator: result.url,
+                mediaType: 'text/markdown',
+                content: result.content,
+                truncated: false,
+              })
+            : undefined;
+          return { content: [{ type: 'text' as const, text }], details };
         },
       });
     }

--- a/packages/pi-web-access/src/types.ts
+++ b/packages/pi-web-access/src/types.ts
@@ -33,6 +33,11 @@ export interface SearchConfig {
 }
 
 export interface FetchConfig {
+  mode?: 'provider_jina_or_local' | 'local_only';
+  observation?: {
+    runId: string;
+    retention: 'source_summary_only_v1';
+  };
   provider?: BuiltInProviderId;
   summary?: SummaryModelConfig;
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-shared",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/shared/src/__tests__/source-observation.test.ts
+++ b/packages/shared/src/__tests__/source-observation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createSourceObservationReceipt } from '../source-observation.js';
+
+describe('createSourceObservationReceipt', () => {
+  it('returns content-free metadata and redacts locator credentials and query values', () => {
+    const receipt = createSourceObservationReceipt({
+      runId: 'run-1',
+      toolName: 'web_fetch',
+      requestedLocator: 'https://user:pass@example.com/private?token=secret#section',
+      finalLocator: 'https://example.com/private?session=other-secret',
+      mediaType: 'text/html',
+      content: 'sensitive source body',
+      truncated: false,
+      now: new Date('2026-08-05T10:00:00.000Z'),
+      observationId: 'observation-1',
+    });
+
+    expect(receipt).toEqual({
+      version: 'source_observation_v1',
+      observationId: 'observation-1',
+      runId: 'run-1',
+      toolName: 'web_fetch',
+      requestedLocator: 'https://example.com/private',
+      finalLocator: 'https://example.com/private',
+      capturedAt: '2026-08-05T10:00:00.000Z',
+      mediaType: 'text/html',
+      contentHash: 'sha256:30eb575e8e123670455e5235aa8c52f02f32dacc2430f408e09243a6b9809cec',
+      observedChars: 21,
+      observedBytes: 21,
+      truncated: false,
+    });
+    expect(JSON.stringify(receipt)).not.toContain('sensitive source body');
+    expect(JSON.stringify(receipt)).not.toContain('secret');
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -480,5 +480,12 @@ export {
   assertPublicHttpUrl,
   type DnsLookup,
   readResponseBytes,
+  resolvePublicHttpUrl,
   safeFetch,
 } from './network.js';
+export {
+  createSourceObservationReceipt,
+  type SourceObservationInput,
+  type SourceObservationReceiptV1,
+  sanitizeObservationLocator,
+} from './source-observation.js';

--- a/packages/shared/src/network.ts
+++ b/packages/shared/src/network.ts
@@ -92,7 +92,7 @@ function isPublicIp(address: string): boolean {
  * Parse an outbound URL once using Node's WHATWG parser and require every DNS
  * answer to be globally routable. Call this again for every redirect target.
  */
-async function resolvePublicHttpUrl(
+export async function resolvePublicHttpUrl(
   value: string | URL,
   lookup: DnsLookup = defaultLookup,
 ): Promise<{ url: URL; addresses: Array<{ address: string; family: number }> }> {

--- a/packages/shared/src/source-observation.ts
+++ b/packages/shared/src/source-observation.ts
@@ -1,0 +1,62 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+export type SourceObservationReceiptV1 = {
+  version: 'source_observation_v1';
+  observationId: string;
+  runId: string;
+  toolName: string;
+  requestedLocator: string;
+  finalLocator: string;
+  capturedAt: string;
+  mediaType: string | null;
+  contentHash: string;
+  observedChars: number | null;
+  observedBytes: number | null;
+  truncated: boolean;
+};
+
+export type SourceObservationInput = {
+  runId: string;
+  toolName: string;
+  requestedLocator: string;
+  finalLocator: string;
+  mediaType: string | null;
+  content: string | Uint8Array;
+  truncated: boolean;
+  observationId?: string;
+  now?: Date;
+};
+
+export function sanitizeObservationLocator(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, url.pathname === '/' ? '/' : '');
+  } catch {
+    return '[redacted]';
+  }
+}
+
+export function createSourceObservationReceipt(
+  input: SourceObservationInput,
+): SourceObservationReceiptV1 {
+  const bytes =
+    typeof input.content === 'string' ? Buffer.from(input.content, 'utf8') : input.content;
+  return {
+    version: 'source_observation_v1',
+    observationId: input.observationId ?? randomUUID(),
+    runId: input.runId,
+    toolName: input.toolName,
+    requestedLocator: sanitizeObservationLocator(input.requestedLocator),
+    finalLocator: sanitizeObservationLocator(input.finalLocator),
+    capturedAt: (input.now ?? new Date()).toISOString(),
+    mediaType: input.mediaType,
+    contentHash: `sha256:${createHash('sha256').update(bytes).digest('hex')}`,
+    observedChars: typeof input.content === 'string' ? input.content.length : null,
+    observedBytes: bytes.byteLength,
+    truncated: input.truncated,
+  };
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-storage",
-  "version": "0.1.2-beta.15",
+  "version": "0.1.2-beta.16",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,13 +51,16 @@ importers:
       chrome-devtools-mcp:
         specifier: ^1.6.0
         version: 1.6.0
+      puppeteer-core:
+        specifier: 25.3.0
+        version: 25.3.0
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -104,10 +107,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.14)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -142,13 +145,13 @@ importers:
     devDependencies:
       '@earendil-works/pi-agent-core':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       typebox:
         specifier: '*'
         version: 1.1.38
@@ -164,10 +167,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       typebox:
         specifier: '*'
         version: 1.1.38
@@ -202,13 +205,13 @@ importers:
     devDependencies:
       '@earendil-works/pi-agent-core':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@types/proper-lockfile':
         specifier: ^4.1.4
         version: 4.1.4
@@ -226,11 +229,11 @@ importers:
         version: link:../shared
       mem0ai:
         specifier: 3.0.7
-        version: 3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0))(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.0)(socks@2.8.9))(ollama@0.5.18)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.0))(ws@8.20.1)
+        version: 3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.21.2)(zod@3.25.76))(ws@8.21.2))(@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0))(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.0)(socks@2.8.9))(ollama@0.5.18)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.0))(ws@8.21.2)
     devDependencies:
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.2)(zod@3.25.76)
       typebox:
         specifier: '*'
         version: 1.1.38
@@ -367,10 +370,10 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.10
-        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+        version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6
@@ -640,24 +643,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.15':
     resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.15':
     resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.15':
     resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.15':
     resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
@@ -1065,89 +1072,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1229,30 +1252,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
@@ -1374,6 +1402,19 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
+  '@puppeteer/browsers@3.0.6':
+    resolution: {integrity: sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      proxy-agent: '>=8.0.1'
+      yauzl: ^2.10.0 || ^3.4.0
+    peerDependenciesMeta:
+      proxy-agent:
+        optional: true
+      yauzl:
+        optional: true
+
   '@qdrant/js-client-rest@1.18.0':
     resolution: {integrity: sha512-/0dqX5uV9chC1DnYSnU4gNMrDqse/pt6hHg3Rqqpl5isH7xl1xSNvffjzBoxycDD79luWn7Ho6Rh/61sOs5DNw==}
     engines: {node: '>=18.17.0', pnpm: '>=8'}
@@ -1455,36 +1496,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
@@ -1546,66 +1593,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -1853,6 +1913,10 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1860,6 +1924,10 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -2007,6 +2075,12 @@ packages:
       '@toon-format/toon':
         optional: true
 
+  chromium-bidi@16.0.1:
+    resolution: {integrity: sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==}
+    engines: {node: '>=20.19.0 <22.0.0 || >=22.12.0'}
+    peerDependencies:
+      devtools-protocol: '*'
+
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -2016,6 +2090,10 @@ packages:
 
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   cloudflare@4.5.0:
     resolution: {integrity: sha512-fPcbPKx4zF45jBvQ0z7PCdgejVAPBBCZxwqk1k7krQNfpM07Cfj97/Q6wBzvYqlWXx/zt1S9+m8vnfCe06umbQ==}
@@ -2154,6 +2232,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  devtools-protocol@0.0.1638949:
+    resolution: {integrity: sha512-mXwg4Fqnv0WR4iuAT/gYUmctNkjILwXFHyZ+m7Ty1dfr0ezZt2U3gnrrJTfRobJTHoXf+IbuFvFITzLrLFjwJA==}
+
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2192,6 +2273,9 @@ packages:
   efrt@2.7.0:
     resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
     engines: {node: '>=12.0.0'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -2236,6 +2320,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2399,6 +2487,10 @@ packages:
   gcp-metadata@8.1.2:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
@@ -2691,24 +2783,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2869,11 +2965,18 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  modern-tar@0.7.7:
+    resolution: {integrity: sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==}
+    engines: {node: '>=18.0.0'}
 
   mongodb-connection-string-url@7.0.1:
     resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
@@ -3253,6 +3356,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  puppeteer-core@25.3.0:
+    resolution: {integrity: sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==}
+    engines: {node: '>=22.12.0'}
+
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
@@ -3457,8 +3564,20 @@ packages:
   stream-browserify@3.0.0:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -3580,6 +3699,9 @@ packages:
 
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -3721,6 +3843,9 @@ packages:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
 
+  webdriver-bidi-protocol@0.4.2:
+    resolution: {integrity: sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -3752,11 +3877,27 @@ packages:
     resolution: {integrity: sha512-zVyFsvE+mq9MCmwXUWHIcpfbrHHClZWZiVOzKSxNJruIcFn2RbY55zkhiAMMxM8zCVSmtNiViq8FsAZSFpMYag==}
     engines: {node: '>=0.6.0'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3779,10 +3920,22 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -4190,7 +4343,7 @@ snapshots:
 
   '@earendil-works/pi-agent-core@0.80.10':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.80.10
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -4202,9 +4355,9 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-agent-core@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)':
+  '@earendil-works/pi-agent-core@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.2)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.2)(zod@3.25.76)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -4230,7 +4383,21 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)':
+  '@earendil-works/pi-agent-core@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.80.10':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -4240,7 +4407,28 @@ snapshots:
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.20.1)(zod@3.25.76)
+      openai: 6.26.0(ws@8.20.1)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.2)(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.2)(zod@3.25.76)
       partial-json: 0.1.7
       typebox: 1.1.38
     transitivePeerDependencies:
@@ -4272,10 +4460,31 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-ai@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.2)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-coding-agent@0.80.10':
     dependencies:
       '@earendil-works/pi-agent-core': 0.80.10
-      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.80.10
       '@earendil-works/pi-tui': 0.80.10
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -4302,10 +4511,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)':
+  '@earendil-works/pi-coding-agent@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.2)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)
-      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.20.1)(zod@3.25.76)
+      '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.2)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))(ws@8.21.2)(zod@3.25.76)
       '@earendil-works/pi-tui': 0.80.10
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -4336,6 +4545,36 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.10
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.10(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.2)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.80.10
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -4698,12 +4937,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)':
+  '@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.21.2)(zod@3.25.76))(ws@8.21.2)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.6(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
+      langsmith: 0.7.6(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.21.2)(zod@3.25.76))(ws@8.21.2)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.4.3
@@ -4911,6 +5150,11 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@puppeteer/browsers@3.0.6':
+    dependencies:
+      modern-tar: 0.7.7
+      yargs: 18.1.0
 
   '@qdrant/js-client-rest@1.18.0(typescript@5.9.3)':
     dependencies:
@@ -5333,11 +5577,15 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -5489,6 +5737,12 @@ snapshots:
 
   chrome-devtools-mcp@1.6.0: {}
 
+  chromium-bidi@16.0.1(devtools-protocol@0.0.1638949):
+    dependencies:
+      devtools-protocol: 0.0.1638949
+      mitt: 3.0.1
+      zod: 3.25.76
+
   ci-info@3.9.0: {}
 
   citty@0.1.6:
@@ -5496,6 +5750,12 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.2: {}
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   cloudflare@4.5.0:
     dependencies:
@@ -5604,6 +5864,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  devtools-protocol@0.0.1638949: {}
+
   diff-sequences@29.6.3: {}
 
   diff@8.0.4: {}
@@ -5645,6 +5907,8 @@ snapshots:
       fast-check: 3.23.2
 
   efrt@2.7.0: {}
+
+  emoji-regex@10.6.0: {}
 
   empathic@2.0.0: {}
 
@@ -5730,6 +5994,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -5919,6 +6185,8 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.6.0: {}
 
@@ -6199,13 +6467,13 @@ snapshots:
     dependencies:
       langfuse-core: 3.38.20
 
-  langsmith@0.7.6(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1):
+  langsmith@0.7.6(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.21.2)(zod@3.25.76))(ws@8.21.2):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      openai: 6.26.0(ws@8.20.1)(zod@3.25.76)
-      ws: 8.20.1
+      openai: 6.26.0(ws@8.21.2)(zod@3.25.76)
+      ws: 8.21.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -6306,14 +6574,14 @@ snapshots:
 
   media-typer@1.1.0: {}
 
-  mem0ai@3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1))(@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0))(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.0)(socks@2.8.9))(ollama@0.5.18)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.0))(ws@8.20.1):
+  mem0ai@3.0.7(@anthropic-ai/sdk@0.91.1(zod@3.25.76))(@azure/identity@4.13.1)(@azure/search-documents@12.2.0)(@cloudflare/workers-types@4.20260611.1)(@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)))(@langchain/core@1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.21.2)(zod@3.25.76))(ws@8.21.2))(@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0))(@qdrant/js-client-rest@1.18.0(typescript@5.9.3))(@supabase/supabase-js@2.108.1)(@types/jest@29.5.14)(@types/pg@8.11.0)(better-sqlite3@12.10.0)(cloudflare@4.5.0)(compromise@14.15.1)(groq-sdk@0.3.0)(natural@8.1.1(@opentelemetry/api@1.9.0)(socks@2.8.9))(ollama@0.5.18)(pg@8.21.0)(redis@5.12.1(@opentelemetry/api@1.9.0))(ws@8.21.2):
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@azure/identity': 4.13.1
       '@azure/search-documents': 12.2.0
       '@cloudflare/workers-types': 4.20260611.1
       '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76))
-      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.20.1)(zod@3.25.76))(ws@8.20.1)
+      '@langchain/core': 1.1.48(@opentelemetry/api@1.9.0)(openai@6.26.0(ws@8.21.2)(zod@3.25.76))(ws@8.21.2)
       '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
       '@qdrant/js-client-rest': 1.18.0(typescript@5.9.3)
       '@supabase/supabase-js': 2.108.1
@@ -6326,7 +6594,7 @@ snapshots:
       groq-sdk: 0.3.0
       natural: 8.1.1(@opentelemetry/api@1.9.0)(socks@2.8.9)
       ollama: 0.5.18
-      openai: 4.104.0(ws@8.20.1)(zod@3.25.76)
+      openai: 4.104.0(ws@8.21.2)(zod@3.25.76)
       pg: 8.21.0
       redis: 5.12.1(@opentelemetry/api@1.9.0)
       uuid: 9.0.1
@@ -6370,6 +6638,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mitt@3.0.1: {}
+
   mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
@@ -6378,6 +6648,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
+
+  modern-tar@0.7.7: {}
 
   mongodb-connection-string-url@7.0.1:
     dependencies:
@@ -6523,7 +6795,7 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  openai@4.104.0(ws@8.20.1)(zod@3.25.76):
+  openai@4.104.0(ws@8.21.2)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -6533,19 +6805,24 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.2
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
-  openai@6.26.0(ws@8.20.1)(zod@3.25.76):
-    optionalDependencies:
-      ws: 8.20.1
-      zod: 3.25.76
-
   openai@6.26.0(ws@8.20.1)(zod@4.4.3):
     optionalDependencies:
       ws: 8.20.1
+      zod: 4.4.3
+
+  openai@6.26.0(ws@8.21.2)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.21.2
+      zod: 3.25.76
+
+  openai@6.26.0(ws@8.21.2)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.2
       zod: 4.4.3
 
   p-finally@1.0.0: {}
@@ -6759,6 +7036,20 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  puppeteer-core@25.3.0:
+    dependencies:
+      '@puppeteer/browsers': 3.0.6
+      chromium-bidi: 16.0.1(devtools-protocol@0.0.1638949)
+      devtools-protocol: 0.0.1638949
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.2
+      ws: 8.21.2
+    transitivePeerDependencies:
+      - bufferutil
+      - proxy-agent
+      - utf-8-validate
+      - yauzl
 
   pure-rand@6.1.0: {}
 
@@ -7042,9 +7333,24 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1: {}
 
@@ -7174,6 +7480,8 @@ snapshots:
 
   typebox@1.1.38: {}
 
+  typed-query-selector@2.12.2: {}
+
   typedarray@0.0.6: {}
 
   typescript@5.9.3: {}
@@ -7290,6 +7598,8 @@ snapshots:
 
   web-streams-polyfill@4.0.0-beta.3: {}
 
+  webdriver-bidi-protocol@0.4.2: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
@@ -7317,9 +7627,17 @@ snapshots:
 
   wordnet-db@3.1.14: {}
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.20.1: {}
+
+  ws@8.21.2: {}
 
   wsl-utils@0.1.0:
     dependencies:
@@ -7329,7 +7647,20 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
   yaml@2.9.0: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

Adds the Pi-owned capability foundation for AMaster Source Acquisition without introducing another Connector reader: hard local-only web fetches, content-free observation receipts, and a runtime-managed browser read policy that enforces exact navigation and public-or-same-origin subresources before transmission. The monorepo version is prepared as `0.1.2-beta.16`; this PR does not publish packages.

This is PR 1 of the release train: Pi packages must merge and be published before the AMaster Connector and Pi Agent runtime can pin the exact artifacts.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 120 files / 1,693 tests
- `pnpm build`
- `git diff --check`

The first combined gate attempt exposed only a local Node ABI mismatch for `better-sqlite3`; after rebuilding that isolated native dependency under the repository-required Node 24 runtime, the same lint/typecheck/test/build hooks passed. One unrelated ffmpeg test timed out once under load and passed on immediate focused rerun plus the subsequent full test run.

## Checklist

- [x] I read the applicable `AGENTS.md` files for every changed path.
- [x] This PR contains no unrelated refactors or generated files.
- [x] Behavior and configuration changes include relevant tests, or the reason they do not is explained above.
- [x] Public tool, command, setting, or user-facing behavior changes include the corresponding documentation and prompt guidance.

Release-train blockers: no npm publication, downstream AMaster merge, Pi Agent image build, deployment, or live Source retry is part of this PR.
