### PR TITLE
ci: accept any subagent orchestration mode in Pi review combine

### DIFF
--- a/.github/scripts/pi-review-trace.mjs
+++ b/.github/scripts/pi-review-trace.mjs
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
 import { pathToFileURL } from 'node:url';
 
 // Renders a compact, human-readable timeline of a Pi `--mode json` event stream
@@ -47,11 +48,15 @@ function describeSubagentChildren(event) {
 }
 
 /**
- * Renders events to log lines. Message content and streaming deltas are skipped
- * by design; agent/turn lifecycle and tool (subagent) outcomes are shown.
+ * Incremental trace renderer. The full event stream can reach gigabytes
+ * (thinking deltas), so main() streams events through this collector instead
+ * of materializing the file as one string. Message content and streaming
+ * deltas are skipped by design; agent/turn lifecycle and tool (subagent)
+ * outcomes are shown.
  */
-export function renderPiReviewTrace(events) {
+export function createTraceCollector() {
   const lines = [];
+  let total = 0;
   let turn = 0;
   let toolCalls = 0;
   let toolErrors = 0;
@@ -61,67 +66,89 @@ export function renderPiReviewTrace(events) {
     if (lines.length < MAX_RENDERED) lines.push(line);
   };
 
-  for (const event of events) {
-    switch (event?.type) {
-      case 'agent_start':
-        push('▶ agent start');
-        break;
-      case 'turn_start':
-        turn += 1;
-        push(`├─ turn ${turn} start`);
-        break;
-      case 'turn_end': {
-        const results = Array.isArray(event?.toolResults) ? event.toolResults.length : 0;
-        push(`├─ turn ${turn} end (${results} tool result(s))`);
-        break;
-      }
-      case 'message_end':
-        assistantMessages += 1;
-        break;
-      case 'tool_execution_start':
-        toolCalls += 1;
-        push(`│  ▶ ${event?.toolName ?? 'tool'}`);
-        break;
-      case 'tool_execution_end': {
-        if (event?.isError) toolErrors += 1;
-        push(`│  ${event?.isError ? '✗' : '✓'} ${event?.toolName ?? 'tool'}${event?.isError ? ' (error)' : ''}`);
-        if (event?.toolName === 'subagent') {
-          for (const child of describeSubagentChildren(event)) push(`│     ${child}`);
+  return {
+    add(event) {
+      total += 1;
+      switch (event?.type) {
+        case 'agent_start':
+          push('▶ agent start');
+          break;
+        case 'turn_start':
+          turn += 1;
+          push(`├─ turn ${turn} start`);
+          break;
+        case 'turn_end': {
+          const results = Array.isArray(event?.toolResults) ? event.toolResults.length : 0;
+          push(`├─ turn ${turn} end (${results} tool result(s))`);
+          break;
         }
-        break;
+        case 'message_end':
+          assistantMessages += 1;
+          break;
+        case 'tool_execution_start':
+          toolCalls += 1;
+          push(`│  ▶ ${event?.toolName ?? 'tool'}`);
+          break;
+        case 'tool_execution_end': {
+          if (event?.isError) toolErrors += 1;
+          push(`│  ${event?.isError ? '✗' : '✓'} ${event?.toolName ?? 'tool'}${event?.isError ? ' (error)' : ''}`);
+          if (event?.toolName === 'subagent') {
+            for (const child of describeSubagentChildren(event)) push(`│     ${child}`);
+          }
+          break;
+        }
+        case 'agent_end': {
+          const messages = Array.isArray(event?.messages) ? event.messages.length : 0;
+          push(`■ agent end (${messages} message(s))`);
+          break;
+        }
+        default:
+          // message_start / message_update / tool_execution_update: streaming, skipped.
+          break;
       }
-      case 'agent_end': {
-        const messages = Array.isArray(event?.messages) ? event.messages.length : 0;
-        push(`■ agent end (${messages} message(s))`);
-        break;
-      }
-      default:
-        // message_start / message_update / tool_execution_update: streaming, skipped.
-        break;
-    }
-  }
+    },
+    finish() {
+      const summary =
+        `Pi review execution trace: ${total} event(s), ${turn} turn(s), ` +
+        `${toolCalls} tool call(s), ${assistantMessages} assistant message(s), ${toolErrors} tool error(s)`;
+      if (lines.length >= MAX_RENDERED) lines.push(`… trace truncated after ${MAX_RENDERED} lines …`);
+      return [summary, ...lines];
+    },
+    get size() {
+      return total;
+    },
+  };
+}
 
-  const summary =
-    `Pi review execution trace: ${events.length} event(s), ${turn} turn(s), ` +
-    `${toolCalls} tool call(s), ${assistantMessages} assistant message(s), ${toolErrors} tool error(s)`;
-  if (lines.length >= MAX_RENDERED) lines.push(`… trace truncated after ${MAX_RENDERED} lines …`);
-  return [summary, ...lines];
+/** Renders a parsed event list to log lines. */
+export function renderPiReviewTrace(events) {
+  const collector = createTraceCollector();
+  for (const event of events) collector.add(event);
+  return collector.finish();
 }
 
 const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const file = process.argv[2];
-  let text = '';
+  const collector = createTraceCollector();
   try {
-    text = readFileSync(file, 'utf8');
-  } catch {
-    console.log(`Pi review execution trace: no event stream captured at ${file ?? '(unset path)'}`);
+    const lines = createInterface({ input: createReadStream(file, 'utf8'), crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        collector.add(JSON.parse(line));
+      } catch {
+        // Skip malformed lines; the uploaded artifact keeps the raw bytes.
+      }
+    }
+  } catch (error) {
+    const reason = error && typeof error === 'object' && 'code' in error ? error.code : String(error);
+    console.log(`Pi review execution trace: no event stream captured at ${file ?? '(unset path)'} (${reason})`);
     process.exit(0);
   }
-  const events = parseTraceEvents(text);
-  if (events.length === 0) {
+  if (collector.size === 0) {
     console.log('Pi review execution trace: event stream is empty');
     process.exit(0);
   }
-  for (const line of renderPiReviewTrace(events)) console.log(line);
+  for (const line of collector.finish()) console.log(line);
 }

--- a/.github/scripts/publish-pi-review.mjs
+++ b/.github/scripts/publish-pi-review.mjs
@@ -124,14 +124,20 @@ export async function combinePiReviewTranscript({ transcriptPath, reviewPath, co
         throw new Error(`Pi review transcript line ${index + 1} is not valid JSON`);
       }
     });
+  // Accept any orchestration mode (parallel tasks, workflow script, or whatever a
+  // future pi-subagents version advertises): the coordinator picks the mode, so
+  // filtering on details.mode breaks whenever that surface evolves. What matters
+  // is that a subagent run produced child results; management calls such as
+  // action:"list" return an empty results array and are ignored here.
   const completedRuns = events.filter((event) =>
     event?.type === 'tool_execution_end' &&
     event?.toolName === 'subagent' &&
-    event?.result?.details?.mode === 'parallel',
+    Array.isArray(event?.result?.details?.results) &&
+    event.result.details.results.length > 0,
   );
-  core.info(`Pi review transcript: ${completedRuns.length} completed parallel subagent run(s)`);
+  core.info(`Pi review transcript: ${completedRuns.length} completed reviewer subagent run(s)`);
   if (completedRuns.length < 1 || completedRuns.length > 10) {
-    throw new Error(`Pi review transcript contained ${completedRuns.length} completed parallel subagent runs; expected 1 to 10`);
+    throw new Error(`Pi review transcript contained ${completedRuns.length} completed reviewer subagent runs; expected 1 to 10`);
   }
 
   const findingsByAxis = new Map();
@@ -140,7 +146,7 @@ export async function combinePiReviewTranscript({ transcriptPath, reviewPath, co
   for (const run of completedRuns) {
     const results = run.result.details.results;
     if (!Array.isArray(results) || results.length < 1 || results.length > 2) {
-      failures.push(`parallel run returned ${Array.isArray(results) ? results.length : 0} results`);
+      failures.push(`subagent run returned ${Array.isArray(results) ? results.length : 0} results`);
       continue;
     }
     resultCount += results.length;

--- a/.github/scripts/publish-pi-review.test.mjs
+++ b/.github/scripts/publish-pi-review.test.mjs
@@ -52,7 +52,7 @@ test('combines schema-validated axis outputs from the Pi JSON transcript', async
     await combinePiReviewTranscript({ transcriptPath, reviewPath, core });
     assert.deepEqual(JSON.parse(await readFile(reviewPath, 'utf8')), { findings: [finding, specFinding] });
     assert.deepEqual(infos, [
-      'Pi review transcript: 1 completed parallel subagent run(s)',
+      'Pi review transcript: 1 completed reviewer subagent run(s)',
       'Pi review Standards reviewer: 1 finding(s)',
       'Pi review Spec reviewer: 1 finding(s)',
       'Pi review combined 2 total finding(s)',
@@ -85,13 +85,57 @@ test('accepts a Standards-only run when the skill finds no specification', async
     assert.deepEqual(JSON.parse(await readFile(reviewPath, 'utf8')), { findings: [finding] });
     // A missing axis is tolerated but must be visible, not silent.
     assert.deepEqual(infos, [
-      'Pi review transcript: 1 completed parallel subagent run(s)',
+      'Pi review transcript: 1 completed reviewer subagent run(s)',
       'Pi review Standards reviewer: 1 finding(s)',
       'Pi review combined 1 total finding(s)',
     ]);
     assert.deepEqual(warnings, [
       'Pi review Spec reviewer produced no usable result; that axis contributes no findings',
     ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('combines workflow-mode runs and ignores management calls', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'pi-review-workflow-'));
+  const transcriptPath = path.join(directory, 'pi.jsonl');
+  const reviewPath = path.join(directory, 'review.json');
+  const infos = [];
+  const warnings = [];
+  const core = { info: (m) => infos.push(m), warning: (m) => warnings.push(m) };
+  try {
+    await writeFile(transcriptPath, [
+      // A subagent action:"list" management call carries an empty results array.
+      JSON.stringify({
+        type: 'tool_execution_end',
+        toolName: 'subagent',
+        result: { details: { mode: 'management', results: [] } },
+      }),
+      // pi-subagents 0.41+ lets the coordinator fan out via a workflow script.
+      JSON.stringify({
+        type: 'tool_execution_end',
+        toolName: 'subagent',
+        result: {
+          details: {
+            mode: 'workflow',
+            results: [
+              { exitCode: 0, structuredOutput: { axis: 'Standards', findings: [finding] } },
+              { exitCode: 0, structuredOutput: { axis: 'Spec', findings: [] } },
+            ],
+          },
+        },
+      }),
+    ].join('\n'));
+    await combinePiReviewTranscript({ transcriptPath, reviewPath, core });
+    assert.deepEqual(JSON.parse(await readFile(reviewPath, 'utf8')), { findings: [finding] });
+    assert.deepEqual(infos, [
+      'Pi review transcript: 1 completed reviewer subagent run(s)',
+      'Pi review Standards reviewer: 1 finding(s)',
+      'Pi review Spec reviewer: 0 finding(s)',
+      'Pi review combined 1 total finding(s)',
+    ]);
+    assert.deepEqual(warnings, []);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -121,7 +165,7 @@ test('combines successful structured outputs across coordinator recovery calls',
     // The failed first attempt is surfaced as a warning, not swallowed.
     assert.deepEqual(warnings, ['Pi review discarded reviewer output: first attempt failed']);
     assert.deepEqual(infos, [
-      'Pi review transcript: 3 completed parallel subagent run(s)',
+      'Pi review transcript: 3 completed reviewer subagent run(s)',
       'Pi review Standards reviewer: 1 finding(s)',
       'Pi review Spec reviewer: 1 finding(s)',
       'Pi review combined 2 total finding(s)',


### PR DESCRIPTION
## Problem

Run [31068173820](https://github.com/TGYD-helige/pi/actions/runs/31068173820) failed at **Combine structured axis review outputs** with:

```
Pi review transcript contained 0 completed parallel subagent runs; expected 1 to 10
```

Root cause chain:

1. **pi-subagents 0.41.0** (published 2026-08-05 23:03 UTC, between the last green run and this one) added the `workflowScript` orchestration mode to the subagent tool. The workflow installs `pi-subagents@latest` on every run.
2. The review coordinator (deepseek-v4-flash) no longer made the instructed single **parallel** call — it called `subagent {action:"list"}`, then fanned out via a **workflow script** (`details.mode: "workflow"`).
3. `combinePiReviewTranscript` filtered strictly on `details.mode === 'parallel'`, so the two **successful** reviewer outputs (Standards/Spec, both `exitCode: 0` with valid structured output) were discarded and the job failed.

The `Print Pi execution trace` step also misreported `no event stream captured`: the full event stream reached 1.1–2GB (`--thinking max` deltas), past the V8 string limit, so `readFileSync` threw and the catch blamed a missing file.

## Changes

- **`publish-pi-review.mjs`** — combine filters structurally instead of by mode: any `subagent` `tool_execution_end` with a non-empty `details.results` array counts, regardless of orchestration mode (parallel, workflow, or future modes). Management calls like `action:"list"` return an empty `results` array and stay excluded.
- **`pi-review-trace.mjs`** — the trace renderer is now an incremental collector fed by a line stream (`createReadStream` + `readline`), so multi-GB streams render fine; the missing-file message now includes the real error code (e.g. `(ENOENT)`). `renderPiReviewTrace`/`parseTraceEvents` exports keep their exact behavior for existing callers/tests.
- Tests: regression case covering a workflow-mode run plus an ignored management call; message expectations updated.

## Verification

- `pnpm vitest run .github/scripts` — 14 passed
- `pnpm lint` — clean
- Smoke-tested the trace entry point against a workflow-mode JSONL sample and a missing file

Deliberately **not** pinning pi-subagents: compatibility with mode drift is the fix, and pinning would forfeit upstream improvements.