### PR TITLE
fix(pi-computer-use): sanitize non-standard integer schema formats

### DIFF
--- a/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
+++ b/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
@@ -108,6 +108,52 @@ describe('sanitizeSchemaFormats', () => {
     sanitizeSchemaFormats(schema);
     expect(schema).toEqual({ properties: { samples: { format: 'uint64' } } });
   });
+
+  it('sanitizes properties named like schema keywords', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        default: { type: 'integer', format: 'uint64' },
+        enum: { type: 'integer', format: 'uint32' },
+      },
+      $defs: { const: { format: 'uint64' } },
+    };
+
+    const sanitized = sanitizeSchemaFormats(schema);
+    expect(sanitized.properties.default).toEqual({ type: 'integer', minimum: 0 });
+    expect(sanitized.properties.enum).toEqual({
+      type: 'integer',
+      minimum: 0,
+      maximum: 4_294_967_295,
+    });
+    expect(sanitized.$defs.const).toEqual({ type: 'integer', minimum: 0 });
+  });
+
+  it('still leaves keyword-position instance data untouched', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        count: { type: 'integer', format: 'uint64', default: { format: 'uint64' } },
+      },
+    };
+
+    const sanitized = sanitizeSchemaFormats(schema);
+    expect(sanitized.properties.count).toEqual({
+      type: 'integer',
+      minimum: 0,
+      default: { format: 'uint64' },
+    });
+  });
+
+  it('leaves integer formats on non-integer types untouched', () => {
+    const schema = { type: 'string', format: 'uint32' };
+    expect(sanitizeSchemaFormats(schema)).toEqual(schema);
+  });
+
+  it('ignores format values matching Object.prototype keys', () => {
+    const schema = { type: 'integer', format: 'constructor' };
+    expect(sanitizeSchemaFormats(schema)).toEqual(schema);
+  });
 });
 
 describe('SanitizingJsonSchemaValidator', () => {

--- a/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
+++ b/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { resolveBundledTarget, resolveDriverLayout, resolveUnixSocketPath } from '../mcp-client.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  resolveBundledTarget,
+  resolveDriverLayout,
+  resolveUnixSocketPath,
+  SanitizingJsonSchemaValidator,
+  sanitizeSchemaFormats,
+} from '../mcp-client.js';
 
 describe('CuaDriverClient', () => {
   it.each([
@@ -39,5 +45,91 @@ describe('CuaDriverClient', () => {
       '/tmp/pi-cua-123-deadbeef.sock',
     );
     expect(Buffer.byteLength(resolveUnixSocketPath('/tmp', '123-deadbeef'))).toBeLessThan(91);
+  });
+});
+
+describe('sanitizeSchemaFormats', () => {
+  it('rewrites uint64 format to standard integer constraints', () => {
+    expect(sanitizeSchemaFormats({ type: 'integer', format: 'uint64' })).toEqual({
+      type: 'integer',
+      minimum: 0,
+    });
+  });
+
+  it('rewrites uint32 with an explicit maximum', () => {
+    expect(sanitizeSchemaFormats({ format: 'uint32' })).toEqual({
+      type: 'integer',
+      minimum: 0,
+      maximum: 4_294_967_295,
+    });
+  });
+
+  it('rewrites nested schemas in the verify_state shape', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        elapsed_ms: { type: 'integer', format: 'uint64' },
+        predicates: {
+          type: 'array',
+          items: { type: 'object', properties: { index: { format: 'uint64' } } },
+        },
+        delivery: { type: 'object', properties: { delivered_count: { format: 'uint32' } } },
+      },
+    };
+
+    const sanitized = sanitizeSchemaFormats(schema);
+    expect(sanitized.properties.elapsed_ms).toEqual({ type: 'integer', minimum: 0 });
+    expect(sanitized.properties.predicates.items.properties.index).toEqual({
+      type: 'integer',
+      minimum: 0,
+    });
+    expect(sanitized.properties.delivery.properties.delivered_count).toEqual({
+      type: 'integer',
+      minimum: 0,
+      maximum: 4_294_967_295,
+    });
+  });
+
+  it('leaves standard formats untouched', () => {
+    const schema = { type: 'string', format: 'date-time' };
+    expect(sanitizeSchemaFormats(schema)).toEqual(schema);
+  });
+
+  it('does not override existing bounds', () => {
+    expect(sanitizeSchemaFormats({ format: 'uint32', minimum: 1, maximum: 10 })).toEqual({
+      type: 'integer',
+      minimum: 1,
+      maximum: 10,
+    });
+  });
+
+  it('does not mutate the input schema', () => {
+    const schema = { properties: { samples: { format: 'uint64' } } };
+    sanitizeSchemaFormats(schema);
+    expect(schema).toEqual({ properties: { samples: { format: 'uint64' } } });
+  });
+});
+
+describe('SanitizingJsonSchemaValidator', () => {
+  it('compiles non-standard formats without ajv warnings and keeps validating', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const validate = new SanitizingJsonSchemaValidator().getValidator({
+        type: 'object',
+        properties: { elapsed_ms: { type: 'integer', format: 'uint64' } },
+      });
+
+      expect(warn).not.toHaveBeenCalled();
+      expect(error).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalled();
+      expect(validate({ elapsed_ms: 5 }).valid).toBe(true);
+      expect(validate({ elapsed_ms: -1 }).valid).toBe(false);
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+      log.mockRestore();
+    }
   });
 });

--- a/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
+++ b/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
@@ -1,11 +1,19 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  CuaDriverClient,
   resolveBundledTarget,
   resolveDriverLayout,
   resolveUnixSocketPath,
   SanitizingJsonSchemaValidator,
   sanitizeSchemaFormats,
 } from '../mcp-client.js';
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({ Client: vi.fn() }));
+vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: vi.fn(),
+  getDefaultEnvironment: () => ({}),
+}));
 
 describe('CuaDriverClient', () => {
   it.each([
@@ -46,21 +54,45 @@ describe('CuaDriverClient', () => {
     );
     expect(Buffer.byteLength(resolveUnixSocketPath('/tmp', '123-deadbeef'))).toBeLessThan(91);
   });
+
+  it('constructs the MCP Client with the sanitizing schema validator', async () => {
+    // biome-ignore lint/complexity/useArrowFunction: arrow functions are not constructible; the mock must survive `new Client(...)`.
+    vi.mocked(Client).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      } as unknown as Client;
+    });
+    const client = new CuaDriverClient({ mode: 'path', binaryPath: '/opt/cua-driver' });
+    // Isolate the wiring from the daemon process and the real binary.
+    const internals = client as unknown as {
+      ensureExecutable: () => void;
+      ensureDaemon: () => Promise<string>;
+    };
+    internals.ensureExecutable = () => {};
+    internals.ensureDaemon = () => Promise.resolve('/tmp/pi-cua-test.sock');
+
+    await client.connect();
+
+    const options = vi.mocked(Client).mock.calls[0]?.[1];
+    expect(options?.jsonSchemaValidator).toBeInstanceOf(SanitizingJsonSchemaValidator);
+  });
 });
 
 describe('sanitizeSchemaFormats', () => {
-  it('rewrites uint64 format to standard integer constraints', () => {
-    expect(sanitizeSchemaFormats({ type: 'integer', format: 'uint64' })).toEqual({
+  it.each([
+    ['int8', { minimum: -128, maximum: 127 }],
+    ['int16', { minimum: -32_768, maximum: 32_767 }],
+    ['int32', { minimum: -2_147_483_648, maximum: 2_147_483_647 }],
+    ['int64', {}],
+    ['uint8', { minimum: 0, maximum: 255 }],
+    ['uint16', { minimum: 0, maximum: 65_535 }],
+    ['uint32', { minimum: 0, maximum: 4_294_967_295 }],
+    ['uint64', { minimum: 0 }],
+  ])('rewrites %s to its standard integer constraints', (format, bounds) => {
+    expect(sanitizeSchemaFormats({ type: 'integer', format })).toEqual({
       type: 'integer',
-      minimum: 0,
-    });
-  });
-
-  it('rewrites uint32 with an explicit maximum', () => {
-    expect(sanitizeSchemaFormats({ format: 'uint32' })).toEqual({
-      type: 'integer',
-      minimum: 0,
-      maximum: 4_294_967_295,
+      ...bounds,
     });
   });
 
@@ -153,6 +185,37 @@ describe('sanitizeSchemaFormats', () => {
   it('ignores format values matching Object.prototype keys', () => {
     const schema = { type: 'integer', format: 'constructor' };
     expect(sanitizeSchemaFormats(schema)).toEqual(schema);
+  });
+
+  it('keeps an own __proto__ key instead of replacing the copy prototype', () => {
+    // JSON.parse creates an own __proto__ property; a plain-object copy would
+    // hit the inherited setter, dropping the key and swapping the prototype.
+    const schema = JSON.parse(
+      '{"properties":{"__proto__":{"type":"integer","format":"uint64"}},"format":"uint64"}',
+    );
+
+    const sanitized = sanitizeSchemaFormats(schema);
+    expect(Object.keys(sanitized.properties)).toEqual(['__proto__']);
+    expect(Object.getPrototypeOf(sanitized.properties)).toBeNull();
+    expect(sanitized.properties.__proto__).toEqual({ type: 'integer', minimum: 0 });
+    expect(sanitized.minimum).toBe(0);
+  });
+
+  it('traverses combinator and applicator keywords', () => {
+    const schema = {
+      allOf: [{ type: 'integer', format: 'uint64' }],
+      additionalProperties: { type: 'integer', format: 'uint32' },
+      patternProperties: { '^x-': { format: 'uint64' } },
+    };
+
+    const sanitized = sanitizeSchemaFormats(schema);
+    expect(sanitized.allOf[0]).toEqual({ type: 'integer', minimum: 0 });
+    expect(sanitized.additionalProperties).toEqual({
+      type: 'integer',
+      minimum: 0,
+      maximum: 4_294_967_295,
+    });
+    expect(sanitized.patternProperties['^x-']).toEqual({ type: 'integer', minimum: 0 });
   });
 });
 

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -11,6 +11,12 @@ import {
   StdioClientTransport,
 } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import type {
+  JsonSchemaType,
+  JsonSchemaValidator,
+  jsonSchemaValidator,
+} from '@modelcontextprotocol/sdk/validation/index.js';
 import type { ComputerUseConfig } from './config.js';
 import type { McpToolResult } from './tool-result.js';
 
@@ -136,6 +142,67 @@ export type ConnectionState =
   | 'failed'
   | 'closing';
 
+/** schemars emits these non-standard `format` values for Rust integer types; ajv warns on each. */
+const INTEGER_FORMAT_BOUNDS: Record<string, { minimum?: number; maximum?: number }> = {
+  int8: { minimum: -128, maximum: 127 },
+  int16: { minimum: -32_768, maximum: 32_767 },
+  int32: { minimum: -2_147_483_648, maximum: 2_147_483_647 },
+  int64: {},
+  uint8: { minimum: 0, maximum: 255 },
+  uint16: { minimum: 0, maximum: 65_535 },
+  uint32: { minimum: 0, maximum: 4_294_967_295 },
+  uint64: { minimum: 0 },
+};
+
+/** Schema keys whose values are instance data, not subschemas — never rewrite inside them. */
+const NON_SCHEMA_KEYS = new Set(['const', 'default', 'enum', 'examples']);
+
+/**
+ * Returns a copy of the schema with schemars' non-standard integer `format`
+ * annotations ("uint64", ...) replaced by standard constraints ajv can enforce.
+ * The input schema is not modified.
+ */
+export function sanitizeSchemaFormats<T>(schema: T): T {
+  return sanitizeSchemaNode(schema) as T;
+}
+
+function sanitizeSchemaNode(node: unknown): unknown {
+  if (Array.isArray(node)) return node.map(sanitizeSchemaNode);
+  if (node === null || typeof node !== 'object') return node;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(node)) {
+    result[key] = NON_SCHEMA_KEYS.has(key) ? value : sanitizeSchemaNode(value);
+  }
+
+  const format = result.format;
+  if (typeof format !== 'string') return result;
+  const bounds = INTEGER_FORMAT_BOUNDS[format];
+  if (!bounds) return result;
+
+  delete result.format;
+  result.type ??= 'integer';
+  if (bounds.minimum !== undefined && result.minimum === undefined) {
+    result.minimum = bounds.minimum;
+  }
+  if (bounds.maximum !== undefined && result.maximum === undefined) {
+    result.maximum = bounds.maximum;
+  }
+  return result;
+}
+
+/**
+ * Wraps the SDK's default ajv validator, sanitizing non-standard integer formats
+ * before compilation so ajv stays silent and the integer bounds stay enforced.
+ */
+export class SanitizingJsonSchemaValidator implements jsonSchemaValidator {
+  private readonly inner = new AjvJsonSchemaValidator();
+
+  getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
+    return this.inner.getValidator<T>(sanitizeSchemaFormats(schema));
+  }
+}
+
 /** Owns the Cua Driver daemon and its stdio MCP proxy as one adapter. */
 export class CuaDriverClient {
   private client: Client | null = null;
@@ -196,7 +263,10 @@ export class CuaDriverClient {
         env,
         stderr: 'pipe',
       });
-      client = new Client({ name: 'pi-computer-use', version: '0.2.0' }, { capabilities: {} });
+      client = new Client(
+        { name: 'pi-computer-use', version: '0.2.0' },
+        { capabilities: {}, jsonSchemaValidator: new SanitizingJsonSchemaValidator() },
+      );
       this.client = client;
 
       transport.onerror = (error: Error) => {

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -183,7 +183,10 @@ function sanitizeSchemaNode(node: unknown): unknown {
   if (Array.isArray(node)) return node.map(sanitizeSchemaNode);
   if (node === null || typeof node !== 'object') return node;
 
-  const result: Record<string, unknown> = {};
+  // Null-prototype copy: a schema from the wire may carry an own "__proto__"
+  // key (JSON.parse creates one), and assigning it on a plain object would hit
+  // the inherited setter — dropping the key and replacing the copy's prototype.
+  const result: Record<string, unknown> = Object.create(null);
   for (const [key, value] of Object.entries(node)) {
     result[key] = sanitizeSchemaValue(key, value);
   }
@@ -214,7 +217,7 @@ function sanitizeSchemaNode(node: unknown): unknown {
 function sanitizeSchemaValue(key: string, value: unknown): unknown {
   if (NON_SCHEMA_KEYS.has(key)) return value;
   if (PROPERTY_MAP_KEYS.has(key) && isRecord(value)) {
-    const map: Record<string, unknown> = {};
+    const map: Record<string, unknown> = Object.create(null);
     for (const [name, subschema] of Object.entries(value)) {
       map[name] = sanitizeSchemaNode(subschema);
     }

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -158,6 +158,19 @@ const INTEGER_FORMAT_BOUNDS: Record<string, { minimum?: number; maximum?: number
 const NON_SCHEMA_KEYS = new Set(['const', 'default', 'enum', 'examples']);
 
 /**
+ * Keywords whose values are maps of property name → subschema. Inside these maps the
+ * keys are property names, not schema keywords, so NON_SCHEMA_KEYS must not apply:
+ * a property literally named "default" or "enum" still needs its subschema sanitized.
+ */
+const PROPERTY_MAP_KEYS = new Set([
+  'properties',
+  'patternProperties',
+  'dependentSchemas',
+  '$defs',
+  'definitions',
+]);
+
+/**
  * Returns a copy of the schema with schemars' non-standard integer `format`
  * annotations ("uint64", ...) replaced by standard constraints ajv can enforce.
  * The input schema is not modified.
@@ -172,13 +185,20 @@ function sanitizeSchemaNode(node: unknown): unknown {
 
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(node)) {
-    result[key] = NON_SCHEMA_KEYS.has(key) ? value : sanitizeSchemaNode(value);
+    result[key] = sanitizeSchemaValue(key, value);
   }
 
   const format = result.format;
   if (typeof format !== 'string') return result;
-  const bounds = INTEGER_FORMAT_BOUNDS[format];
+  // Own-property check: a plain table lookup would match Object.prototype keys
+  // ("constructor", "toString", ...) on hostile or malformed schemas.
+  const bounds = Object.hasOwn(INTEGER_FORMAT_BOUNDS, format)
+    ? INTEGER_FORMAT_BOUNDS[format]
+    : undefined;
   if (!bounds) return result;
+  // Only rewrite integer schemas; injecting numeric bounds into a node that
+  // declares another type would misannotate it.
+  if (!isIntegerType(result.type)) return result;
 
   delete result.format;
   result.type ??= 'integer';
@@ -189,6 +209,28 @@ function sanitizeSchemaNode(node: unknown): unknown {
     result.maximum = bounds.maximum;
   }
   return result;
+}
+
+function sanitizeSchemaValue(key: string, value: unknown): unknown {
+  if (NON_SCHEMA_KEYS.has(key)) return value;
+  if (PROPERTY_MAP_KEYS.has(key) && isRecord(value)) {
+    const map: Record<string, unknown> = {};
+    for (const [name, subschema] of Object.entries(value)) {
+      map[name] = sanitizeSchemaNode(subschema);
+    }
+    return map;
+  }
+  return sanitizeSchemaNode(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isIntegerType(type: unknown): boolean {
+  if (type === undefined) return true;
+  if (Array.isArray(type)) return type.includes('integer');
+  return type === 'integer';
 }
 
 /**


### PR DESCRIPTION
## Summary

Client-side fix for #119. cua-driver v0.17.0 emits schemars' non-standard JSON Schema `format` values (`"uint64"`, `"uint32"`, ...) in MCP tool **output schemas**. The MCP SDK's default ajv instance runs with `validateFormats: true`, so every schema compile logs `unknown format "uint64" ignored…` warnings.

## Root cause

- These `format` values are not part of the JSON Schema spec (draft-07 / 2019-09 / 2020-12); ajv cannot recognize them, so it warns and ignores them.
- cua-driver is an external Rust binary whose source is **not in this repo**, so the issue's suggested driver-side fix is not actionable here. This PR applies a client-side mitigation instead.

## Changes (`packages/pi-computer-use/src/mcp-client.ts`)

1. **`sanitizeSchemaFormats`** — recursively rewrites the 8 schemars integer formats (`int8`–`int64`, `uint8`–`uint64`) into standard `minimum`/`maximum` constraints. Does not mutate the input; skips instance-data keys (`const` / `enum` / `default` / `examples`).
2. **`SanitizingJsonSchemaValidator`** — wraps the SDK's `AjvJsonSchemaValidator`, sanitizing the schema before compilation.
3. Injected via the `Client`'s `jsonSchemaValidator` option — the exact validator used to compile `tool.outputSchema` at callTool time (SDK `client/index.js`). This covers 100% of the warning source: output schemas never reach pi-coding-agent, and input schemas carry none of these formats.

## Design trade-offs

- **From "ignore" to "enforce"**: ajv previously ignored the unknown format (permissive); it now enforces the integer bounds. The bounds match the real Rust types, so compliant driver output is unaffected.
- **`uint64` / `int64` get no upper bound**: uint64's max exceeds `Number.MAX_SAFE_INTEGER`, so an upper bound would cause false rejections from precision loss. uint64 keeps only `minimum: 0` (int64 gets none).
- **All 8 formats covered** (not just the 2 in the issue): same root cause (schemars generates these for Rust integer types), prevents recurrence on driver upgrades, and costs only one small constant table.

## Verification

- `pnpm build` ✅ / `pnpm test` (59 passed) ✅ / `pnpm typecheck` ✅ / `biome check` ✅
- New unit tests: uint64/uint32 rewriting, nested `verify_state` shapes, existing bounds preserved, input not mutated, no warnings emitted, and bounds enforced.
- Control experiment: the default `AjvJsonSchemaValidator` **does** warn on the issue's real schema; `SanitizingJsonSchemaValidator` produces **zero** warnings while accepting valid values and rejecting negative / out-of-range ones.

## Relationship to the issue

Refs #119. This is a **client-side mitigation** — it does not change the driver itself. Whether to close #119 depends on whether the team also wants to track an upstream driver fix; if "Pi no longer warns" is sufficient, it can be closed after merge.
