### PR TITLE
ci: register ext:video-gen in the PR labeler catalog

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -65,7 +65,7 @@ jobs:
             const EXT_PACKAGES = [
               'attachments', 'browser-use', 'channels', 'computer-use', 'dingtalk',
               'goal', 'image-gen', 'lark', 'memory', 'security', 'task-scheduler',
-              'teamwork', 'telemetry', 'web-access', 'wecom',
+              'teamwork', 'telemetry', 'video-gen', 'web-access', 'wecom',
             ];
             for (const n of EXT_PACKAGES) defs.set(`ext:${n}`, ['5B21B6', `Changes to packages/pi-${n}`]);
             defs.set('core:shared', ['8B5CF6', 'Changes to packages/shared']);


### PR DESCRIPTION
## Summary

`packages/pi-video-gen` was never registered in the labeler's `EXT_PACKAGES` catalog (added after the catalog was written). The path rule still derived `ext:video-gen` from changed files, so `addLabels` auto-created the repo label with GitHub's default `#ededed` (white), while `ensureLabels` had no def for it — and never recolors existing labels (422 already-exists is swallowed by design).

One-word fix: add `'video-gen'` to `EXT_PACKAGES` so the catalog defines it as `#5B21B6` like every other `ext:*` label. The existing repo label's color was already corrected out-of-band (`gh label edit`), so no migration is needed once this lands; verified every other `packages/pi-*` directory is covered (incl. the `memory-mem0` → `ext:memory` special case).

## Verification

- `gh label list`: all other `ext:*` labels are `#5B21B6`; only `ext:video-gen` was `#ededed`, now `#5B21B6` after the manual edit.
- Compared `EXT_PACKAGES` against `ls packages/pi-*/` — `video-gen` was the only missing package.
- Workflow YAML change only; no code paths affected. Not run: the labeler itself (runs on PR events from the base branch).

## Checklist

- [x] I read the applicable `AGENTS.md` files for every changed path.
- [x] This PR contains no unrelated refactors or generated files.
- [x] Behavior and configuration changes include relevant tests, or the reason they do not is explained above.
- [x] Public tool, command, setting, or user-facing behavior changes include the corresponding documentation and prompt guidance.
