### PR TITLE
ci: publish Pi review results as one fresh review per run

### DIFF
--- a/.github/scripts/publish-pi-review.mjs
+++ b/.github/scripts/publish-pi-review.mjs
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -7,7 +7,6 @@ const severities = ['P0', 'P1', 'P2', 'P3'];
 const axes = new Set(['Standards', 'Spec']);
 const sides = new Set(['LEFT', 'RIGHT']);
 const summaryMarker = '<!-- pi-code-review -->';
-const inlineMarkerPrefix = '<!-- pi-code-review-inline:';
 
 function stripJsonFence(value) {
   return value
@@ -305,8 +304,9 @@ export async function preparePiReview({ github, context, core, contextPath, work
     'Each structured output must have this exact shape:',
     '{"axis":"Standards|Spec","findings":[{"severity":"P0|P1|P2|P3","axis":"Standards|Spec","path":"repo/relative/file",',
     '"line":123,"side":"RIGHT|LEFT","title":"short defect","body":"evidence and impact","fix":"smallest fix"}]}.',
-    'Write every title, body, and fix in concise English. Keep the title short, the body to one or two',
-    'sentences, and the suggested fix to one sentence.',
+    'Write every title, body, and fix in concise English, regardless of the language used in the PR',
+    'title, body, or linked issues. Keep the title short, the body to one or two sentences, and the',
+    'suggested fix to one sentence.',
     'Copy path, side, and line exactly from this list of Allowed changed-line locations. If no listed',
     'location fits a finding, omit that finding.',
     'Every finding must be an actionable defect on an added RIGHT or removed LEFT line in the supplied diff.',
@@ -358,16 +358,8 @@ function sanitizeComment(value) {
 }
 
 function inlineBody(finding) {
-  const fingerprint = createHash('sha256')
-    .update([finding.axis, finding.path, finding.side, finding.line].join('\0'))
-    .digest('hex')
-    .slice(0, 24);
-  const marker = `${inlineMarkerPrefix}${fingerprint} -->`;
   const fix = finding.fix ? `\n\n**Suggested fix:** ${sanitizeComment(finding.fix)}` : '';
-  return {
-    marker,
-    body: `${marker}\n**[${finding.severity}] ${sanitizeComment(finding.title)}** · ${finding.axis}\n\n${sanitizeComment(finding.body)}${fix}`,
-  };
+  return `**[${finding.severity}] ${sanitizeComment(finding.title)}** · ${finding.axis}\n\n${sanitizeComment(finding.body)}${fix}`;
 }
 
 function sentence(value) {
@@ -421,84 +413,33 @@ export async function publishPiReview({ github, context, core, reviewPath }) {
     per_page: 100,
   });
   const validLocations = commentableLines(files);
-  const inlineFindings = findings.filter((finding) => {
-    if (validLocations.has(`${finding.path}\0${finding.side}\0${finding.line}`)) return true;
-    core.warning(`Summary-only Pi review finding outside changed lines: ${finding.path}:${finding.line} (${finding.side})`);
-    return false;
-  });
+  const comments = [];
+  for (const finding of findings) {
+    if (validLocations.has(`${finding.path}\0${finding.side}\0${finding.line}`)) {
+      comments.push({ path: finding.path, line: finding.line, side: finding.side, body: inlineBody(finding) });
+    } else {
+      core.warning(`Summary-only Pi review finding outside changed lines: ${finding.path}:${finding.line} (${finding.side})`);
+    }
+  }
 
-  const previousInline = await github.paginate(github.rest.pulls.listReviewComments, {
+  // Every run posts exactly one brand-new review: the body carries the full
+  // summary and the comments carry all current inline findings. Previous
+  // reviews and their comments are never read, updated, or deleted.
+  await github.rest.pulls.createReview({
     owner,
     repo,
     pull_number: pullNumber,
-    per_page: 100,
-  });
-  const newComments = [];
-  const retainedCommentIds = new Set();
-  for (const finding of inlineFindings) {
-    const formatted = inlineBody(finding);
-    const previous = previousInline.find(
-      (comment) =>
-        !retainedCommentIds.has(comment.id) &&
-        comment.user?.type === 'Bot' &&
-        comment.body?.includes(formatted.marker),
-    );
-    if (previous) {
-      retainedCommentIds.add(previous.id);
-      if (previous.body !== formatted.body) {
-        await github.rest.pulls.updateReviewComment({ owner, repo, comment_id: previous.id, body: formatted.body });
-      }
-    } else {
-      newComments.push({
-        path: finding.path,
-        line: finding.line,
-        side: finding.side,
-        body: formatted.body,
-      });
-    }
-  }
-  if (newComments.length) {
-    await github.rest.pulls.createReview({
+    commit_id: pull.head.sha,
+    event: 'COMMENT',
+    body: summaryBody(findings, {
       owner,
       repo,
-      pull_number: pullNumber,
-      commit_id: pull.head.sha,
-      event: 'COMMENT',
-      body: 'Pi code review inline findings.',
-      comments: newComments,
-    });
-  }
-  for (const comment of previousInline) {
-    if (
-      comment.user?.type === 'Bot' &&
-      comment.body?.includes(inlineMarkerPrefix) &&
-      !retainedCommentIds.has(comment.id)
-    ) {
-      await github.rest.pulls.deleteReviewComment({ owner, repo, comment_id: comment.id });
-    }
-  }
-
-  const body = summaryBody(findings, {
-    owner,
-    repo,
-    headSha: pull.head.sha,
-    baseSha: pull.base?.sha,
-    serverUrl: process.env.GITHUB_SERVER_URL,
+      headSha: pull.head.sha,
+      baseSha: pull.base?.sha,
+      serverUrl: process.env.GITHUB_SERVER_URL,
+    }),
+    comments,
   });
-  const previousSummaries = await github.paginate(github.rest.issues.listComments, {
-    owner,
-    repo,
-    issue_number: pullNumber,
-    per_page: 100,
-  });
-  const previousSummary = previousSummaries.find(
-    (comment) => comment.user?.type === 'Bot' && comment.body?.includes(summaryMarker),
-  );
-  if (previousSummary) {
-    await github.rest.issues.updateComment({ owner, repo, comment_id: previousSummary.id, body });
-  } else {
-    await github.rest.issues.createComment({ owner, repo, issue_number: pullNumber, body });
-  }
 
   const blocking = findings.filter((finding) => finding.severity === 'P0' || finding.severity === 'P1');
   if (blocking.length) core.setFailed(`Pi review found ${blocking.length} blocking P0/P1 finding(s)`);

--- a/.github/scripts/publish-pi-review.test.mjs
+++ b/.github/scripts/publish-pi-review.test.mjs
@@ -196,51 +196,22 @@ test('prepares the review prompt outside the workflow', async () => {
   assert.doesNotMatch(workflow, /const diffResponse =/);
 });
 
-test('publishes inline findings, keeps the summary concise, and fails only for P0/P1', async () => {
+test('posts one new review per run with the full summary and current findings', async () => {
   const directory = await mkdtemp(path.join(tmpdir(), 'pi-review-'));
   const reviewPath = path.join(directory, 'review.json');
   await writeFile(reviewPath, JSON.stringify({ findings: [finding] }));
   const calls = [];
-  const reviewComments = [];
-  const issueComments = [];
   const listFiles = () => {};
-  const listReviewComments = () => {};
-  const listComments = () => {};
   const github = {
     paginate: async (method) => {
       if (method === listFiles) return [{ filename: 'src/example.ts', patch: '@@ -10 +10,2 @@\n old\n+new' }];
-      if (method === listReviewComments) return [...reviewComments];
-      if (method === listComments) return [...issueComments];
       throw new Error('Unexpected pagination method');
     },
     rest: {
       pulls: {
         listFiles,
-        listReviewComments,
-        updateReviewComment: async (args) => {
-          calls.push(['updateReviewComment', args]);
-          reviewComments.find((comment) => comment.id === args.comment_id).body = args.body;
-        },
-        deleteReviewComment: async (args) => {
-          calls.push(['deleteReviewComment', args]);
-          reviewComments.splice(reviewComments.findIndex((comment) => comment.id === args.comment_id), 1);
-        },
         createReview: async (args) => {
           calls.push(['createReview', args]);
-          for (const comment of args.comments) {
-            reviewComments.push({ id: reviewComments.length + 1, user: { type: 'Bot' }, body: comment.body });
-          }
-        },
-      },
-      issues: {
-        listComments,
-        updateComment: async (args) => {
-          calls.push(['updateComment', args]);
-          issueComments.find((comment) => comment.id === args.comment_id).body = args.body;
-        },
-        createComment: async (args) => {
-          calls.push(['createComment', args]);
-          issueComments.push({ id: issueComments.length + 1, user: { type: 'Bot' }, body: args.body });
         },
       },
     },
@@ -251,59 +222,68 @@ test('publishes inline findings, keeps the summary concise, and fails only for P
     setFailed: (message) => failures.push(message),
     warning: (message) => warnings.push(message),
   };
+  const publish = (sha) => publishPiReview({
+    github,
+    context: {
+      repo: { owner: 'owner', repo: 'repo' },
+      payload: { pull_request: { number: 123, head: { sha } } },
+    },
+    core,
+    reviewPath,
+  });
   try {
-    await publishPiReview({
-      github,
-      context: {
-        repo: { owner: 'owner', repo: 'repo' },
-        payload: { pull_request: { number: 123, head: { sha: 'abc123' } } },
-      },
-      core,
-      reviewPath,
-    });
+    await publish('abc123');
     await writeFile(reviewPath, JSON.stringify({
       findings: [
         { ...finding, severity: 'P2', title: 'Cleanup can be skipped' },
         { ...finding, severity: 'P0', line: 12, title: 'Invalid model location' },
       ],
     }));
-    await publishPiReview({
-      github,
-      context: {
-        repo: { owner: 'owner', repo: 'repo' },
-        payload: { pull_request: { number: 123, head: { sha: 'def456' } } },
-      },
-      core,
-      reviewPath,
-    });
+    await publish('def456');
     await writeFile(reviewPath, JSON.stringify({ findings: [] }));
-    await publishPiReview({
-      github,
-      context: {
-        repo: { owner: 'owner', repo: 'repo' },
-        payload: { pull_request: { number: 123, head: { sha: 'def456' } } },
-      },
-      core,
-      reviewPath,
-    });
+    await publish('def456');
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 
+  // Every run creates exactly one brand-new review. History is never touched:
+  // the mock has no review-comment list/update/delete or issue-comment APIs,
+  // so any such call would throw.
   const reviews = calls.filter(([name]) => name === 'createReview');
-  assert.equal(reviews.length, 1);
-  assert.ok(reviews[0][1].body);
-  assert.equal(calls.filter(([name]) => name === 'updateReviewComment').length, 1);
-  assert.equal(calls.filter(([name]) => name === 'deleteReviewComment').length, 1);
-  assert.equal(calls.filter(([name]) => name === 'createComment').length, 1);
-  assert.equal(calls.filter(([name]) => name === 'updateComment').length, 2);
-  assert.equal(reviewComments.length, 0);
+  assert.equal(reviews.length, 3);
+  const [first, second, third] = reviews.map(([, args]) => args);
+
+  assert.equal(first.commit_id, 'abc123');
+  assert.equal(first.event, 'COMMENT');
+  assert.equal(first.comments.length, 1);
+  assert.equal(first.comments[0].path, 'src/example.ts');
+  assert.equal(first.comments[0].line, 11);
+  assert.equal(first.comments[0].side, 'RIGHT');
+  assert.match(first.comments[0].body, /\*\*\[P1\] Unchecked failure path\*\* · Standards/);
+  assert.match(first.body, /^<!-- pi-code-review -->\n## Standards/);
+  assert.match(first.body, /Unchecked failure path/);
+  assert.match(first.body, /\*\*Summary:\*\* Standards: 1 finding, highest P1; Spec: no findings\./);
+
+  assert.equal(second.commit_id, 'def456');
+  assert.equal(second.comments.length, 1);
+  assert.match(second.comments[0].body, /\*\*\[P2\] Cleanup can be skipped\*\*/);
+  // Findings outside changed lines stay summary-only: no inline comment, but
+  // still present in the review body.
+  assert.match(second.body, /Invalid model location/);
+  assert.match(second.body, /\*\*Summary:\*\* Standards: 2 findings, highest P0; Spec: no findings\./);
+
+  // A findings-free run still posts its review, with no inline comments.
+  assert.equal(third.comments.length, 0);
+  assert.equal(
+    third.body,
+    '<!-- pi-code-review -->\n## Standards\n\nNo actionable findings.\n\n## Spec\n\nNo actionable findings.\n\n**Summary:** Standards: no findings; Spec: no findings.',
+  );
+
   assert.deepEqual(failures, [
     'Pi review found 1 blocking P0/P1 finding(s)',
     'Pi review found 1 blocking P0/P1 finding(s)',
   ]);
   assert.deepEqual(warnings, ['Summary-only Pi review finding outside changed lines: src/example.ts:12 (RIGHT)']);
-  assert.match(calls.find(([name]) => name === 'updateComment')[1].body, /Invalid model location/);
   const summary = summaryBody(
     [
       finding,

--- a/.github/workflows/pi-review.yml
+++ b/.github/workflows/pi-review.yml
@@ -11,7 +11,7 @@ concurrency:
 
 permissions:
   contents: read
-  issues: write
+  issues: read
   pull-requests: write
 
 env:
@@ -144,6 +144,7 @@ jobs:
           extensions, credentials, network access, or repository changes. Return only concrete findings with
           severity, file and changed-line references, evidence, and the smallest viable fix. Never include
           praise, compliant code, process narration, or speculative concerns.
+          Write all output in English, regardless of the language used in the pull request or linked issues.
           Finish by calling the runtime-provided structured_output tool with the requested findings object.
           Do not call or mention any other tool.
           AGENT


### PR DESCRIPTION
## Summary

- **One comment, not two**: the full review summary (Standards/Spec sections + totals) now goes into the PR review body, with inline findings attached as that same review's per-line comments. The separate issue-comment summary is gone.
- **A new comment every run**: each run posts exactly one brand-new review pinned to the current head SHA — including zero-findings runs (empty comments, full summary body). Previous reviews and their inline comments are never read, updated, or deleted; the fingerprint/update/stale-delete machinery (~50 lines) is removed.
- **English output hardened**: both the sub-agent system prompt (pi-review.yml) and the trusted review instructions (publish-pi-review.mjs) now require English regardless of the PR/linked-issue language.
- Permissions tightened: `issues: write` → `issues: read` (no more issue comments; linked-issue reads still work).

## Test plan

- `publish-pi-review.test.mjs` rewritten: exactly one new review per run with full summary body; findings outside the diff appear only in the body with a warning; zero-findings runs still post a review; the mock exposes no history APIs, so any regression to history-managing calls throws.
- Pre-commit hook ran the full gate: biome, typecheck, 1677 vitest tests, build — all green.