### PR TITLE
fix(computer-use): wait for Windows daemon readiness

### DIFF
--- a/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
+++ b/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
@@ -7,6 +7,7 @@ import {
   resolveUnixSocketPath,
   SanitizingJsonSchemaValidator,
   sanitizeSchemaFormats,
+  waitForDaemonStatus,
 } from '../mcp-client.js';
 
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({ Client: vi.fn() }));
@@ -53,6 +54,37 @@ describe('CuaDriverClient', () => {
       '/tmp/pi-cua-123-deadbeef.sock',
     );
     expect(Buffer.byteLength(resolveUnixSocketPath('/tmp', '123-deadbeef'))).toBeLessThan(91);
+  });
+
+  it('waits until the Windows daemon responds before opening the MCP proxy', async () => {
+    const checkStatus = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('named pipe is not ready'))
+      .mockRejectedValueOnce(new Error('named pipe is not ready'))
+      .mockResolvedValue(undefined);
+
+    await waitForDaemonStatus('cua-driver.exe', '\\\\.\\pipe\\pi-cua-test', undefined, checkStatus);
+
+    expect(checkStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops Windows daemon status retries when the session is aborted', async () => {
+    const controller = new AbortController();
+    const reason = new Error('session stopped');
+    const checkStatus = vi.fn(async () => {
+      controller.abort(reason);
+      throw new Error('named pipe is not ready');
+    });
+
+    await expect(
+      waitForDaemonStatus(
+        'cua-driver.exe',
+        '\\\\.\\pipe\\pi-cua-test',
+        controller.signal,
+        checkStatus,
+      ),
+    ).rejects.toBe(reason);
+    expect(checkStatus).toHaveBeenCalledOnce();
   });
 
   it('constructs the MCP Client with the sanitizing schema validator', async () => {

--- a/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
+++ b/packages/pi-computer-use/src/__tests__/mcp-client.test.ts
@@ -87,6 +87,19 @@ describe('CuaDriverClient', () => {
     expect(checkStatus).toHaveBeenCalledOnce();
   });
 
+  it('does not retry permanent Windows daemon status errors', async () => {
+    const cause = Object.assign(new Error('spawn failed'), { code: 'EACCES' });
+    const checkStatus = vi.fn().mockRejectedValue(cause);
+
+    await expect(
+      waitForDaemonStatus('cua-driver.exe', '\\\\.\\pipe\\pi-cua-test', undefined, checkStatus),
+    ).rejects.toMatchObject({
+      message: 'Cua Driver status check failed (EACCES).',
+      cause,
+    });
+    expect(checkStatus).toHaveBeenCalledOnce();
+  });
+
   it('constructs the MCP Client with the sanitizing schema validator', async () => {
     // biome-ignore lint/complexity/useArrowFunction: arrow functions are not constructible; the mock must survive `new Client(...)`.
     vi.mocked(Client).mockImplementation(function () {

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -22,6 +22,7 @@ import type { McpToolResult } from './tool-result.js';
 
 const MCP_TIMEOUT_MS = 60_000;
 const DAEMON_START_TIMEOUT_MS = 10_000;
+const PERMANENT_STATUS_ERROR_CODES = new Set(['EACCES', 'ENOENT', 'EPERM']);
 const DAEMON_LEASE_SCRIPT = `
 if IFS= read -r _; then exit 0; fi
 attempt=0
@@ -113,16 +114,25 @@ export async function waitForDaemonStatus(
     }),
 ): Promise<void> {
   const deadline = Date.now() + DAEMON_START_TIMEOUT_MS;
+  let lastError: unknown;
   while (Date.now() < deadline) {
     try {
       await checkStatus();
       return;
-    } catch {
+    } catch (error) {
       if (signal?.aborted) throw abortError(signal);
+      lastError = error;
+      const code =
+        error && typeof error === 'object' && 'code' in error && typeof error.code === 'string'
+          ? error.code
+          : undefined;
+      if (code && PERMANENT_STATUS_ERROR_CODES.has(code)) {
+        throw new Error(`Cua Driver status check failed (${code}).`, { cause: error });
+      }
     }
     await delay(50, signal);
   }
-  throw new Error('Cua Driver daemon did not respond to a status check.');
+  throw new Error('Cua Driver daemon did not respond to a status check.', { cause: lastError });
 }
 
 export interface DriverLayout {

--- a/packages/pi-computer-use/src/mcp-client.ts
+++ b/packages/pi-computer-use/src/mcp-client.ts
@@ -101,6 +101,30 @@ export function resolveUnixSocketPath(tempDir: string, suffix: string): string {
     : path.join('/tmp', filename);
 }
 
+export async function waitForDaemonStatus(
+  binaryPath: string,
+  socket: string,
+  signal?: AbortSignal,
+  checkStatus: () => Promise<unknown> = () =>
+    execFileAsync(binaryPath, ['status', '--socket', socket], {
+      signal,
+      timeout: 250,
+      windowsHide: true,
+    }),
+): Promise<void> {
+  const deadline = Date.now() + DAEMON_START_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    try {
+      await checkStatus();
+      return;
+    } catch {
+      if (signal?.aborted) throw abortError(signal);
+    }
+    await delay(50, signal);
+  }
+  throw new Error('Cua Driver daemon did not respond to a status check.');
+}
+
 export interface DriverLayout {
   binaryPath: string;
   appPath?: string;
@@ -420,6 +444,9 @@ export class CuaDriverClient {
     });
     this.daemonProcess = daemon;
     await this.waitForDaemonReady(daemon, socket, signal);
+    if (process.platform === 'win32') {
+      await waitForDaemonStatus(layout.binaryPath, socket, signal);
+    }
     return socket;
   }
 


### PR DESCRIPTION
## Summary
- wait for the Windows Cua Driver to answer a real status request after its startup log
- bound readiness polling and propagate session cancellation
- cover retry and abort behavior with regression tests

## Root cause
On Windows, the driver writes `daemon listening` before its named pipe can accept the MCP proxy connection. Starting the proxy immediately closes the transport and leaves only the recovery tool registered.

## Verification
- `pnpm --filter @amaster.ai/pi-computer-use exec vitest run src/__tests__/mcp-client.test.ts -t "Windows daemon"`
- `pnpm --filter @amaster.ai/pi-computer-use build`
- `pnpm --filter @amaster.ai/pi-computer-use typecheck`
- `pnpm exec biome check packages/pi-computer-use/src/mcp-client.ts packages/pi-computer-use/src/__tests__/mcp-client.test.ts`
- Windows bundled-driver smoke: 3/3 first-attempt connections, 50 tools each (811ms, 804ms, 815ms)
