### PR TITLE
feat(pi-video-gen): MiniMax-H3 provider, capability inheritance, version-pinned aliases

### DIFF
--- a/packages/pi-video-gen/README.md
+++ b/packages/pi-video-gen/README.md
@@ -15,6 +15,7 @@ that orchestrates the full shot-book workflow together with
 | `ark` (Volcengine Ark) | Seedance 2.0 standard / fast / mini | ✅ built-in |
 | `dashscope` (Alibaba) | HappyHorse 1.1 / 1.0 (t2v/i2v/r2v auto-routed) | ✅ built-in |
 | `kling` (Kuaishou) | Kling 3.0 Turbo / 3.0 Omni (API 2.0) | ✅ built-in |
+| `minimax` | MiniMax-H3 (v2 API) | ✅ built-in |
 | `openrouter` | google/veo-3.1 (+ custom models) | ✅ built-in |
 | `newapi` | self-hosted NewAPI relay (Kling / Jimeng / Vidu / Gemini channels) | ✅ via `customProviders` — `baseUrl` **required** |
 | custom | your own endpoints | ✅ via `customProviders` |
@@ -32,7 +33,7 @@ Global settings (`~/.pi/agent/settings.json`):
 ```jsonc
 {
   "pi-video-gen": {
-    "defaultModel": "seedance",                  // alias of doubao-seedance-2-0-260128
+    "defaultModel": "seedance-2.0",              // alias of doubao-seedance-2-0-260128
     "providers": {
       "ark": { "apiKey": "${ARK_API_KEY}" }      // Volcengine Ark key
     },
@@ -44,7 +45,12 @@ Global settings (`~/.pi/agent/settings.json`):
 
 **Custom providers** (same idea as pi-image-gen's — point any Ark-compatible
 endpoint at your own models; string models get conservative capabilities,
-object models declare them):
+object models declare them). When a custom model's `id` names a built-in
+model (e.g. `"MiniMax-H3"` behind your relay), the built-in capability table
+and defaults are inherited automatically — undeclared `capabilities`,
+`defaultResolution`/`defaultAspectRatio`/`defaultDurationSec` fall back to
+the registry values instead of the conservative 720p/16:9 profile, and any
+field you do declare overrides the inherited one:
 
 ```jsonc
 {
@@ -95,6 +101,22 @@ ambiguous submits are parked for manual resolution rather than auto-retried:
   }
 }
 ```
+
+**MiniMax notes** (v2 API, [create](https://platform.minimax.io/docs/api-reference/video-generation-v2-create) / [query](https://platform.minimax.io/docs/api-reference/video-generation-v2-query)):
+MiniMax-H3 speaks a multimodal task API — prompt + frames ride in one
+`content` array with `first_frame` / `last_frame` / `reference_image` roles
+(first/last frames and reference images are mutually exclusive; a last frame
+requires a first frame). Resolution is `768P` or `2K`, duration 4–15s, ratio
+`16:9|4:3|1:1|3:4|9:16|21:9` — required and non-adaptive for text-to-video,
+ignored (forced adaptive) once a first frame is present. There is no audio
+toggle, no idempotency key and no documented cancel endpoint, so ambiguous
+submits are parked for manual resolution rather than auto-retried. Auth is a
+plain Bearer key (`providers.minimax.apiKey`, env `MINIMAX_API_KEY`), and keys
+are region-locked: the default endpoint is international
+`api.minimax.io` — mainland-China keys need `providers.minimax.baseUrl` set
+to `https://api.minimaxi.com` (and vice versa a 401 means wrong region).
+Result URLs are time-limited; clips are downloaded immediately, and tasks
+stay queryable for 7 days.
 
 **Kling notes** (verified against kling.ai/document-api via browser, 2026-07):
 current Kling API 2.0 uses a plain API key (`providers.kling.apiKey`, env

--- a/packages/pi-video-gen/src/__tests__/config.test.ts
+++ b/packages/pi-video-gen/src/__tests__/config.test.ts
@@ -56,7 +56,7 @@ describe('loadVideoGenSettings', () => {
 
   it('ignores the project layer entirely when untrusted', () => {
     writeJson(join(cwd, '.pi', 'settings.json'), {
-      'pi-video-gen': { defaultModel: 'seedance-fast', outputDir: 'custom-out' },
+      'pi-video-gen': { defaultModel: 'seedance-2.0-fast', outputDir: 'custom-out' },
     });
     const settings = loadVideoGenSettings(cwd, false);
     expect(settings.defaultModel).toBeUndefined();
@@ -66,13 +66,13 @@ describe('loadVideoGenSettings', () => {
   it('honors whitelisted keys from a trusted project', () => {
     writeJson(join(cwd, '.pi', 'settings.json'), {
       'pi-video-gen': {
-        defaultModel: 'seedance-fast',
+        defaultModel: 'seedance-2.0-fast',
         outputDir: 'custom-out',
         concurrency: { clips: 1 },
       },
     });
     const settings = loadVideoGenSettings(cwd, true);
-    expect(settings.defaultModel).toBe('seedance-fast');
+    expect(settings.defaultModel).toBe('seedance-2.0-fast');
     expect(settings.outputDir).toBe('custom-out');
     expect(settings.concurrency?.clips).toBe(1);
   });
@@ -80,13 +80,13 @@ describe('loadVideoGenSettings', () => {
   it('strips sensitive keys from a trusted project layer', () => {
     writeJson(join(cwd, '.pi', 'settings.json'), {
       'pi-video-gen': {
-        defaultModel: 'seedance-fast',
+        defaultModel: 'seedance-2.0-fast',
         providers: { ark: { apiKey: 'stolen', baseUrl: 'https://evil.example' } },
         ffmpegPath: '/tmp/evil-ffmpeg',
       },
     });
     const settings = loadVideoGenSettings(cwd, true);
-    expect(settings.defaultModel).toBe('seedance-fast');
+    expect(settings.defaultModel).toBe('seedance-2.0-fast');
     expect(settings.providers?.ark?.apiKey).toBeUndefined();
     expect(settings.ffmpegPath).toBeUndefined();
   });
@@ -132,13 +132,13 @@ describe('loadVideoGenSettings', () => {
 
   it('project whitelist keys override global ones when trusted', () => {
     writeJson(join(home, '.pi', 'agent', 'settings.json'), {
-      'pi-video-gen': { defaultModel: 'seedance-mini' },
+      'pi-video-gen': { defaultModel: 'seedance-2.0-mini' },
     });
     writeJson(join(cwd, '.pi', 'settings.json'), {
-      'pi-video-gen': { defaultModel: 'seedance-fast' },
+      'pi-video-gen': { defaultModel: 'seedance-2.0-fast' },
     });
-    expect(loadVideoGenSettings(cwd, true).defaultModel).toBe('seedance-fast');
-    expect(loadVideoGenSettings(cwd, false).defaultModel).toBe('seedance-mini');
+    expect(loadVideoGenSettings(cwd, true).defaultModel).toBe('seedance-2.0-fast');
+    expect(loadVideoGenSettings(cwd, false).defaultModel).toBe('seedance-2.0-mini');
   });
 });
 
@@ -224,7 +224,7 @@ describe('config validation & loud project read', () => {
 });
 
 describe('resolveModel', () => {
-  it('defaults to the seedance alias and ark default base url', () => {
+  it('defaults to the seedance 2.0 standard model and ark default base url', () => {
     const resolved = resolveModel({});
     expect(resolved?.entry.id).toBe('doubao-seedance-2-0-260128');
     expect(resolved?.provider.style).toBe('ark');
@@ -232,7 +232,7 @@ describe('resolveModel', () => {
   });
 
   it('resolves aliases case-insensitively', () => {
-    expect(resolveModel({}, 'Seedance-FAST')?.entry.id).toBe('doubao-seedance-2-0-fast-260128');
+    expect(resolveModel({}, 'Seedance-2.0-FAST')?.entry.id).toBe('doubao-seedance-2-0-fast-260128');
   });
 
   it('returns null for unknown models', () => {
@@ -276,6 +276,80 @@ describe('resolveModel', () => {
       /providers.newapi.baseUrl/,
     );
   });
+
+  it('custom models with unknown ids get conservative capabilities', () => {
+    const resolved = resolveModel(
+      {
+        customProviders: {
+          myproxy: { api: 'ark', baseUrl: 'https://proxy.example/v3', models: ['mystery-9'] },
+        },
+      },
+      'mystery-9',
+    );
+    expect(resolved?.entry.capabilities).toMatchObject({
+      maxReferenceImages: 1,
+      resolutions: ['720p'],
+      aspectRatios: ['16:9'],
+      nativeAudio: false,
+      supportsFirstLastFrame: false,
+    });
+    expect(resolved?.entry.defaultResolution).toBe('720p');
+  });
+
+  it('custom models inherit built-in capabilities when the id names a known model', () => {
+    const resolved = resolveModel(
+      {
+        customProviders: {
+          relay: {
+            api: 'minimax',
+            baseUrl: 'https://relay.example',
+            apiKey: 'k',
+            models: [{ id: 'MiniMax-H3', alias: 'h3-relay' }],
+          },
+        },
+      },
+      'h3-relay',
+    );
+    // No capabilities declared: the registry's H3 contract applies (768P/2K,
+    // flf, 4-15s) instead of the conservative 720p/16:9 fallback, while the
+    // relay keeps its own wire format, endpoint and remote id.
+    expect(resolved?.provider.style).toBe('minimax');
+    expect(resolved?.provider.baseUrl).toBe('https://relay.example');
+    expect(resolved?.remoteId).toBe('MiniMax-H3');
+    expect(resolved?.entry.capabilities.resolutions).toEqual(['768P', '2K']);
+    expect(resolved?.entry.capabilities.supportsFirstLastFrame).toBe(true);
+    expect(resolved?.entry.defaultResolution).toBe('768P');
+    expect(resolved?.entry.defaultAspectRatio).toBe('16:9');
+    expect(resolved?.entry.defaultDurationSec).toBe(5);
+  });
+
+  it('explicit custom capabilities/defaults override the inherited ones per field', () => {
+    const resolved = resolveModel(
+      {
+        customProviders: {
+          relay: {
+            api: 'minimax',
+            baseUrl: 'https://relay.example',
+            models: [
+              {
+                id: 'MiniMax-H3',
+                alias: 'h3x',
+                capabilities: { resolutions: ['768P'] },
+                defaultDurationSec: 10,
+              },
+            ],
+          },
+        },
+      },
+      'h3x',
+    );
+    // Overridden field wins; untouched fields keep the built-in values; the
+    // built-in 2K default is skipped because the override dropped it.
+    expect(resolved?.entry.capabilities.resolutions).toEqual(['768P']);
+    expect(resolved?.entry.capabilities.aspectRatios).toContain('21:9');
+    expect(resolved?.entry.defaultResolution).toBe('768P');
+    expect(resolved?.entry.defaultDurationSec).toBe(10);
+  });
 });
 
 describe('listModelRegistry', () => {
@@ -286,7 +360,7 @@ describe('listModelRegistry', () => {
     expect(info.models.filter((m) => m.provider === 'dashscope').every((m) => !m.keyReady)).toBe(
       true,
     );
-    expect(info.models).toHaveLength(8);
+    expect(info.models).toHaveLength(9);
   });
 
   it('includes custom provider models in the registry view', () => {

--- a/packages/pi-video-gen/src/__tests__/extension.test.ts
+++ b/packages/pi-video-gen/src/__tests__/extension.test.ts
@@ -956,7 +956,7 @@ describe('pi-video-gen extension', () => {
       join(home, '.pi', 'agent', 'settings.json'),
       JSON.stringify({
         'pi-video-gen': {
-          defaultModel: 'happyhorse',
+          defaultModel: 'happyhorse-1.1',
           providers: { dashscope: { apiKey: 'k' } },
         },
       }),

--- a/packages/pi-video-gen/src/__tests__/minimax.test.ts
+++ b/packages/pi-video-gen/src/__tests__/minimax.test.ts
@@ -1,0 +1,306 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AmbiguousSubmitError, RemoteTaskNotFoundError, VideoGenError } from '../errors.js';
+import { minimaxAdapter } from '../providers/minimax.js';
+import type { ResolvedProvider } from '../types.js';
+
+const suiteDir = join(tmpdir(), 'pi-video-gen-minimax');
+afterEach(() => rmSync(suiteDir, { recursive: true, force: true }));
+
+const provider: ResolvedProvider = {
+  style: 'minimax',
+  apiKey: 'test-key',
+  baseUrl: 'https://api.minimax.io',
+};
+
+function mockFetch(
+  handler: (url: string, init?: RequestInit) => Response | Promise<Response>,
+): typeof fetch {
+  return (async (url: unknown, init?: RequestInit) => handler(String(url), init)) as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('minimaxAdapter.submit (v2)', () => {
+  beforeEach(() => {
+    mkdirSync(suiteDir, { recursive: true });
+    writeFileSync(join(suiteDir, 'frame.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  });
+
+  it('t2v: content text item, concrete ratio, Bearer apiKey', async () => {
+    let seen:
+      | { url: string; headers: Record<string, string>; body: Record<string, unknown> }
+      | undefined;
+    const fetchImpl = mockFetch((url, init) => {
+      seen = {
+        url,
+        headers: init?.headers as Record<string, string>,
+        body: JSON.parse(String(init?.body)),
+      };
+      return jsonResponse(200, { task_id: 'mm-1' });
+    });
+
+    const handle = await minimaxAdapter.submit(
+      provider,
+      'MiniMax-H3',
+      { prompt: 'a calm sea', durationSec: 8, aspectRatio: '16:9', resolution: '2K' },
+      fetchImpl,
+    );
+
+    expect(handle.taskId).toBe('mm-1');
+    expect(seen?.url).toBe('https://api.minimax.io/v2/video_generation');
+    expect(seen?.headers.authorization).toBe('Bearer test-key');
+    expect(seen?.body.model).toBe('MiniMax-H3');
+    expect(seen?.body.content).toEqual([{ type: 'text', text: 'a calm sea' }]);
+    expect(seen?.body.resolution).toBe('2K');
+    expect(seen?.body.duration).toBe(8);
+    expect(seen?.body.ratio).toBe('16:9');
+    expect(seen?.body.aigc_watermark).toBe(false);
+  });
+
+  it('i2v: first_frame role with a data URI, ratio omitted (server forces adaptive)', async () => {
+    let body: Record<string, unknown> | undefined;
+    const fetchImpl = mockFetch((_url, init) => {
+      body = JSON.parse(String(init?.body));
+      return jsonResponse(200, { task_id: 'mm-2' });
+    });
+
+    await minimaxAdapter.submit(
+      provider,
+      'MiniMax-H3',
+      {
+        prompt: 'cat runs',
+        firstFramePath: join(suiteDir, 'frame.png'),
+        aspectRatio: '9:16',
+        durationSec: 5,
+        resolution: '768P',
+      },
+      fetchImpl,
+    );
+
+    expect(body?.ratio).toBeUndefined();
+    const content = body?.content as Record<string, unknown>[];
+    expect(content[0]).toEqual({ type: 'text', text: 'cat runs' });
+    expect(content[1]?.type).toBe('image_url');
+    expect(content[1]?.role).toBe('first_frame');
+    expect(String((content[1]?.image_url as { url: string }).url)).toMatch(
+      /^data:image\/png;base64,/,
+    );
+  });
+
+  it('flf: last_frame role pairs with first_frame', async () => {
+    let body: Record<string, unknown> | undefined;
+    const fetchImpl = mockFetch((_url, init) => {
+      body = JSON.parse(String(init?.body));
+      return jsonResponse(200, { task_id: 'mm-3' });
+    });
+
+    await minimaxAdapter.submit(
+      provider,
+      'MiniMax-H3',
+      {
+        prompt: 'cat runs',
+        firstFramePath: join(suiteDir, 'frame.png'),
+        lastFramePath: join(suiteDir, 'frame.png'),
+      },
+      fetchImpl,
+    );
+
+    const roles = (body?.content as Record<string, unknown>[]).map((item) => item.role);
+    expect(roles).toEqual([undefined, 'first_frame', 'last_frame']);
+  });
+
+  it('reference images: reference_image roles, ratio sent when provided', async () => {
+    let body: Record<string, unknown> | undefined;
+    const fetchImpl = mockFetch((_url, init) => {
+      body = JSON.parse(String(init?.body));
+      return jsonResponse(200, { task_id: 'mm-4' });
+    });
+
+    await minimaxAdapter.submit(
+      provider,
+      'MiniMax-H3',
+      {
+        prompt: 'the character dances',
+        referenceImagePaths: [join(suiteDir, 'frame.png'), join(suiteDir, 'frame.png')],
+        aspectRatio: '1:1',
+      },
+      fetchImpl,
+    );
+
+    expect(body?.ratio).toBe('1:1');
+    const roles = (body?.content as Record<string, unknown>[]).map((item) => item.role);
+    expect(roles).toEqual([undefined, 'reference_image', 'reference_image']);
+  });
+
+  it('rejects a last frame without a first frame', async () => {
+    await expect(
+      minimaxAdapter.submit(
+        provider,
+        'MiniMax-H3',
+        { prompt: 'x', lastFramePath: join(suiteDir, 'frame.png') },
+        mockFetch(() => jsonResponse(200, { task_id: 'mm-5' })),
+      ),
+    ).rejects.toThrow(/requires a first frame/);
+  });
+
+  it('rejects mixing first frame with reference images', async () => {
+    await expect(
+      minimaxAdapter.submit(
+        provider,
+        'MiniMax-H3',
+        {
+          prompt: 'x',
+          firstFramePath: join(suiteDir, 'frame.png'),
+          referenceImagePaths: [join(suiteDir, 'frame.png')],
+        },
+        mockFetch(() => jsonResponse(200, { task_id: 'mm-6' })),
+      ),
+    ).rejects.toThrow(/not both/);
+  });
+
+  it('fails clearly without an api key', async () => {
+    await expect(
+      minimaxAdapter.submit(
+        { ...provider, apiKey: undefined },
+        'MiniMax-H3',
+        { prompt: 'x' },
+        mockFetch(() => jsonResponse(200, { task_id: 'mm-7' })),
+      ),
+    ).rejects.toThrow(/No API key configured for MiniMax/);
+  });
+
+  it('network failure on submit is ambiguous (no idempotency lookup exists)', async () => {
+    await expect(
+      minimaxAdapter.submit(
+        provider,
+        'MiniMax-H3',
+        { prompt: 'x' },
+        mockFetch(() => Promise.reject(new Error('socket hangup'))),
+      ),
+    ).rejects.toBeInstanceOf(AmbiguousSubmitError);
+  });
+
+  it('5xx on submit is ambiguous; 4xx is a plain http error', async () => {
+    await expect(
+      minimaxAdapter.submit(
+        provider,
+        'MiniMax-H3',
+        { prompt: 'x' },
+        mockFetch(() => jsonResponse(500, { type: 'error' })),
+      ),
+    ).rejects.toBeInstanceOf(AmbiguousSubmitError);
+    await expect(
+      minimaxAdapter.submit(
+        provider,
+        'MiniMax-H3',
+        { prompt: 'x' },
+        mockFetch(() => jsonResponse(400, { type: 'error' })),
+      ),
+    ).rejects.toThrow(/HTTP 400/);
+  });
+
+  it('2xx without a task id is ambiguous, not a clean failure', async () => {
+    await expect(
+      minimaxAdapter.submit(
+        provider,
+        'MiniMax-H3',
+        { prompt: 'x' },
+        mockFetch(() => jsonResponse(200, {})),
+      ),
+    ).rejects.toBeInstanceOf(AmbiguousSubmitError);
+  });
+});
+
+describe('minimaxAdapter.inspect (v2)', () => {
+  const handle = {
+    taskId: 'mm-1',
+    submittedAt: '2026-08-06T00:00:00.000Z',
+    requestFingerprint: 'fp',
+  };
+
+  function inspectWith(body: unknown, status = 200) {
+    return minimaxAdapter.inspect(
+      provider,
+      handle,
+      mockFetch((url) => {
+        expect(url).toBe('https://api.minimax.io/v2/query/video_generation/mm-1');
+        return jsonResponse(status, body);
+      }),
+    );
+  }
+
+  it('maps queued → pending and running → running', async () => {
+    await expect(inspectWith({ task: { id: 'mm-1', status: 'queued' } })).resolves.toEqual({
+      phase: 'pending',
+    });
+    await expect(inspectWith({ task: { id: 'mm-1', status: 'running' } })).resolves.toEqual({
+      phase: 'running',
+    });
+  });
+
+  it('maps succeeded → video url from task.content.url', async () => {
+    await expect(
+      inspectWith({
+        task: { id: 'mm-1', status: 'succeeded', content: { url: 'https://cdn.example/v.mp4' } },
+      }),
+    ).resolves.toEqual({ phase: 'succeeded', videoUrl: 'https://cdn.example/v.mp4' });
+  });
+
+  it('succeeded without a url throws', async () => {
+    await expect(inspectWith({ task: { id: 'mm-1', status: 'succeeded' } })).rejects.toThrow(
+      /no video URL/,
+    );
+  });
+
+  it('maps failed → provider message, cancelled → failed', async () => {
+    await expect(
+      inspectWith({
+        task: { id: 'mm-1', status: 'failed', error: { code: '1026', message: 'sensitive' } },
+      }),
+    ).resolves.toEqual({ phase: 'failed', message: 'sensitive' });
+    await expect(inspectWith({ task: { id: 'mm-1', status: 'cancelled' } })).resolves.toEqual({
+      phase: 'failed',
+      message: 'task was cancelled on the provider',
+    });
+  });
+
+  it('unknown status and malformed payloads throw', async () => {
+    await expect(inspectWith({ task: { id: 'mm-1', status: 'mystery' } })).rejects.toThrow(
+      /unknown task status/,
+    );
+    await expect(inspectWith({})).rejects.toThrow(/malformed task payload/);
+  });
+
+  it('404 on inspect means the remote task is gone', async () => {
+    await expect(inspectWith({ type: 'error' }, 404)).rejects.toBeInstanceOf(
+      RemoteTaskNotFoundError,
+    );
+  });
+
+  it('network failure is retryable', async () => {
+    await expect(
+      minimaxAdapter.inspect(
+        provider,
+        handle,
+        mockFetch(() => Promise.reject(new Error('dns'))),
+      ),
+    ).rejects.toThrow(/network error/);
+  });
+
+  it('non-VideoGenError surprises stay off the user channel', async () => {
+    try {
+      await inspectWith({ task: { id: 'mm-1', status: 'mystery' } });
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(VideoGenError);
+    }
+  });
+});

--- a/packages/pi-video-gen/src/__tests__/models.test.ts
+++ b/packages/pi-video-gen/src/__tests__/models.test.ts
@@ -3,14 +3,15 @@ import { BUILT_IN_VIDEO_MODELS, findBuiltInModel } from '../providers/models.js'
 
 describe('model registry', () => {
   it('contains only smoke-testable models (no placeholders)', () => {
-    expect(BUILT_IN_VIDEO_MODELS.length).toBeGreaterThanOrEqual(8);
+    expect(BUILT_IN_VIDEO_MODELS.length).toBeGreaterThanOrEqual(9);
     for (const m of BUILT_IN_VIDEO_MODELS) {
-      expect(['ark', 'dashscope', 'kling', 'openrouter']).toContain(m.provider);
+      expect(['ark', 'dashscope', 'kling', 'openrouter', 'minimax']).toContain(m.provider);
       expect(
         m.id.startsWith('doubao-seedance-2-0-') ||
           m.id.startsWith('happyhorse-') ||
           m.id.startsWith('kling-') ||
-          m.id.startsWith('google/'),
+          m.id.startsWith('google/') ||
+          m.id.startsWith('MiniMax-'),
       ).toBe(true);
       expect(m.capabilities.durations[0]).toBeLessThan(m.capabilities.durations[1]);
       expect(m.defaultResolution).toBeOneOf(m.capabilities.resolutions);
@@ -18,8 +19,48 @@ describe('model registry', () => {
     }
   });
 
+  it('minimax entry: v2 contract — 768P/2K, flf, no audio, no adaptive ratio', () => {
+    const h3 = findBuiltInModel('minimax-h3')!;
+    expect(h3.id).toBe('MiniMax-H3');
+    expect(h3.provider).toBe('minimax');
+    expect(h3.capabilities.resolutions).toEqual(['768P', '2K']);
+    expect(h3.capabilities.aspectRatios).not.toContain('adaptive');
+    expect(h3.capabilities.nativeAudio).toBe(false);
+    expect(h3.capabilities.supportsFirstLastFrame).toBe(true);
+    expect(h3.capabilities.durations).toEqual([4, 15]);
+    expect(findBuiltInModel('MiniMax-H3')?.id).toBe('MiniMax-H3');
+    expect(findBuiltInModel('h3')?.id).toBe('MiniMax-H3');
+  });
+
+  it('aliases always carry a version marker (no vendor-name aliases)', () => {
+    // A version-less alias (seedance, kling, minimax) becomes ambiguous the
+    // day the next model generation ships — the registry must never regain one.
+    for (const m of BUILT_IN_VIDEO_MODELS) {
+      for (const alias of m.aliases) {
+        expect(alias, `${m.id} alias "${alias}" has no version marker`).toMatch(/\d/);
+      }
+    }
+  });
+
+  it('version-less vendor aliases do not resolve', () => {
+    for (const alias of [
+      'seedance',
+      'seedance-fast',
+      'seedance-mini',
+      'seedance-std',
+      'happyhorse',
+      'kling',
+      'kling-turbo',
+      'kling-omni',
+      'veo',
+      'minimax',
+    ]) {
+      expect(findBuiltInModel(alias), alias).toBeUndefined();
+    }
+  });
+
   it('veo entry: openrouter provider, audio + flf, 5-8s', () => {
-    const veo = findBuiltInModel('veo')!;
+    const veo = findBuiltInModel('veo-3.1')!;
     expect(veo.id).toBe('google/veo-3.1');
     expect(veo.provider).toBe('openrouter');
     expect(veo.capabilities.nativeAudio).toBe(true);
@@ -28,12 +69,12 @@ describe('model registry', () => {
   });
 
   it('kling entries: turbo silent, omni audio-capable', () => {
-    const turbo = findBuiltInModel('kling')!;
+    const turbo = findBuiltInModel('kling-v3-turbo')!;
     expect(turbo.id).toBe('kling-3.0-turbo');
     expect(turbo.provider).toBe('kling');
     expect(turbo.capabilities.nativeAudio).toBe(false);
     expect(turbo.capabilities.supportsFirstLastFrame).toBe(false);
-    const omni = findBuiltInModel('kling-omni')!;
+    const omni = findBuiltInModel('kling-v3-omni')!;
     expect(omni.id).toBe('kling-3.0');
     expect(omni.capabilities.nativeAudio).toBe(true);
     expect(omni.capabilities.supportsFirstLastFrame).toBe(true);
@@ -41,7 +82,7 @@ describe('model registry', () => {
   });
 
   it('happyhorse entries: dashscope provider, no audio, no last-frame', () => {
-    const hh = findBuiltInModel('happyhorse')!;
+    const hh = findBuiltInModel('happyhorse-1.1')!;
     expect(hh.id).toBe('happyhorse-1.1');
     expect(hh.provider).toBe('dashscope');
     expect(hh.capabilities.nativeAudio).toBe(false);
@@ -49,14 +90,14 @@ describe('model registry', () => {
     expect(hh.capabilities.maxReferenceImages).toBe(9);
   });
 
-  it('resolves the seedance alias to the standard 2.0 model', () => {
-    expect(findBuiltInModel('seedance')?.id).toBe('doubao-seedance-2-0-260128');
-    expect(findBuiltInModel('seedance-fast')?.id).toBe('doubao-seedance-2-0-fast-260128');
-    expect(findBuiltInModel('seedance-mini')?.id).toBe('doubao-seedance-2-0-mini-260615');
+  it('resolves the seedance 2.0 aliases to their dated model ids', () => {
+    expect(findBuiltInModel('seedance-2.0')?.id).toBe('doubao-seedance-2-0-260128');
+    expect(findBuiltInModel('seedance-2.0-fast')?.id).toBe('doubao-seedance-2-0-fast-260128');
+    expect(findBuiltInModel('seedance-2.0-mini')?.id).toBe('doubao-seedance-2-0-mini-260615');
   });
 
   it('fast/mini cap resolution at 720p', () => {
-    for (const id of ['seedance-fast', 'seedance-mini']) {
+    for (const id of ['seedance-2.0-fast', 'seedance-2.0-mini']) {
       const caps = findBuiltInModel(id)!.capabilities;
       expect(caps.resolutions).not.toContain('1080p');
     }

--- a/packages/pi-video-gen/src/config.ts
+++ b/packages/pi-video-gen/src/config.ts
@@ -4,6 +4,7 @@ import { providerLabel, VideoGenError } from './errors.js';
 import { ARK_DEFAULT_BASE_URL } from './providers/ark.js';
 import { DASHSCOPE_DEFAULT_BASE_URL } from './providers/dashscope.js';
 import { KLING_DEFAULT_BASE_URL } from './providers/kling.js';
+import { MINIMAX_DEFAULT_BASE_URL } from './providers/minimax.js';
 import { BUILT_IN_VIDEO_MODELS, findBuiltInModel } from './providers/models.js';
 import { OPENROUTER_DEFAULT_BASE_URL } from './providers/openrouter.js';
 import type {
@@ -16,6 +17,13 @@ import type {
 } from './types.js';
 
 const SETTINGS_KEY = 'pi-video-gen';
+
+/**
+ * Fallback model when neither the caller nor settings.defaultModel name one.
+ * A full registry id, NOT an alias — aliases can be dropped between versions,
+ * the default must not depend on one.
+ */
+export const DEFAULT_VIDEO_MODEL_ID = 'doubao-seedance-2-0-260128';
 
 /**
  * Keys a project-level settings file may set. Everything else — notably
@@ -34,6 +42,7 @@ const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<VideoApiStyle, string>> = {
   kling: KLING_DEFAULT_BASE_URL,
   dashscope: DASHSCOPE_DEFAULT_BASE_URL,
   openrouter: OPENROUTER_DEFAULT_BASE_URL,
+  minimax: MINIMAX_DEFAULT_BASE_URL,
 };
 
 /** Resolve the effective base URL, failing clearly when the style mandates one. */
@@ -153,7 +162,7 @@ function validateCapabilities(value: unknown, path: string): void {
   }
 }
 
-const WIRE_FORMATS = ['ark', 'kling', 'dashscope', 'openrouter', 'newapi'];
+const WIRE_FORMATS = ['ark', 'kling', 'dashscope', 'openrouter', 'newapi', 'minimax'];
 
 function validateCustomProviders(value: unknown): void {
   if (value === undefined) return;
@@ -295,9 +304,13 @@ export function resolveProvider(
 
 /**
  * Conservative capabilities for custom models declared as a bare string (or
- * with a partial capabilities object): text-to-video + first frame only, no
- * audio, no last-frame interpolation, 720p/16:9. Declare full capabilities in
- * the custom model object to lift these.
+ * with a partial capabilities object) whose id matches NO built-in registry
+ * entry: text-to-video + first frame only, no audio, no last-frame
+ * interpolation, 720p/16:9. Declare full capabilities in the custom model
+ * object to lift these. When the id DOES name a built-in model (e.g.
+ * "MiniMax-H3" behind a relay), the built-in capability table is the base
+ * instead — the remote contract is known, so resolution/duration/ratio
+ * defaults come from the registry.
  */
 const CONSERVATIVE_CUSTOM_CAPABILITIES: VideoModelCapabilities = {
   maxReferenceImages: 1,
@@ -308,6 +321,20 @@ const CONSERVATIVE_CUSTOM_CAPABILITIES: VideoModelCapabilities = {
   supportsFirstLastFrame: false,
 };
 
+/**
+ * Default-value inheritance for custom models: an explicit settings value
+ * wins; then the built-in registry default (only while it stays valid against
+ * the merged capabilities); finally the caller-supplied fallback.
+ */
+function inheritDefault<T>(
+  explicit: T | undefined,
+  builtIn: T | undefined,
+  isValid: (value: T) => boolean,
+  fallback: T,
+): T {
+  return explicit ?? (builtIn !== undefined && isValid(builtIn) ? builtIn : fallback);
+}
+
 function resolveCustomModel(settings: VideoGenSettings, wanted: string): ResolvedModel | null {
   const needle = wanted.trim().toLowerCase();
   for (const [providerName, cp] of Object.entries(settings.customProviders ?? {})) {
@@ -317,16 +344,38 @@ function resolveCustomModel(settings: VideoGenSettings, wanted: string): Resolve
         model.id.toLowerCase() === needle ||
         (model.alias != null && model.alias.toLowerCase() === needle);
       if (!matches) continue;
-      const capabilities = { ...CONSERVATIVE_CUSTOM_CAPABILITIES, ...(model.capabilities ?? {}) };
+      const builtIn = findBuiltInModel(model.id);
+      const capabilities = {
+        ...(builtIn?.capabilities ?? CONSERVATIVE_CUSTOM_CAPABILITIES),
+        ...(model.capabilities ?? {}),
+      };
+      const defaultResolution = inheritDefault(
+        model.defaultResolution,
+        builtIn?.defaultResolution,
+        (v) => capabilities.resolutions.includes(v),
+        capabilities.resolutions[0]!,
+      );
+      const defaultAspectRatio = inheritDefault(
+        model.defaultAspectRatio,
+        builtIn?.defaultAspectRatio,
+        (v) => capabilities.aspectRatios.includes(v),
+        capabilities.aspectRatios[0]!,
+      );
+      const defaultDurationSec = inheritDefault(
+        model.defaultDurationSec,
+        builtIn?.defaultDurationSec,
+        (v) => v >= capabilities.durations[0] && v <= capabilities.durations[1],
+        capabilities.durations[0],
+      );
       return {
         entry: {
           id: model.id,
           aliases: model.alias ? [model.alias] : [],
           provider: cp.api,
           capabilities,
-          defaultResolution: model.defaultResolution ?? capabilities.resolutions[0]!,
-          defaultAspectRatio: model.defaultAspectRatio ?? capabilities.aspectRatios[0]!,
-          defaultDurationSec: model.defaultDurationSec ?? capabilities.durations[0],
+          defaultResolution,
+          defaultAspectRatio,
+          defaultDurationSec,
         },
         remoteId: model.id,
         provider: {
@@ -347,10 +396,11 @@ function resolveCustomModel(settings: VideoGenSettings, wanted: string): Resolve
 
 /**
  * Resolve a model id/alias (defaulting to settings.defaultModel, then
- * 'seedance'). Built-in registry wins over custom provider models on conflict.
+ * DEFAULT_VIDEO_MODEL_ID). Built-in registry wins over custom provider
+ * models on conflict.
  */
 export function resolveModel(settings: VideoGenSettings, modelId?: string): ResolvedModel | null {
-  const wanted = modelId ?? settings.defaultModel ?? 'seedance';
+  const wanted = modelId ?? settings.defaultModel ?? DEFAULT_VIDEO_MODEL_ID;
   const entry = findBuiltInModel(wanted);
   if (entry) {
     return {
@@ -368,7 +418,7 @@ export function listModelRegistry(settings: VideoGenSettings): {
   activeResolved: boolean;
   models: { id: string; aliases: string[]; provider: string; keyReady: boolean }[];
 } {
-  const wanted = settings.defaultModel ?? 'seedance';
+  const wanted = settings.defaultModel ?? DEFAULT_VIDEO_MODEL_ID;
   const active = resolveModel(settings, wanted);
   return {
     activeId: active?.entry.id ?? wanted,

--- a/packages/pi-video-gen/src/errors.ts
+++ b/packages/pi-video-gen/src/errors.ts
@@ -75,6 +75,7 @@ const PROVIDER_LABELS: Record<VideoApiStyle, string> = {
   dashscope: 'DashScope',
   openrouter: 'OpenRouter',
   newapi: 'NewAPI',
+  minimax: 'MiniMax',
 };
 
 export function providerLabel(style: VideoApiStyle): string {

--- a/packages/pi-video-gen/src/index.ts
+++ b/packages/pi-video-gen/src/index.ts
@@ -12,6 +12,7 @@ import {
 import { Type } from 'typebox';
 import { runCompose } from './compose.js';
 import {
+  DEFAULT_VIDEO_MODEL_ID,
   listModelRegistry,
   loadVideoGenSettings,
   resolveModel,
@@ -47,6 +48,7 @@ import {
 import { arkAdapter } from './providers/ark.js';
 import { dashscopeAdapter } from './providers/dashscope.js';
 import { klingAdapter } from './providers/kling.js';
+import { minimaxAdapter } from './providers/minimax.js';
 import { newapiAdapter } from './providers/newapi.js';
 import { openrouterAdapter } from './providers/openrouter.js';
 import { requestFingerprint } from './providers/request.js';
@@ -69,6 +71,7 @@ const ADAPTERS: Partial<Record<VideoApiStyle, VideoProviderAdapter>> = {
   ark: arkAdapter,
   dashscope: dashscopeAdapter,
   kling: klingAdapter,
+  minimax: minimaxAdapter,
   newapi: newapiAdapter,
   openrouter: openrouterAdapter,
 };
@@ -77,6 +80,7 @@ const ENV_VAR_BY_STYLE: Record<VideoApiStyle, string> = {
   ark: 'ARK_API_KEY',
   dashscope: 'DASHSCOPE_API_KEY',
   kling: 'KLING_API_KEY',
+  minimax: 'MINIMAX_API_KEY',
   newapi: 'NEWAPI_API_KEY',
   openrouter: 'OPENROUTER_API_KEY',
 };
@@ -232,7 +236,7 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
     const resolved = resolveModel(settings);
     if (!resolved) {
       return errResult(
-        `Cannot resolve model "${settings.defaultModel ?? 'seedance'}" against the built-in registry. Run /video-gen models to see available ids and aliases, or fix "pi-video-gen.defaultModel" in settings.`,
+        `Cannot resolve model "${settings.defaultModel ?? DEFAULT_VIDEO_MODEL_ID}" against the built-in registry. Run /video-gen models to see available ids and aliases, or fix "pi-video-gen.defaultModel" in settings.`,
       );
     }
     const caps = resolved.entry.capabilities;
@@ -668,7 +672,7 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
       const resolved = resolveModel(settings);
       if (!resolved) {
         return errResult(
-          `Cannot resolve model "${settings.defaultModel ?? 'seedance'}". Run /video-gen models, or fix pi-video-gen.defaultModel.`,
+          `Cannot resolve model "${settings.defaultModel ?? DEFAULT_VIDEO_MODEL_ID}". Run /video-gen models, or fix pi-video-gen.defaultModel.`,
         );
       }
       const adapter = ADAPTERS[resolved.provider.style];
@@ -1081,7 +1085,7 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
     const resolved = resolveModel(settings);
     if (!resolved) {
       checks.push(
-        `❌ defaultModel "${settings.defaultModel ?? 'seedance'}" not in registry — fix pi-video-gen.defaultModel`,
+        `❌ defaultModel "${settings.defaultModel ?? DEFAULT_VIDEO_MODEL_ID}" not in registry — fix pi-video-gen.defaultModel`,
       );
     } else {
       const label = providerLabel(resolved.provider.style);

--- a/packages/pi-video-gen/src/providers/minimax.ts
+++ b/packages/pi-video-gen/src/providers/minimax.ts
@@ -1,0 +1,241 @@
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import {
+  AmbiguousSubmitError,
+  httpStatusError,
+  missingKeyError,
+  networkError,
+  safeBasename,
+  VideoGenError,
+} from '../errors.js';
+import type {
+  RemoteTaskHandle,
+  RemoteTaskStatus,
+  VideoFileMeta,
+  VideoProviderAdapter,
+} from '../types.js';
+import { requestFingerprint } from './request.js';
+import { downloadFile } from './task.js';
+
+/**
+ * MiniMax video generation API v2 (MiniMax-H3).
+ *
+ *   POST {baseUrl}/v2/video_generation              → { task_id }
+ *   GET  {baseUrl}/v2/query/video_generation/{id}   → task.status / task.content.url
+ *
+ * Docs: https://platform.minimax.io/docs/api-reference/video-generation-v2-create
+ * (China mirror: platform.minimaxi.com — same schema, host api.minimaxi.com).
+ *
+ * - Auth: `Authorization: Bearer {apiKey}`; keys are REGION-LOCKED — an
+ *   international (minimax.io) key 401s on api.minimaxi.com and vice versa.
+ * - The prompt and frames ride in a multimodal `content` array: one required
+ *   `text` item plus `image_url` items carrying a `role`
+ *   (first_frame / last_frame / reference_image). Images may be public URLs
+ *   or base64 data URIs — we always send data URIs read from local files.
+ * - `ratio`: REQUIRED and non-adaptive for text-to-video; IGNORED (forced
+ *   adaptive) once a first frame is present; optional for reference-only.
+ * - v2 has NO audio toggle, NO idempotency/external-task-id field and NO
+ *   documented cancel endpoint — an ambiguous submit is parked for manual
+ *   resolution, never auto-retried (same policy as dashscope/newapi).
+ * - The result URL at task.content.url is a time-limited CDN link — download
+ *   promptly. Tasks are queryable for 7 days.
+ */
+
+// International default; mainland-China accounts set baseUrl to
+// https://api.minimaxi.com (keys do not work cross-region).
+export const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
+
+const MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+};
+
+async function imageFileToDataUri(path: string): Promise<string> {
+  const mime = MIME_BY_EXT[extname(path).toLowerCase()];
+  if (!mime) {
+    throw new VideoGenError(
+      `Reference image must be png/jpg/webp: ${safeBasename(path)}`,
+      'minimax: unsupported image extension',
+    );
+  }
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(path);
+  } catch {
+    throw new VideoGenError(
+      `Reference image is not readable: ${safeBasename(path)}`,
+      'minimax: image unreadable',
+    );
+  }
+  return `data:${mime};base64,${bytes.toString('base64')}`;
+}
+
+function ambiguousSubmitError(): AmbiguousSubmitError {
+  return new AmbiguousSubmitError(
+    'Task creation failed with an ambiguous result (network error or server 5xx). The provider MAY have created a paid task — check the MiniMax console before retrying to avoid double billing.',
+    'minimax submit: ambiguous outcome',
+  );
+}
+
+type MinimaxTask = {
+  id?: string;
+  status?: string;
+  error?: { code?: string; message?: string };
+  content?: { url?: string };
+};
+
+function mapTask(task: MinimaxTask, handle: RemoteTaskHandle): RemoteTaskStatus {
+  switch (task.status) {
+    case 'queued':
+      return { phase: 'pending' };
+    case 'running':
+      return { phase: 'running' };
+    case 'succeeded': {
+      const videoUrl = task.content?.url;
+      if (!videoUrl) {
+        throw new VideoGenError(
+          'The task succeeded but returned no video URL. Report this with the task id.',
+          'minimax inspect: succeeded without url',
+        );
+      }
+      return { phase: 'succeeded', videoUrl };
+    }
+    case 'failed':
+      return { phase: 'failed', message: task.error?.message ?? 'unknown provider error' };
+    case 'cancelled':
+      return { phase: 'failed', message: 'task was cancelled on the provider' };
+    default:
+      throw new VideoGenError(
+        `The provider returned an unknown task status. Task id kept for support: ${handle.taskId}.`,
+        'minimax inspect: unknown status',
+      );
+  }
+}
+
+export const minimaxAdapter: VideoProviderAdapter = {
+  async submit(provider, remoteModelId, params, fetchImpl, signal): Promise<RemoteTaskHandle> {
+    if (!provider.apiKey) {
+      throw missingKeyError('minimax', 'MINIMAX_API_KEY', provider.apiKeyPath);
+    }
+    if (params.lastFramePath && !params.firstFramePath) {
+      throw new VideoGenError(
+        'MiniMax requires a first frame when a last frame is given. Add firstFrame or remove lastFrame.',
+        'minimax: last frame without first frame',
+      );
+    }
+    if (params.firstFramePath && params.referenceImagePaths?.length) {
+      throw new VideoGenError(
+        'MiniMax supports either first/last frames OR reference images, not both in one call.',
+        'minimax: mixed frame and references',
+      );
+    }
+
+    const content: Record<string, unknown>[] = [{ type: 'text', text: params.prompt }];
+    const pushImage = async (role: string, path: string) => {
+      content.push({
+        type: 'image_url',
+        image_url: { url: await imageFileToDataUri(path) },
+        role,
+      });
+    };
+    if (params.firstFramePath) await pushImage('first_frame', params.firstFramePath);
+    if (params.lastFramePath) await pushImage('last_frame', params.lastFramePath);
+    for (const path of params.referenceImagePaths ?? []) await pushImage('reference_image', path);
+
+    const body: Record<string, unknown> = {
+      model: remoteModelId,
+      content,
+      aigc_watermark: false,
+    };
+    if (params.resolution) body.resolution = params.resolution;
+    if (params.durationSec != null) body.duration = params.durationSec;
+    // A first frame forces ratio=adaptive server-side — sending one is ignored;
+    // t2v requires a concrete ratio, reference-only takes it optionally.
+    if (params.aspectRatio && !params.firstFramePath) body.ratio = params.aspectRatio;
+
+    let res: Response;
+    try {
+      res = await fetchImpl(`${provider.baseUrl}/v2/video_generation`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${provider.apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+        signal: signal ?? null,
+      });
+    } catch {
+      throw ambiguousSubmitError();
+    }
+    if (!res.ok) {
+      if (res.status >= 500) throw ambiguousSubmitError();
+      throw httpStatusError('minimax', 'submit', res.status);
+    }
+
+    let taskId: string | undefined;
+    try {
+      const json = (await res.json()) as { task_id?: string };
+      taskId = json.task_id;
+    } catch {
+      throw ambiguousSubmitError();
+    }
+    if (!taskId) {
+      // 2xx but no id: the task MAY exist server-side — this is ambiguous,
+      // not a clean failure, and must park the shot rather than re-submit.
+      throw new AmbiguousSubmitError(
+        'The provider accepted the request but returned no task id. Not retrying automatically; check the MiniMax console.',
+        'minimax submit: no task id',
+      );
+    }
+    return {
+      taskId,
+      submittedAt: new Date().toISOString(),
+      requestFingerprint: requestFingerprint(remoteModelId, params),
+    };
+  },
+
+  async inspect(provider, handle, fetchImpl, signal): Promise<RemoteTaskStatus> {
+    if (!provider.apiKey) {
+      throw missingKeyError('minimax', 'MINIMAX_API_KEY', provider.apiKeyPath);
+    }
+
+    let res: Response;
+    try {
+      res = await fetchImpl(
+        `${provider.baseUrl}/v2/query/video_generation/${encodeURIComponent(handle.taskId)}`,
+        {
+          headers: { authorization: `Bearer ${provider.apiKey}` },
+          signal: signal ?? null,
+        },
+      );
+    } catch {
+      throw networkError('minimax', 'inspect');
+    }
+    if (!res.ok) throw httpStatusError('minimax', 'inspect', res.status);
+
+    const json = (await res.json()) as { task?: MinimaxTask };
+    if (!json.task || typeof json.task !== 'object') {
+      throw new VideoGenError(
+        'The provider returned a malformed task payload. Task id kept for support.',
+        'minimax inspect: malformed payload',
+      );
+    }
+    return mapTask(json.task, handle);
+  },
+
+  async downloadTo(
+    _provider,
+    _handle,
+    videoUrl,
+    destPath,
+    fetchImpl,
+    signal,
+  ): Promise<VideoFileMeta> {
+    // MiniMax result URLs are time-limited CDN links; download promptly.
+    return downloadFile({ url: videoUrl, destPath, fetchImpl, signal });
+  },
+
+  // cancel: no documented task-cancellation endpoint on the v2 API.
+};

--- a/packages/pi-video-gen/src/providers/models.ts
+++ b/packages/pi-video-gen/src/providers/models.ts
@@ -6,6 +6,12 @@ import type { BuiltInVideoModel } from '../types.js';
  * (Seedance 2.5 stays on the roadmap until its API ID and parameter contract
  * are officially published).
  *
+ * Alias rule: every alias must carry the model's version/generation marker
+ * (seedance-2.0, kling-v3-turbo, minimax-h3). A version-less vendor alias
+ * (seedance, kling, minimax) becomes a trap the day the next generation
+ * ships — it either keeps pointing at the old model or silently re-bills
+ * users under a new one. Enforced by the registry test.
+ *
  * Capability values reflect provider documentation as of 2026-07 and are
  * PENDING live verification (run /video-gen doctor + a small paid clip):
  * - Seedance 2.0: https://www.volcengine.com/docs/82379/1520757
@@ -14,7 +20,7 @@ import type { BuiltInVideoModel } from '../types.js';
 export const BUILT_IN_VIDEO_MODELS: BuiltInVideoModel[] = [
   {
     id: 'doubao-seedance-2-0-260128',
-    aliases: ['seedance', 'seedance-2.0', 'seedance-std'],
+    aliases: ['seedance-2.0', 'seedance-2.0-std'],
     provider: 'ark',
     capabilities: {
       maxReferenceImages: 9,
@@ -30,7 +36,7 @@ export const BUILT_IN_VIDEO_MODELS: BuiltInVideoModel[] = [
   },
   {
     id: 'doubao-seedance-2-0-fast-260128',
-    aliases: ['seedance-fast'],
+    aliases: ['seedance-2.0-fast'],
     provider: 'ark',
     capabilities: {
       maxReferenceImages: 9,
@@ -46,7 +52,7 @@ export const BUILT_IN_VIDEO_MODELS: BuiltInVideoModel[] = [
   },
   {
     id: 'happyhorse-1.1',
-    aliases: ['happyhorse', 'happyhorse-1.1'],
+    aliases: ['happyhorse-1.1'],
     provider: 'dashscope',
     capabilities: {
       maxReferenceImages: 9,
@@ -80,7 +86,7 @@ export const BUILT_IN_VIDEO_MODELS: BuiltInVideoModel[] = [
     // Verified against kling.ai/document-api (2026-07): model id is the URL
     // path segment. Turbo: first-frame only, silent, 720p/1080p.
     id: 'kling-3.0-turbo',
-    aliases: ['kling', 'kling-turbo', 'kling-v3-turbo'],
+    aliases: ['kling-v3-turbo'],
     provider: 'kling',
     capabilities: {
       maxReferenceImages: 1,
@@ -97,7 +103,7 @@ export const BUILT_IN_VIDEO_MODELS: BuiltInVideoModel[] = [
   {
     // Kling 3.0 "Omni": last_frame, native audio, 4k.
     id: 'kling-3.0',
-    aliases: ['kling-omni', 'kling-v3-omni', 'kling-3.0-omni'],
+    aliases: ['kling-v3-omni', 'kling-3.0-omni'],
     provider: 'kling',
     capabilities: {
       maxReferenceImages: 2,
@@ -115,7 +121,7 @@ export const BUILT_IN_VIDEO_MODELS: BuiltInVideoModel[] = [
     // Per OpenRouter docs example (2026-07): 5s/8s, 720p, 16:9, audio, flf.
     // Live list: GET https://openrouter.ai/api/v1/videos/models
     id: 'google/veo-3.1',
-    aliases: ['veo', 'veo-3.1'],
+    aliases: ['veo-3.1'],
     provider: 'openrouter',
     capabilities: {
       maxReferenceImages: 2,
@@ -130,8 +136,28 @@ export const BUILT_IN_VIDEO_MODELS: BuiltInVideoModel[] = [
     defaultDurationSec: 8,
   },
   {
+    // Per MiniMax v2 docs (2026-08): resolution 768P|2K, duration 4-15s, ratio
+    // 16:9|4:3|1:1|3:4|9:16|21:9 (t2v must be concrete — 'adaptive' is rejected),
+    // first/last frame + ≤9 reference images, no audio toggle.
+    // https://platform.minimax.io/docs/api-reference/video-generation-v2-create
+    id: 'MiniMax-H3',
+    aliases: ['minimax-h3', 'h3'],
+    provider: 'minimax',
+    capabilities: {
+      maxReferenceImages: 9,
+      durations: [4, 15],
+      resolutions: ['768P', '2K'],
+      aspectRatios: ['16:9', '4:3', '1:1', '3:4', '9:16', '21:9'],
+      nativeAudio: false,
+      supportsFirstLastFrame: true,
+    },
+    defaultResolution: '768P',
+    defaultAspectRatio: '16:9',
+    defaultDurationSec: 5,
+  },
+  {
     id: 'doubao-seedance-2-0-mini-260615',
-    aliases: ['seedance-mini'],
+    aliases: ['seedance-2.0-mini'],
     provider: 'ark',
     capabilities: {
       maxReferenceImages: 9,

--- a/packages/pi-video-gen/src/types.ts
+++ b/packages/pi-video-gen/src/types.ts
@@ -11,7 +11,7 @@
  */
 
 /** Wire format, NOT vendor — the same model via official or proxy endpoints differs only in baseUrl. */
-export type VideoApiStyle = 'ark' | 'kling' | 'dashscope' | 'openrouter' | 'newapi';
+export type VideoApiStyle = 'ark' | 'kling' | 'dashscope' | 'openrouter' | 'newapi' | 'minimax';
 
 export type VideoModelCapabilities = {
   /** Max reference images a request may carry (0 = text-to-video only). */
@@ -57,10 +57,12 @@ export type CustomVideoModel = {
   /** Optional display name. */
   name?: string | undefined;
   /**
-   * Capability declaration driving tool schema and preflight. Omitted fields
-   * fall back to conservative defaults (no audio, no last-frame, 720p, 16:9).
+   * Capability declaration driving tool schema and preflight. Every field is
+   * optional; omitted fields fall back to the built-in registry entry of the
+   * same id when one exists, else to conservative defaults (no audio, no
+   * last-frame, 720p, 16:9).
    */
-  capabilities?: VideoModelCapabilities | undefined;
+  capabilities?: Partial<VideoModelCapabilities> | undefined;
   defaultResolution?: string | undefined;
   defaultAspectRatio?: string | undefined;
   defaultDurationSec?: number | undefined;


### PR DESCRIPTION
## Summary

Adds the MiniMax video-generation v2 API (MiniMax-H3) as a new `minimax` wire format, lets custom-provider models inherit built-in capabilities when settings don't declare them, and cleans registry aliases to version-pinned forms only (intentional break — the plugin is pre-adoption, confirmed with the owner).

- **`minimax` adapter** (`providers/minimax.ts`): `POST /v2/video_generation` → `GET /v2/query/video_generation/{task_id}`. Multimodal `content[]` with `first_frame` / `last_frame` / `reference_image` roles (local images sent as base64 data URIs); `768P`/`2K`, 4–15s; ratio sent for t2v (required, non-adaptive) and reference-only, omitted once a first frame is present (server forces adaptive). v2 has no audio toggle, no idempotency key and no cancel endpoint, so ambiguous submits park instead of auto-retrying. Keys are region-locked: default `api.minimax.io`, mainland-China keys via `providers.minimax.baseUrl` → `https://api.minimaxi.com`; auth via `providers.minimax.apiKey` / `MINIMAX_API_KEY`.
- **Capability inheritance** (`resolveCustomModel`): a `customProviders` model whose `id` names a built-in model (e.g. `MiniMax-H3` behind a relay) inherits the registry capability table and defaults per-field (`inheritDefault`: explicit setting → built-in default if still valid → first listed value); unknown ids keep the conservative 720p/16:9 profile. `CustomVideoModel.capabilities` widened to `Partial<…>` to match the long-standing per-field runtime validation.
- **BREAKING — alias cleanup**: all version-less vendor aliases removed (`seedance`, `seedance-fast`, `seedance-mini`, `seedance-std`, `happyhorse`, `kling`, `kling-turbo`, `kling-omni`, `veo`, `minimax`) — a version-less alias becomes a trap the day the next generation ships. Every alias must now carry a version marker, enforced by a registry test. The default-model fallback is the full id `doubao-seedance-2-0-260128` (`DEFAULT_VIDEO_MODEL_ID`) instead of the removed `seedance` alias. Users with `defaultModel: "seedance"` etc. must switch to a pinned alias (e.g. `seedance-2.0`); accepted per owner (pre-adoption plugin).

Smallest change: each wire format is one adapter file following the established dashscope/kling pattern; registry/config/index touchpoints are the six existing parallel lists; inheritance reuses `findBuiltInModel` rather than a parallel table.

## Verification

- `pnpm pr-check` (build + test + typecheck): 117 test files / 1721 tests pass; Biome clean. Pre-commit hook re-ran the same suite green.
- New tests: `minimax.test.ts` (submit body shapes for t2v/i2v/flf/reference, guard rejections, ambiguous-submit policy, inspect status mapping, 404 → `RemoteTaskNotFoundError`); registry tests (alias version-marker invariant, removed aliases no longer resolve); `config.test.ts` (capability inheritance, per-field override, conservative fallback for unknown ids).
- Two-axis code review (standards vs repo CLAUDE.md + spec vs the official MiniMax v2 docs) run twice; all findings fixed and re-verified clean.
- Not run: live smoke against a real MiniMax account — the registry header already marks capability values as pending live verification (`/video-gen doctor` + one small paid clip), same as the other providers.

## Checklist

- [x] I read the applicable `AGENTS.md` files for every changed path.
- [x] This PR contains no unrelated refactors or generated files.
- [x] Behavior and configuration changes include relevant tests, or the reason they do not is explained above.
- [x] Public tool, command, setting, or user-facing behavior changes include the corresponding documentation and prompt guidance.
