### PR TITLE
ci: make the Pi review run observable (combine logging + execution trace)

### DIFF
--- a/.github/scripts/pi-review-trace.mjs
+++ b/.github/scripts/pi-review-trace.mjs
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+// Renders a compact, human-readable timeline of a Pi `--mode json` event stream
+// so a review run's execution is visible in the CI log. The full event stream is
+// far too large for the log (streaming thinking deltas, large tool args), so this
+// prints lifecycle and per-reviewer outcomes only; the raw stream is uploaded as
+// an artifact for full-fidelity inspection.
+
+const MAX_VALUE = 200;
+const MAX_RENDERED = 2000;
+
+function truncate(value, max = MAX_VALUE) {
+  const text = typeof value === 'string' ? value : JSON.stringify(value);
+  if (text == null) return '';
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/** Parses a JSONL event stream into events, skipping blank or malformed lines. */
+export function parseTraceEvents(text) {
+  return text
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+/** One summary line per child reviewer inside a parallel subagent result. */
+function describeSubagentChildren(event) {
+  const results = event?.result?.details?.results;
+  if (!Array.isArray(results)) return [];
+  return results.map((child) => {
+    const axis = child?.structuredOutput?.axis ?? 'reviewer';
+    if (child?.exitCode !== 0) {
+      const reason = child?.error ? ` — ${truncate(child.error, 160)}` : '';
+      return `${axis}: FAILED (exit ${child?.exitCode ?? '?'})${reason}`;
+    }
+    const findings = Array.isArray(child?.structuredOutput?.findings) ? child.structuredOutput.findings.length : 0;
+    return `${axis}: exit 0, ${findings} finding(s)`;
+  });
+}
+
+/**
+ * Renders events to log lines. Message content and streaming deltas are skipped
+ * by design; agent/turn lifecycle and tool (subagent) outcomes are shown.
+ */
+export function renderPiReviewTrace(events) {
+  const lines = [];
+  let turn = 0;
+  let toolCalls = 0;
+  let toolErrors = 0;
+  let assistantMessages = 0;
+
+  const push = (line) => {
+    if (lines.length < MAX_RENDERED) lines.push(line);
+  };
+
+  for (const event of events) {
+    switch (event?.type) {
+      case 'agent_start':
+        push('▶ agent start');
+        break;
+      case 'turn_start':
+        turn += 1;
+        push(`├─ turn ${turn} start`);
+        break;
+      case 'turn_end': {
+        const results = Array.isArray(event?.toolResults) ? event.toolResults.length : 0;
+        push(`├─ turn ${turn} end (${results} tool result(s))`);
+        break;
+      }
+      case 'message_end':
+        assistantMessages += 1;
+        break;
+      case 'tool_execution_start':
+        toolCalls += 1;
+        push(`│  ▶ ${event?.toolName ?? 'tool'}`);
+        break;
+      case 'tool_execution_end': {
+        if (event?.isError) toolErrors += 1;
+        push(`│  ${event?.isError ? '✗' : '✓'} ${event?.toolName ?? 'tool'}${event?.isError ? ' (error)' : ''}`);
+        if (event?.toolName === 'subagent') {
+          for (const child of describeSubagentChildren(event)) push(`│     ${child}`);
+        }
+        break;
+      }
+      case 'agent_end': {
+        const messages = Array.isArray(event?.messages) ? event.messages.length : 0;
+        push(`■ agent end (${messages} message(s))`);
+        break;
+      }
+      default:
+        // message_start / message_update / tool_execution_update: streaming, skipped.
+        break;
+    }
+  }
+
+  const summary =
+    `Pi review execution trace: ${events.length} event(s), ${turn} turn(s), ` +
+    `${toolCalls} tool call(s), ${assistantMessages} assistant message(s), ${toolErrors} tool error(s)`;
+  if (lines.length >= MAX_RENDERED) lines.push(`… trace truncated after ${MAX_RENDERED} lines …`);
+  return [summary, ...lines];
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  const file = process.argv[2];
+  let text = '';
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch {
+    console.log(`Pi review execution trace: no event stream captured at ${file ?? '(unset path)'}`);
+    process.exit(0);
+  }
+  const events = parseTraceEvents(text);
+  if (events.length === 0) {
+    console.log('Pi review execution trace: event stream is empty');
+    process.exit(0);
+  }
+  for (const line of renderPiReviewTrace(events)) console.log(line);
+}

--- a/.github/scripts/pi-review-trace.test.mjs
+++ b/.github/scripts/pi-review-trace.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'vitest';
+import { parseTraceEvents, renderPiReviewTrace } from './pi-review-trace.mjs';
+
+const subagentEnd = (results, isError = false) => ({
+  type: 'tool_execution_end',
+  toolCallId: 'call-1',
+  toolName: 'subagent',
+  isError,
+  result: { details: { mode: 'parallel', results } },
+});
+
+test('renders lifecycle and per-reviewer outcomes, skipping message content', () => {
+  const events = [
+    { type: 'agent_start' },
+    { type: 'turn_start' },
+    { type: 'message_start', message: { role: 'assistant' } },
+    { type: 'message_update', message: { role: 'assistant' }, assistantMessageEvent: { delta: 'thinking…' } },
+    { type: 'message_end', message: { role: 'assistant' } },
+    { type: 'tool_execution_start', toolCallId: 'call-1', toolName: 'subagent', args: { tasks: [{}, {}] } },
+    subagentEnd([
+      { exitCode: 0, structuredOutput: { axis: 'Standards', findings: [] } },
+      { exitCode: 1, error: 'spec reviewer blew up' },
+    ]),
+    { type: 'tool_execution_start', toolCallId: 'call-2', toolName: 'subagent_wait', args: {} },
+    { type: 'tool_execution_end', toolCallId: 'call-2', toolName: 'subagent_wait', isError: false, result: {} },
+    { type: 'turn_end', message: { role: 'assistant' }, toolResults: [{}, {}] },
+    { type: 'agent_end', messages: [{}, {}, {}] },
+  ];
+
+  const output = renderPiReviewTrace(events).join('\n');
+
+  // Headline summary.
+  assert.match(output, /Pi review execution trace: 11 event\(s\), 1 turn\(s\), 2 tool call\(s\), 1 assistant message\(s\), 0 tool error\(s\)/);
+  // Lifecycle and tool events.
+  assert.match(output, /▶ agent start/);
+  assert.match(output, /├─ turn 1 start/);
+  assert.match(output, /├─ turn 1 end \(2 tool result\(s\)\)/);
+  assert.match(output, /│  ▶ subagent/);
+  assert.match(output, /│  ✓ subagent/);
+  assert.match(output, /│  ✓ subagent_wait/);
+  assert.match(output, /■ agent end \(3 message\(s\)\)/);
+  // Per-reviewer outcomes from the parallel subagent result.
+  assert.match(output, /Standards: exit 0, 0 finding\(s\)/);
+  assert.match(output, /reviewer: FAILED \(exit 1\) — spec reviewer blew up/);
+  // Streaming message content is not rendered.
+  assert.doesNotMatch(output, /thinking…/);
+  assert.doesNotMatch(output, /message_start/);
+});
+
+test('flags a failed subagent tool call as an error', () => {
+  const output = renderPiReviewTrace([
+    { type: 'tool_execution_start', toolCallId: 'c', toolName: 'subagent', args: {} },
+    subagentEnd([], true),
+  ]).join('\n');
+  assert.match(output, /1 tool error\(s\)/);
+  assert.match(output, /✗ subagent \(error\)/);
+});
+
+test('parseTraceEvents skips blank and malformed lines', () => {
+  const events = parseTraceEvents([
+    '{"type":"agent_start"}',
+    '',
+    '   ',
+    'not json',
+    '{"type":"agent_end","messages":[]}',
+  ].join('\n'));
+  assert.deepEqual(events.map((event) => event.type), ['agent_start', 'agent_end']);
+});
+
+test('renders an empty stream as just the zero summary', () => {
+  assert.deepEqual(renderPiReviewTrace([]), [
+    'Pi review execution trace: 0 event(s), 0 turn(s), 0 tool call(s), 0 assistant message(s), 0 tool error(s)',
+  ]);
+});
+
+test('workflow captures the full event stream and renders the trace', async () => {
+  const workflow = await readFile(new URL('../workflows/pi-review.yml', import.meta.url), 'utf8');
+  // The run step tees the full event stream before filtering it into the transcript.
+  assert.match(workflow, /tee "\$PI_REVIEW_FULL"/);
+  assert.match(workflow, /Print Pi execution trace/);
+  assert.match(workflow, /node \.github\/scripts\/pi-review-trace\.mjs "\$PI_REVIEW_FULL"/);
+  // Full-fidelity evidence is uploaded even when the run fails.
+  assert.match(workflow, /Upload Pi review execution artifacts/);
+  assert.match(workflow, /pi-review-full\.jsonl/);
+  assert.match(workflow, /pi-review-stderr\.log/);
+});

--- a/.github/scripts/publish-pi-review.mjs
+++ b/.github/scripts/publish-pi-review.mjs
@@ -113,7 +113,7 @@ function reviewOutputSchema(axis) {
   };
 }
 
-export async function combinePiReviewTranscript({ transcriptPath, reviewPath }) {
+export async function combinePiReviewTranscript({ transcriptPath, reviewPath, core }) {
   const events = (await readFile(transcriptPath, 'utf8'))
     .split('\n')
     .filter((line) => line.trim())
@@ -129,6 +129,7 @@ export async function combinePiReviewTranscript({ transcriptPath, reviewPath }) 
     event?.toolName === 'subagent' &&
     event?.result?.details?.mode === 'parallel',
   );
+  core.info(`Pi review transcript: ${completedRuns.length} completed parallel subagent run(s)`);
   if (completedRuns.length < 1 || completedRuns.length > 10) {
     throw new Error(`Pi review transcript contained ${completedRuns.length} completed parallel subagent runs; expected 1 to 10`);
   }
@@ -166,12 +167,25 @@ export async function combinePiReviewTranscript({ transcriptPath, reviewPath }) 
       }
     }
   }
+
+  // Surface what was combined and what was silently dropped, so a reviewer that
+  // failed is visible in the log instead of reading as a clean axis.
+  for (const failure of failures) core.warning(`Pi review discarded reviewer output: ${failure}`);
+  for (const axis of axes) {
+    if (findingsByAxis.has(axis)) {
+      core.info(`Pi review ${axis} reviewer: ${findingsByAxis.get(axis).length} finding(s)`);
+    } else {
+      core.warning(`Pi review ${axis} reviewer produced no usable result; that axis contributes no findings`);
+    }
+  }
+
   if (!findingsByAxis.has('Standards')) {
     throw new Error(`Pi review returned no valid Standards result${failures.length ? `: ${failures.at(-1)}` : ''}`);
   }
   const findings = [...findingsByAxis.get('Standards'), ...(findingsByAxis.get('Spec') ?? [])];
   if (findings.length > 20) throw new Error('Pi review returned more than 20 combined findings');
   await writeFile(reviewPath, `${JSON.stringify({ findings })}\n`, { mode: 0o600 });
+  core.info(`Pi review combined ${findings.length} total finding(s)`);
 }
 
 export function commentableLines(files) {
@@ -442,6 +456,10 @@ export async function publishPiReview({ github, context, core, reviewPath }) {
   });
 
   const blocking = findings.filter((finding) => finding.severity === 'P0' || finding.severity === 'P1');
+  core.info(
+    `Pi review published ${findings.length} finding(s): ${comments.length} inline, ` +
+    `${findings.length - comments.length} summary-only; blocking P0/P1: ${blocking.length}`,
+  );
   if (blocking.length) core.setFailed(`Pi review found ${blocking.length} blocking P0/P1 finding(s)`);
   return { findings, blocking };
 }

--- a/.github/scripts/publish-pi-review.test.mjs
+++ b/.github/scripts/publish-pi-review.test.mjs
@@ -29,6 +29,9 @@ test('combines schema-validated axis outputs from the Pi JSON transcript', async
   const transcriptPath = path.join(directory, 'pi.jsonl');
   const reviewPath = path.join(directory, 'review.json');
   const specFinding = { ...finding, severity: 'P2', axis: 'Spec', title: 'Documented fallback is missing' };
+  const infos = [];
+  const warnings = [];
+  const core = { info: (m) => infos.push(m), warning: (m) => warnings.push(m) };
   try {
     await writeFile(transcriptPath, [
       JSON.stringify({ type: 'tool_execution_start', toolName: 'subagent' }),
@@ -46,8 +49,15 @@ test('combines schema-validated axis outputs from the Pi JSON transcript', async
         },
       }),
     ].join('\n'));
-    await combinePiReviewTranscript({ transcriptPath, reviewPath });
+    await combinePiReviewTranscript({ transcriptPath, reviewPath, core });
     assert.deepEqual(JSON.parse(await readFile(reviewPath, 'utf8')), { findings: [finding, specFinding] });
+    assert.deepEqual(infos, [
+      'Pi review transcript: 1 completed parallel subagent run(s)',
+      'Pi review Standards reviewer: 1 finding(s)',
+      'Pi review Spec reviewer: 1 finding(s)',
+      'Pi review combined 2 total finding(s)',
+    ]);
+    assert.deepEqual(warnings, []);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -57,6 +67,9 @@ test('accepts a Standards-only run when the skill finds no specification', async
   const directory = await mkdtemp(path.join(tmpdir(), 'pi-review-no-spec-'));
   const transcriptPath = path.join(directory, 'pi.jsonl');
   const reviewPath = path.join(directory, 'review.json');
+  const infos = [];
+  const warnings = [];
+  const core = { info: (m) => infos.push(m), warning: (m) => warnings.push(m) };
   try {
     await writeFile(transcriptPath, JSON.stringify({
       type: 'tool_execution_end',
@@ -68,8 +81,17 @@ test('accepts a Standards-only run when the skill finds no specification', async
         },
       },
     }));
-    await combinePiReviewTranscript({ transcriptPath, reviewPath });
+    await combinePiReviewTranscript({ transcriptPath, reviewPath, core });
     assert.deepEqual(JSON.parse(await readFile(reviewPath, 'utf8')), { findings: [finding] });
+    // A missing axis is tolerated but must be visible, not silent.
+    assert.deepEqual(infos, [
+      'Pi review transcript: 1 completed parallel subagent run(s)',
+      'Pi review Standards reviewer: 1 finding(s)',
+      'Pi review combined 1 total finding(s)',
+    ]);
+    assert.deepEqual(warnings, [
+      'Pi review Spec reviewer produced no usable result; that axis contributes no findings',
+    ]);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -80,6 +102,9 @@ test('combines successful structured outputs across coordinator recovery calls',
   const transcriptPath = path.join(directory, 'pi.jsonl');
   const reviewPath = path.join(directory, 'review.json');
   const specFinding = { ...finding, severity: 'P2', axis: 'Spec', title: 'Documented fallback is missing' };
+  const infos = [];
+  const warnings = [];
+  const core = { info: (m) => infos.push(m), warning: (m) => warnings.push(m) };
   const event = (results) => JSON.stringify({
     type: 'tool_execution_end',
     toolName: 'subagent',
@@ -91,8 +116,16 @@ test('combines successful structured outputs across coordinator recovery calls',
       event([{ exitCode: 0, structuredOutput: { axis: 'Standards', findings: [finding] } }]),
       event([{ exitCode: 0, structuredOutput: { axis: 'Spec', findings: [specFinding] } }]),
     ].join('\n'));
-    await combinePiReviewTranscript({ transcriptPath, reviewPath });
+    await combinePiReviewTranscript({ transcriptPath, reviewPath, core });
     assert.deepEqual(JSON.parse(await readFile(reviewPath, 'utf8')), { findings: [finding, specFinding] });
+    // The failed first attempt is surfaced as a warning, not swallowed.
+    assert.deepEqual(warnings, ['Pi review discarded reviewer output: first attempt failed']);
+    assert.deepEqual(infos, [
+      'Pi review transcript: 3 completed parallel subagent run(s)',
+      'Pi review Standards reviewer: 1 finding(s)',
+      'Pi review Spec reviewer: 1 finding(s)',
+      'Pi review combined 2 total finding(s)',
+    ]);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -188,7 +221,7 @@ test('prepares the review prompt outside the workflow', async () => {
   const workflow = await readFile(new URL('../workflows/pi-review.yml', import.meta.url), 'utf8');
   assert.match(workflow, /preparePiReview\(\{ github, context, core/);
   assert.match(workflow, /PI_REVIEW_TRANSCRIPT/);
-  assert.match(workflow, /combinePiReviewTranscript/);
+  assert.match(workflow, /combinePiReviewTranscript\(\{[^}]*\bcore\b/);
   assert.match(workflow, /--mode json/);
   assert.match(workflow, /> "\$PI_REVIEW_TRANSCRIPT"/);
   assert.match(workflow, /acceptanceRole: read-only/);
@@ -218,9 +251,11 @@ test('posts one new review per run with the full summary and current findings', 
   };
   const failures = [];
   const warnings = [];
+  const infos = [];
   const core = {
     setFailed: (message) => failures.push(message),
     warning: (message) => warnings.push(message),
+    info: (message) => infos.push(message),
   };
   const publish = (sha) => publishPiReview({
     github,
@@ -284,6 +319,11 @@ test('posts one new review per run with the full summary and current findings', 
     'Pi review found 1 blocking P0/P1 finding(s)',
   ]);
   assert.deepEqual(warnings, ['Summary-only Pi review finding outside changed lines: src/example.ts:12 (RIGHT)']);
+  assert.deepEqual(infos, [
+    'Pi review published 1 finding(s): 1 inline, 0 summary-only; blocking P0/P1: 1',
+    'Pi review published 2 finding(s): 1 inline, 1 summary-only; blocking P0/P1: 1',
+    'Pi review published 0 finding(s): 0 inline, 0 summary-only; blocking P0/P1: 0',
+  ]);
   const summary = summaryBody(
     [
       finding,

--- a/.github/workflows/pi-review.yml
+++ b/.github/workflows/pi-review.yml
@@ -211,6 +211,7 @@ jobs:
             await combinePiReviewTranscript({
               transcriptPath: process.env.PI_REVIEW_TRANSCRIPT,
               reviewPath: process.env.PI_REVIEW_OUTPUT,
+              core,
             });
 
       - name: Publish review comment

--- a/.github/workflows/pi-review.yml
+++ b/.github/workflows/pi-review.yml
@@ -54,6 +54,7 @@ jobs:
           echo "PI_CODING_AGENT_DIR=$RUNNER_TEMP/pi-review-agent" >> "$GITHUB_ENV"
           echo "PI_REVIEW_CONTEXT=$RUNNER_TEMP/pi-review-context.md" >> "$GITHUB_ENV"
           echo "PI_REVIEW_TRANSCRIPT=$RUNNER_TEMP/pi-review-transcript.jsonl" >> "$GITHUB_ENV"
+          echo "PI_REVIEW_FULL=$RUNNER_TEMP/pi-review-full.jsonl" >> "$GITHUB_ENV"
           echo "PI_REVIEW_OUTPUT=$RUNNER_TEMP/pi-review-output.json" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/pi-review-agent/agents" "$RUNNER_TEMP/pi-review-skills"
 
@@ -188,6 +189,7 @@ jobs:
             -p \
             < "$PI_REVIEW_CONTEXT" \
             2> "$RUNNER_TEMP/pi-review-stderr.log" \
+            | tee "$PI_REVIEW_FULL" \
             | grep -F '"type":"tool_execution_end"' > "$PI_REVIEW_TRANSCRIPT"
           rc=$?
           set -e
@@ -200,6 +202,12 @@ jobs:
             echo '::error::Pi review returned no JSON transcript'
             exit 1
           fi
+
+      # Always render the captured event stream, even if the run failed, so a
+      # clean review and a silent reviewer failure are distinguishable in the log.
+      - name: Print Pi execution trace
+        if: always()
+        run: node .github/scripts/pi-review-trace.mjs "$PI_REVIEW_FULL"
 
       - name: Combine structured axis review outputs
         uses: actions/github-script@v7
@@ -224,3 +232,17 @@ jobs:
             const scriptUrl = pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/publish-pi-review.mjs`);
             const { publishPiReview } = await import(scriptUrl.href);
             await publishPiReview({ github, context, core, reviewPath: process.env.REVIEW_PATH });
+
+      # Full-fidelity evidence for download: the complete event stream (including
+      # streaming thinking and large tool args), Pi stderr, and the combined review.
+      - name: Upload Pi review execution artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pi-review-execution-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            ${{ runner.temp }}/pi-review-full.jsonl
+            ${{ runner.temp }}/pi-review-stderr.log
+            ${{ runner.temp }}/pi-review-output.json


### PR DESCRIPTION
## Summary

Two related observability improvements to the Pi code-review workflow. This was prompted by a PR whose published review read "No actionable findings" on both axes, with no way to tell from the job log whether the reviewers genuinely found nothing or had failed silently.

## 1. Combine-step logging

`combinePiReviewTranscript` ran silently, and a failed axis reviewer (e.g. Spec) was swallowed by the `?? []` fallback and rendered as **"No actionable findings."** — indistinguishable from a reviewer that ran and legitimately found nothing.

- `combinePiReviewTranscript({ ..., core })` now logs the completed run count, each axis's finding count, every discarded reviewer output (warning, with its reason), and any axis that produced no usable result (warning).
- `publishPiReview` logs a one-line summary (total / inline / summary-only findings, blocking P0/P1 count).
- Semantics unchanged: a Standards-only run is still tolerated; missing Standards still fails the step.

## 2. Execution trace + full event-stream artifacts

The "Run Pi code review" step was a black box: the `--mode json` event stream was grepped down to just `tool_execution_end` for the transcript and everything else was discarded; Pi's stderr only surfaced on hard failure.

- Run step tees the full event stream to `pi-review-full.jsonl` (transcript/combine path unchanged).
- New `pi-review-trace.mjs` renders a compact timeline into the job log: agent/turn lifecycle, each tool call, and per-reviewer outcome (axis, exit code, finding count, or failure reason). Streaming thinking deltas and large tool args are intentionally not printed; long values truncated, lines capped. Tolerates a missing/empty stream.
- New "Print Pi execution trace" step (`if: always()`) prints the trace even when the run fails.
- New "Upload Pi review execution artifacts" step (`if: always()`, 14-day retention) uploads the full event stream, Pi stderr, and the combined review JSON.

## Example trace (a clean run)

```
Pi review execution trace: 9 event(s), 1 turn(s), 1 tool call(s), 1 assistant message(s), 0 tool error(s)
▶ agent start
├─ turn 1 start
│  ▶ subagent
│  ✓ subagent
│     Standards: exit 0, 0 finding(s)
│     Spec: exit 0, 0 finding(s)
├─ turn 1 end (1 tool result(s))
■ agent end (3 message(s))
```

A silent reviewer failure now shows plainly, e.g. `Spec: FAILED (exit 1) — <reason>`, instead of reading as "No actionable findings."

## Verification

- `pnpm vitest run .github/scripts/` — 18 passed: combine-logging assertions, the trace renderer (lifecycle + per-reviewer outcomes, message content skipped, failed-tool flagging, malformed-line tolerance), and workflow-wiring assertions (combine receives `core`; run step tees the full stream; trace + artifact steps present).
- Workflow YAML parses; step order is Run → Print trace → Combine → Publish → Upload.
