### PR TITLE
feat(eval): add ViMax-Bench video quality eval for pi-video-gen

### DIFF
--- a/.github/workflows/agentic-eval.yml
+++ b/.github/workflows/agentic-eval.yml
@@ -13,10 +13,10 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: Which eval to run
+        description: Which eval to run (both = browser + computer; video is paid, always explicit)
         type: choice
         default: browser
-        options: [browser, computer, both]
+        options: [browser, computer, both, video]
       model:
         description: Model (provider is deepseek-integration)
         type: string
@@ -30,6 +30,15 @@ on:
         description: Limit to first N tasks (0 = all)
         type: string
         default: '0'
+      samples:
+        description: Video eval only — number of ViMax stories (each is 8-16 PAID clips)
+        type: string
+        default: '2'
+      tier:
+        description: Video eval only — story tier
+        type: choice
+        default: medium
+        options: [medium, long, all]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -219,5 +228,112 @@ jobs:
         with:
           name: computer-eval-results
           path: tests/eval/results/computer-tasks.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  video-eval:
+    name: Video eval (ViMax-Bench render quality)
+    if: inputs.target == 'video'
+    runs-on:
+      - instance-hnpsq9go
+      - linux
+      - x64
+    # One Medium story ≈ 9 paid clips + frames — tens of minutes per story.
+    timeout-minutes: 120
+    env:
+      PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
+      PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
+      # Same gateway image model integration.yml uses for pi-image-gen.
+      PI_EVAL_IMAGE_MODEL: doubao-seedream-5-0-lite-260128
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pi build environment
+        uses: ./.github/actions/setup-pi-build
+        with:
+          install-pi-cli: 'true'
+          set-pi-agent-dir: 'true'
+          install-video-tools: 'true'
+
+      - name: Guard — require provider secrets
+        run: |
+          set -euo pipefail
+          if [ -z "${PI_INTEGRATION_BASE_URL}" ] || [ -z "${PI_INTEGRATION_API_KEY}" ]; then
+            echo "::error::PI_INTEGRATION_BASE_URL / PI_INTEGRATION_API_KEY not set — cannot run eval"
+            exit 1
+          fi
+
+      - name: Write eval models.json from secrets
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/eval"
+          # apiKey is written literally from the secret; the file lives under
+          # RUNNER_TEMP and is not uploaded (same convention as the browser job).
+          cat > "$RUNNER_TEMP/eval/models.json" <<EOF
+          {
+            "providers": {
+              "deepseek-integration": {
+                "baseUrl": "${PI_INTEGRATION_BASE_URL}",
+                "api": "openai-completions",
+                "apiKey": "${PI_INTEGRATION_API_KEY}",
+                "models": [
+                  { "id": "${{ inputs.model }}", "name": "${{ inputs.model }}", "input": ["text"] }
+                ]
+              }
+            }
+          }
+          EOF
+          echo "MODELS_PATH=$RUNNER_TEMP/eval/models.json" >> "$GITHUB_ENV"
+
+      - name: Fetch ViMax-Bench
+        run: pnpm --filter @amaster.ai/pi-eval fetch:vimax
+
+      - name: Eval — pi-video-gen (ViMax-Bench slice)
+        run: |
+          set -euo pipefail
+          # --timeout caps ONE story at 45min so samples*N stays under the
+          # 120min job limit and results get written even if a story hangs.
+          pnpm --filter @amaster.ai/pi-eval eval:video -- \
+            --provider deepseek-integration \
+            --model "${{ inputs.model }}" \
+            --thinking "${{ inputs.thinking }}" \
+            --samples "${{ inputs.samples }}" \
+            --tier "${{ inputs.tier }}" \
+            --timeout 2700000 \
+            --models "$MODELS_PATH"
+
+      - name: Summarize
+        if: always()
+        run: |
+          set -euo pipefail
+          f=tests/eval/results/video-vimax.json
+          [ -f "$f" ] || { echo "no results"; exit 0; }
+          {
+            echo "## Video eval — ViMax-Bench render"
+            node -e '
+              const d = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+              const s = d.summary || {};
+              console.log("");
+              console.log(`- model: \`${s.model ?? "?"}\` + video \`${s.videoModel ?? "?"}\``);
+              console.log(`- completionRate: **${(s.completionRate ?? 0).toFixed(3)}** (${s.completed ?? 0}/${s.n ?? 0} stories)`);
+              console.log(`- specViolations (LLM re-planned the shot book): ${s.specViolations ?? 0}`);
+              console.log(`- avgTurns: ${(s.avgTurns ?? 0).toFixed(1)}`);
+              console.log(`- failureMix: \`${JSON.stringify(s.failureMix ?? {})}\``);
+              console.log("");
+              for (const r of d.rows ?? []) {
+                console.log(`- ${r.completed ? "✅" : "❌"} ${r.story} (type ${r.type}, ${r.shots} shots) — ${r.failureMode}`);
+              }
+              console.log("");
+              console.log("Quality scores: run `judge:video` locally with a vision model (see tests/eval/README).");
+            ' "$f"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: video-eval-results
+          path: tests/eval/results/video-vimax.json
           if-no-files-found: warn
           retention-days: 14

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -27,6 +27,8 @@ tests/eval/
   computer/
     run-computer.ts     # pi-computer-use L3 runner (real cua-driver via pi CLI; macOS-only)
     tasks.ts            # desktop task set + deterministic success predicates
+  video/
+    run-video.ts        # pi-video-gen ViMax-Bench runner (real shot-book pipeline via pi CLI)
 ```
 
 ## Quick start
@@ -174,9 +176,59 @@ The **Agentic Eval** workflow includes a `computer-eval` job (run it via the
 Linux runner it no-ops via the graceful skip above. Point the job's `runs-on` at
 a macOS runner with the TCC grants to get real numbers.
 
+## Video (pi-video-gen on ViMax-Bench — render quality + cross-shot consistency)
+
+Answers "how good is the video our shot-book pipeline actually produces" — a
+**quality** eval, unlike the L3 task-completion runners above. Input data is
+[HKUDS/ViMax](https://github.com/HKUDS/ViMax)'s `vimax_benchmark/` (MIT): 35
+multi-shot story specs (Type A = character persistence, B = background
+persistence, C = multi-person separability; Medium = 2 scenes/8-10 shots,
+Long = 3-4 scenes/12-16 shots). The runner converts each spec **deterministically**
+into a VideoProject shot book, then drives the real `pi` CLI to execute it
+(`image_generate` per shot frame → one `video_render`) — the LLM only executes
+the plan, so scores reflect render/orchestration quality, not planning variance.
+
+**COST WARNING: every story is 8-16 paid video clips + ~1 image per shot.**
+Always slice with `--samples`/`--tier`/`--story`.
+
+```bash
+pnpm --filter @amaster.ai/pi-eval fetch:vimax        # one-time, pinned commit
+
+# local: reuse your ~/.pi/agent video/image provider config
+pnpm --filter @amaster.ai/pi-eval eval:video -- --use-default-pi --model deepseek-v4-flash --samples 2 --tier medium
+
+# CI shape: generated extension settings from env (mirrors integration.yml's gateway)
+export PI_INTEGRATION_BASE_URL="https://your-gateway/v1"
+export PI_INTEGRATION_API_KEY="sk-..."
+export PI_EVAL_IMAGE_MODEL="doubao-seedream-5-0-lite-260128"
+pnpm --filter @amaster.ai/pi-eval eval:video -- --model deepseek-v4-flash --samples 2 --models "$MODELS"
+
+# VLM-judge the run (needs ffmpeg on PATH or FFMPEG_PATH, and a vision model)
+pnpm --filter @amaster.ai/pi-eval judge:video -- \
+  --input results/video-vimax.json --llm-model kimi-k2.6 --models "$MODELS"
+```
+
+Extra flags: `--tier medium|long|all`, `--story <id>`, `--video-model`
+(default `doubao-seedance-2-0-260128` via a newapi-shaped gateway),
+`--timeout` (default 2h per story — a full shot-book render takes tens of
+minutes). Artifacts (generated images, per-shot clips, `final_video.mp4`,
+judge frames) land in `results/artifacts/`.
+
+**Scoring.** `run-video.ts` reports pipeline health: `completionRate` (final
+video verified on disk), `specViolations` (runs where the LLM rewrote the shot
+book instead of executing it — the written `render-input.json`'s shot ids/order
+are compared against the spec), `avgTurns`, `failureMix`. `judge-video.ts`
+reports quality: a VLM scores `consistency` (1-5, rubric keyed to the story's
+ViMax type) and per-shot `prompt_following` from probed mid-clip frames,
+aggregated overall and by type. The VLM judge reimplements the *spirit* of the
+paper's ViCLIP consistency metric — **scores are comparable across providers
+and across our own releases, not to the ViMax paper numbers** (that would
+require reimplementing ViCLIP; out of scope, see Status).
+
 ## Datasets
 
 - **LoCoMo** — multi-session conversational QA. Pulled from [snap-research/locomo](https://github.com/snap-research/locomo) (MIT). ~600 samples; runner takes `--samples N` for a slice.
+- **ViMax-Bench** — 35 multi-shot story specs for video consistency. Pulled from [HKUDS/ViMax](https://github.com/HKUDS/ViMax) (MIT), pinned commit in `scripts/fetch-vimax.ts`. Data only — scoring is ours.
 - LongMemEval / MemBench — TODO. Same fetch-on-demand pattern.
 
 We deliberately do **not** consume [OpenDataBox/MemoryData](https://github.com/OpenDataBox/MemoryData) directly — that repo has no license. We borrow its evaluation taxonomy (recall / conflict / multi-session / update) and pull data from each upstream.
@@ -227,6 +279,8 @@ Notes:
 Working, run manually (no CI hook). Open items:
 
 - Only LoCoMo wired; LongMemEval / MemBench are TODO (same fetch-on-demand pattern).
+- Video eval v1 executes pre-planned shot books only; LLM-planned runs (planning
+  quality) and a ViCLIP reimplementation (paper-comparable numbers) are TODO.
 - Multi-sample averaging to shrink variance (currently 2 samples).
 - Judge variance reduction (multi-pass majority vote).
 - Reasoning models need generous `max_tokens` (write loop uses 4096, judge 512) —

--- a/tests/eval/package.json
+++ b/tests/eval/package.json
@@ -6,11 +6,14 @@
   "type": "module",
   "scripts": {
     "fetch:locomo": "tsx scripts/fetch-locomo.ts",
+    "fetch:vimax": "tsx scripts/fetch-vimax.ts",
     "eval:memory:mem0": "tsx memory/run-mem0.ts",
     "eval:memory:curated": "tsx memory/run-memory.ts",
     "eval:browser": "tsx browser/run-browser.ts",
     "eval:computer": "tsx computer/run-computer.ts",
-    "judge:llm": "tsx scripts/judge-llm.ts"
+    "eval:video": "tsx video/run-video.ts",
+    "judge:llm": "tsx scripts/judge-llm.ts",
+    "judge:video": "tsx scripts/judge-video.ts"
   },
   "dependencies": {
     "@amaster.ai/pi-memory": "workspace:*",

--- a/tests/eval/scripts/fetch-vimax.ts
+++ b/tests/eval/scripts/fetch-vimax.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Fetch ViMax-Bench story specs into datasets/vimax/.
+ * Source: https://github.com/HKUDS/ViMax (MIT), vimax_benchmark/ — 35 multi-shot
+ * story specs + benchmark_index.json. Data only: the scoring protocol lives in
+ * the paper (arXiv 2606.07649) and is reimplemented in scripts/judge-video.ts.
+ * Pinned to a commit so upstream edits don't silently shift the eval.
+ *
+ * Usage: pnpm --filter @amaster.ai/pi-eval fetch:vimax
+ */
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const COMMIT = '05a48943878312d88fe5a016c12a9654940ecc43';
+const TREE_URL = `https://api.github.com/repos/HKUDS/ViMax/git/trees/${COMMIT}?recursive=1`;
+const RAW_BASE = `https://raw.githubusercontent.com/HKUDS/ViMax/${COMMIT}/`;
+const OUT_DIR = path.resolve(import.meta.dirname, '..', 'datasets', 'vimax');
+
+async function main() {
+  const res = await fetch(TREE_URL, { headers: { 'User-Agent': 'pi-eval' } });
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${TREE_URL}`);
+  const tree = (await res.json()) as { tree?: Array<{ path: string; type: string }> };
+  const files = (tree.tree ?? [])
+    .filter((e) => e.type === 'blob' && /^vimax_benchmark\/[^/]+\.json$/.test(e.path))
+    .map((e) => e.path)
+    .sort();
+  if (files.length === 0) {
+    throw new Error('no vimax_benchmark/*.json in pinned tree — upstream restructured?');
+  }
+
+  await mkdir(OUT_DIR, { recursive: true });
+  for (const p of files) {
+    const url = RAW_BASE + p;
+    const out = path.join(OUT_DIR, path.basename(p));
+    process.stderr.write(`[fetch-vimax] ${url} -> ${out}\n`);
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(`HTTP ${r.status} for ${url}`);
+    await writeFile(out, await r.text());
+  }
+  process.stderr.write(`[fetch-vimax] done (${files.length} files @ ${COMMIT.slice(0, 7)})\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[fetch-vimax] error: ${err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/scripts/judge-llm.ts
+++ b/tests/eval/scripts/judge-llm.ts
@@ -11,9 +11,16 @@
  *     --models /Users/weaxs/Desktop/Workspace/pi-agent/.pi/models.json \
  *     --concurrency 4
  */
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
+import {
+  chatCompletion,
+  getFlag,
+  type JudgeConfig,
+  loadJudgeConfig,
+  runPool,
+} from '../src/judge-client.js';
 
 interface Args {
   input: string;
@@ -40,26 +47,18 @@ interface Bundle {
   rows: Row[];
 }
 
-interface ModelsJson {
-  providers: Record<string, { apiKey: string; baseUrl?: string }>;
-}
-
 function parseArgs(): Args {
   const argv = process.argv.slice(2);
-  const get = (flag: string, dflt: string) => {
-    const i = argv.indexOf(flag);
-    return i >= 0 ? argv[i + 1] : dflt;
-  };
   return {
-    input: get('--input', 'results/mem0-locomo-oss.json'),
+    input: getFlag(argv, '--input', 'results/mem0-locomo-oss.json'),
     modelsPath:
-      get('--models', '') ||
+      getFlag(argv, '--models', '') ||
       process.env.PI_MODELS_PATH ||
       path.join(os.homedir(), '.pi', 'agent', 'models.json'),
-    llmProvider: get('--llm-provider', 'amaster'),
-    llmModel: get('--llm-model', 'deepseek-v4-flash'),
-    concurrency: Number(get('--concurrency', '4')),
-    limit: Number(get('--limit', '0')),
+    llmProvider: getFlag(argv, '--llm-provider', 'amaster'),
+    llmModel: getFlag(argv, '--llm-model', 'deepseek-v4-flash'),
+    concurrency: Number(getFlag(argv, '--concurrency', '4')),
+    limit: Number(getFlag(argv, '--limit', '0')),
   };
 }
 
@@ -83,77 +82,29 @@ function buildUserPrompt(question: string, gold: string, blob: string): string {
   ].join('\n');
 }
 
-interface JudgeConfig {
-  apiKey: string;
-  baseUrl: string;
-  model: string;
-}
-
-async function loadJudge(args: Args): Promise<JudgeConfig> {
-  const raw = await readFile(args.modelsPath, 'utf8');
-  const models = JSON.parse(raw) as ModelsJson;
-  const entry = models.providers?.[args.llmProvider];
-  if (!entry?.apiKey || !entry?.baseUrl) {
-    throw new Error(`provider ${args.llmProvider} missing apiKey/baseUrl in ${args.modelsPath}`);
-  }
-  return { apiKey: entry.apiKey, baseUrl: entry.baseUrl, model: args.llmModel };
-}
-
-function isTransient(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  const cause = err instanceof Error && err.cause instanceof Error ? err.cause.message : '';
-  const haystack = `${msg}\n${cause}`;
-  return /\b(5\d\d|429|overloaded|timeout|timed out|ETIMEDOUT|ECONN|EAI_AGAIN|ENOTFOUND|getaddrinfo|fetch failed|socket|Connection error|APIConnection)\b/i.test(
-    haystack,
-  );
-}
-
 async function callJudge(cfg: JudgeConfig, prompt: string): Promise<'YES' | 'NO'> {
-  const delays = [1000, 4000, 16000];
-  let lastErr: unknown;
-  for (let attempt = 0; attempt <= delays.length; attempt++) {
-    try {
-      const res = await fetch(`${cfg.baseUrl}/chat/completions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${cfg.apiKey}`,
-        },
-        body: JSON.stringify({
-          model: cfg.model,
-          temperature: 0,
-          // deepseek-v4-flash is a reasoning model — reasoning_tokens eat the
-          // budget before content is emitted. Give it enough headroom.
-          max_tokens: 512,
-          messages: [
-            { role: 'system', content: JUDGE_SYSTEM },
-            { role: 'user', content: prompt },
-          ],
-        }),
-      });
-      if (!res.ok) {
-        const body = await res.text();
-        throw new Error(`HTTP ${res.status}: ${body.slice(0, 200)}`);
-      }
-      const data = (await res.json()) as {
-        choices?: Array<{ message?: { content?: string } }>;
-      };
-      const text = (data.choices?.[0]?.message?.content ?? '').trim().toUpperCase();
-      // Reasoning models sometimes prepend their scratchpad. Find the last
-      // clear YES / NO signal in the response.
-      const yesIdx = text.lastIndexOf('YES');
-      const noIdx = text.lastIndexOf('NO');
-      if (yesIdx < 0 && noIdx < 0) {
-        throw new Error(`unexpected judge reply: ${text.slice(-120)}`);
-      }
-      return yesIdx > noIdx ? 'YES' : 'NO';
-    } catch (err) {
-      lastErr = err;
-      if (attempt === delays.length || !isTransient(err)) break;
-      await new Promise((r) => setTimeout(r, delays[attempt]));
-    }
+  // deepseek-v4-flash is a reasoning model — reasoning_tokens eat the budget
+  // before content is emitted. 512 gives it enough headroom.
+  const text = (
+    await chatCompletion(cfg, {
+      maxTokens: 512,
+      temperature: 0,
+      messages: [
+        { role: 'system', content: JUDGE_SYSTEM },
+        { role: 'user', content: prompt },
+      ],
+    })
+  )
+    .trim()
+    .toUpperCase();
+  // Reasoning models sometimes prepend their scratchpad. Find the last clear
+  // YES / NO signal in the response.
+  const yesIdx = text.lastIndexOf('YES');
+  const noIdx = text.lastIndexOf('NO');
+  if (yesIdx < 0 && noIdx < 0) {
+    throw new Error(`unexpected judge reply: ${text.slice(-120)}`);
   }
-  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+  return yesIdx > noIdx ? 'YES' : 'NO';
 }
 
 async function main() {
@@ -171,32 +122,23 @@ async function main() {
     );
   }
 
-  const cfg = await loadJudge(args);
+  const cfg = loadJudgeConfig(args.modelsPath, args.llmProvider, args.llmModel);
   process.stderr.write(`[judge:llm] model=${cfg.model} concurrency=${args.concurrency}\n`);
 
-  let cursor = 0;
   let done = 0;
-  const worker = async (): Promise<void> => {
-    while (true) {
-      const idx = cursor++;
-      if (idx >= rows.length) return;
-      const r = rows[idx];
-      try {
-        const verdict = await callJudge(cfg, buildUserPrompt(r.question, r.gold, r.blob!));
-        r.judge = verdict === 'YES' ? 1 : 0;
-      } catch (err) {
-        r.judge = 0;
-        r.judgeError = err instanceof Error ? err.message.slice(0, 200) : String(err);
-      }
-      done++;
-      if (done % 20 === 0 || done === rows.length) {
-        process.stderr.write(`[judge:llm]   ${done}/${rows.length}\n`);
-      }
+  await runPool(rows, args.concurrency, async (r) => {
+    try {
+      const verdict = await callJudge(cfg, buildUserPrompt(r.question, r.gold, r.blob!));
+      r.judge = verdict === 'YES' ? 1 : 0;
+    } catch (err) {
+      r.judge = 0;
+      r.judgeError = err instanceof Error ? err.message.slice(0, 200) : String(err);
     }
-  };
-  await Promise.all(
-    Array.from({ length: Math.max(1, Math.min(args.concurrency, rows.length)) }, worker),
-  );
+    done++;
+    if (done % 20 === 0 || done === rows.length) {
+      process.stderr.write(`[judge:llm]   ${done}/${rows.length}\n`);
+    }
+  });
 
   const judged = rows.filter((r) => r.judgeError === undefined);
   const recallJudge = judged.reduce((a, r) => a + (r.judge ?? 0), 0) / Math.max(1, judged.length);

--- a/tests/eval/scripts/judge-video.ts
+++ b/tests/eval/scripts/judge-video.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * VLM-judge a results/video-vimax.json run: for each completed story, extract one
+ * mid-clip frame per shot and ask a vision model to score cross-shot consistency
+ * (rubric keyed to the story's ViMax type) plus per-shot prompt following.
+ * Writes results/video-vimax-judged.json.
+ *
+ * This reimplements the SPIRIT of ViMax-Bench's automatic consistency scoring
+ * (arXiv 2606.07649) with a VLM judge instead of ViCLIP embeddings — scores are
+ * for cross-provider comparison and self-regression, NOT comparable to the paper.
+ *
+ * Requires ffmpeg+ffprobe (FFMPEG_PATH/FFPROBE_PATH env or on PATH) and a
+ * vision-capable --llm-model.
+ *
+ * Usage:
+ *   pnpm --filter @amaster.ai/pi-eval judge:video -- \
+ *     --input results/video-vimax.json --llm-model kimi-k2.6 --models /path/to/models.json
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  chatCompletion,
+  getFlag,
+  type JudgeConfig,
+  loadJudgeConfig,
+  runPool,
+} from '../src/judge-client.js';
+import { loadVimax, type VimaxStory, type VimaxType } from '../src/loaders/vimax.js';
+
+interface Args {
+  input: string;
+  modelsPath: string;
+  llmProvider: string;
+  llmModel: string;
+  concurrency: number;
+  limit: number;
+}
+
+interface ResultRow {
+  story: string;
+  type: VimaxType;
+  tier: string;
+  shots: number;
+  completed: number;
+  finalVideoPath: string;
+}
+
+interface Bundle {
+  summary: Record<string, unknown>;
+  rows: ResultRow[];
+}
+
+interface ShotScore {
+  shot_id: string;
+  prompt_following: number;
+}
+
+interface StoryScore {
+  story: string;
+  type: VimaxType;
+  tier: string;
+  consistency?: number;
+  promptFollowing?: number;
+  perShot?: ShotScore[];
+  notes?: string;
+  judgeError?: string;
+}
+
+function parseArgs(): Args {
+  const argv = process.argv.slice(2);
+  return {
+    input: getFlag(argv, '--input', 'results/video-vimax.json'),
+    modelsPath:
+      getFlag(argv, '--models', '') ||
+      process.env.PI_MODELS_PATH ||
+      path.join(os.homedir(), '.pi', 'agent', 'models.json'),
+    llmProvider: getFlag(argv, '--llm-provider', 'amaster'),
+    llmModel: getFlag(argv, '--llm-model', 'kimi-k2.6'),
+    concurrency: Number(getFlag(argv, '--concurrency', '2')),
+    limit: Number(getFlag(argv, '--limit', '0')),
+  };
+}
+
+const TYPE_RUBRIC: Record<VimaxType, string> = {
+  A: 'CHARACTER PERSISTENCE — the same character keeps identity (face, hair, outfit, body) across every shot despite changing environment, lighting, and camera. 5 = identity indistinguishable throughout; 3 = same person but drifting details; 1 = a different person per shot.',
+  B: 'BACKGROUND PERSISTENCE — within the same scene, the space stays stable (geometry, layout, furniture, props). 5 = identical space across cuts; 3 = same room, rearranged details; 1 = unrelated rooms between shots of one scene.',
+  C: 'MULTI-PERSON SEPARABILITY — multiple visually distinct characters stay separable while interacting: no merging, no identity swaps, no attribute bleed. 5 = every character keeps their own identity throughout; 1 = characters merge or swap.',
+};
+
+function buildSystem(type: VimaxType): string {
+  return `You judge an AI-generated multi-shot video story for visual consistency. You see one mid-clip frame per shot, in story order, each labeled with the motion prompt it was generated from.
+
+Score:
+1. "consistency" (1-5, integer) — ${TYPE_RUBRIC[type]}
+2. "prompt_following" (1-5, integer) PER SHOT — does the frame match what the shot asked for (subject, composition, action)?
+
+Reply with STRICT JSON only, no prose:
+{"consistency": <1-5>, "per_shot": [{"shot_id": "<id>", "prompt_following": <1-5>}...], "notes": "<=200 chars"}`;
+}
+
+const FRAMES_ROOT = path.resolve(import.meta.dirname, '..', 'results', 'artifacts', 'frames');
+
+function ffmpegBin(): string {
+  return process.env.FFMPEG_PATH || 'ffmpeg';
+}
+
+function ffprobeBin(): string {
+  return process.env.FFPROBE_PATH || 'ffprobe';
+}
+
+/** Clip duration in seconds, 0 when unknown (ffprobe missing/unparseable). */
+let ffprobeWarned = false;
+function probeDuration(clipPath: string): number {
+  const r = spawnSync(
+    ffprobeBin(),
+    ['-v', 'error', '-show_entries', 'format=duration', '-of', 'csv=p=0', clipPath],
+    { stdio: 'pipe', timeout: 30_000 },
+  );
+  const d = Number.parseFloat(String(r.stdout).trim());
+  const ok = Number.isFinite(d) && d > 0;
+  if (!ok && !ffprobeWarned) {
+    ffprobeWarned = true;
+    process.stderr.write('[judge:video] ffprobe unavailable/unparseable — judging fixed 2s seeks, not true mid-clip\n');
+  }
+  return ok ? d : 0;
+}
+
+/**
+ * True mid-clip frame (probed duration / 2), downscaled to keep the judge
+ * request small. Falls back to ~2s, then the first frame, for unprobed or
+ * short clips.
+ */
+function extractFrame(clipPath: string, outPath: string): void {
+  const base = ['-y', '-i', clipPath, '-frames:v', '1', '-vf', 'scale=512:-1', '-q:v', '4', outPath];
+  const duration = probeDuration(clipPath);
+  const seeks = duration > 0 ? [duration / 2, 2] : [2];
+  for (const ss of seeks) {
+    // timeout: a hung ffmpeg on a corrupt clip must not park a judge worker.
+    const r = spawnSync(ffmpegBin(), ['-ss', ss.toFixed(2), ...base], { stdio: 'pipe', timeout: 60_000 });
+    if (r.status === 0 && existsSync(outPath)) return;
+  }
+  const r = spawnSync(ffmpegBin(), base, { stdio: 'pipe', timeout: 60_000 });
+  if (r.status !== 0 || !existsSync(outPath)) {
+    throw new Error(`ffmpeg produced no frame for ${clipPath}`);
+  }
+}
+
+interface JudgeReply {
+  consistency: number;
+  per_shot: ShotScore[];
+  notes?: string;
+}
+
+type ContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } };
+
+async function callJudge(
+  cfg: JudgeConfig,
+  system: string,
+  content: ContentPart[],
+): Promise<JudgeReply> {
+  const text = await chatCompletion(cfg, {
+    maxTokens: 2048,
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content },
+    ],
+  });
+  const jsonMatch = /\{[\s\S]*\}/.exec(text);
+  if (!jsonMatch) throw new Error(`no JSON in judge reply: ${text.slice(-120)}`);
+  const parsed = JSON.parse(jsonMatch[0]) as JudgeReply;
+  if (typeof parsed.consistency !== 'number' || !Array.isArray(parsed.per_shot)) {
+    throw new Error(`malformed judge reply: ${text.slice(-120)}`);
+  }
+  return parsed;
+}
+
+async function judgeStory(
+  cfg: JudgeConfig,
+  story: VimaxStory,
+  jobDir: string,
+): Promise<Omit<StoryScore, 'story' | 'type' | 'tier'>> {
+  const framesDir = path.join(FRAMES_ROOT, story.id);
+  await mkdir(framesDir, { recursive: true });
+  // ponytail: one message holds all shots of a story (≤16 images) — if a VLM
+  // rejects the payload, chunk by scene and average.
+  const content: ContentPart[] = [
+    { type: 'text', text: `Story: ${story.overview}\n\nFrames follow, one per shot, in story order.` },
+  ];
+  let frames = 0;
+  let firstExtractErr: unknown;
+  let skipped = 0;
+  for (const shot of story.shots) {
+    const clipPath = path.join(jobDir, 'shots', shot.shotId, 'video.mp4');
+    const framePath = path.join(framesDir, `${shot.shotId}.jpg`);
+    try {
+      extractFrame(clipPath, framePath);
+    } catch (err) {
+      firstExtractErr ??= err; // clip missing (shot failed) — judge sees the rest
+      skipped++;
+      continue;
+    }
+    const b64 = await readFile(framePath, 'base64');
+    content.push({ type: 'text', text: `Shot ${shot.shotId} — motion prompt: ${shot.videoPrompt}` });
+    content.push({ type: 'image_url', image_url: { url: `data:image/jpeg;base64,${b64}` } });
+    frames++;
+  }
+  if (frames === 0) {
+    const cause = firstExtractErr instanceof Error ? firstExtractErr.message : String(firstExtractErr);
+    throw new Error(`no extractable frames (first error: ${cause.slice(0, 200)})`);
+  }
+  if (skipped > 0) {
+    process.stderr.write(`[judge:video] ${story.id}: ${skipped} shot(s) had no extractable frame\n`);
+  }
+
+  const reply = await callJudge(cfg, buildSystem(story.type), content);
+  const pf = reply.per_shot.map((s) => s.prompt_following).filter((n) => typeof n === 'number');
+  return {
+    consistency: reply.consistency,
+    promptFollowing: pf.length ? pf.reduce((a, b) => a + b, 0) / pf.length : undefined,
+    perShot: reply.per_shot,
+    notes: reply.notes,
+  };
+}
+
+async function main() {
+  const args = parseArgs();
+  const bundle = JSON.parse(await readFile(args.input, 'utf8')) as Bundle;
+  const stories = new Map((await loadVimax()).map((s) => [s.id, s]));
+  const rows = bundle.rows.filter((r) => r.completed === 1 && r.finalVideoPath);
+  const selected = args.limit > 0 ? rows.slice(0, args.limit) : rows;
+  process.stderr.write(`[judge:video] input=${args.input} completed=${rows.length} judging=${selected.length}\n`);
+
+  const cfg = loadJudgeConfig(args.modelsPath, args.llmProvider, args.llmModel);
+  const scores: StoryScore[] = [];
+  await runPool(selected, args.concurrency, async (row) => {
+    const story = stories.get(row.story);
+    const base = { story: row.story, type: row.type, tier: row.tier };
+    if (!story) {
+      scores.push({ ...base, judgeError: 'story not in datasets/vimax (refetch?)' });
+      return;
+    }
+    try {
+      const scored = await judgeStory(cfg, story, path.dirname(row.finalVideoPath));
+      scores.push({ ...base, ...scored });
+      process.stderr.write(`[judge:video] ${row.story}: consistency=${scored.consistency}\n`);
+    } catch (err) {
+      scores.push({ ...base, judgeError: err instanceof Error ? err.message.slice(0, 200) : String(err) });
+    }
+  });
+  scores.sort((a, b) => selected.findIndex((r) => r.story === a.story) - selected.findIndex((r) => r.story === b.story));
+
+  const judged = scores.filter((s) => s.judgeError === undefined && s.consistency !== undefined);
+  const mean = (ns: number[]) => (ns.length ? ns.reduce((a, b) => a + b, 0) / ns.length : 0);
+  const byType: Record<string, { n: number; meanConsistency: number }> = {};
+  for (const t of ['A', 'B', 'C'] as const) {
+    const ns = judged.filter((s) => s.type === t).map((s) => s.consistency!);
+    if (ns.length) byType[t] = { n: ns.length, meanConsistency: mean(ns) };
+  }
+  const summary = {
+    ...bundle.summary,
+    llmModel: args.llmModel,
+    judged: judged.length,
+    judgeErrors: scores.length - judged.length,
+    meanConsistency: mean(judged.map((s) => s.consistency!)),
+    meanPromptFollowing: mean(judged.flatMap((s) => (s.promptFollowing !== undefined ? [s.promptFollowing] : []))),
+    byType,
+  };
+  process.stderr.write(`[judge:video] ${JSON.stringify(summary)}\n`);
+
+  const out = path.join(path.dirname(args.input), `${path.basename(args.input, '.json')}-judged.json`);
+  await writeFile(out, JSON.stringify({ summary, scores }, null, 2));
+}
+
+main().catch((err) => {
+  process.stderr.write(`[judge:video] error: ${err.stack ?? err.message}\n`);
+  process.exit(1);
+});

--- a/tests/eval/src/judge-client.ts
+++ b/tests/eval/src/judge-client.ts
@@ -1,0 +1,105 @@
+/**
+ * Shared OpenAI-compatible judge client for the results-judging scripts
+ * (judge-llm, judge-video): CLI flag helper, models.json resolution,
+ * transient-retry chat call, and a small worker pool. Payload shape and reply
+ * parsing stay per-script.
+ */
+import { readFileSync } from 'node:fs';
+
+export interface JudgeConfig {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+}
+
+/** CLI flag helper shared by the eval scripts. */
+export function getFlag(argv: string[], flag: string, dflt: string): string {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1]! : dflt;
+}
+
+export function loadJudgeConfig(modelsPath: string, provider: string, model: string): JudgeConfig {
+  const models = JSON.parse(readFileSync(modelsPath, 'utf8')) as {
+    providers?: Record<string, { apiKey?: string; baseUrl?: string }>;
+  };
+  const entry = models.providers?.[provider];
+  if (!entry?.apiKey || !entry.baseUrl) {
+    throw new Error(`provider ${provider} missing apiKey/baseUrl in ${modelsPath}`);
+  }
+  // models.json may reference the key by env name ($VAR / ${VAR}) — resolve it
+  // here; pi does the same at runtime for its own providers.
+  const ref = /^\$\{?([A-Z0-9_]+)\}?$/.exec(entry.apiKey);
+  const apiKey = ref ? process.env[ref[1]!] : entry.apiKey;
+  if (!apiKey) {
+    throw new Error(`provider ${provider} apiKey references $${ref![1]} which is not set`);
+  }
+  return { apiKey, baseUrl: entry.baseUrl, model };
+}
+
+export function isTransient(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  const cause = err instanceof Error && err.cause instanceof Error ? err.cause.message : '';
+  const haystack = `${msg}\n${cause}`;
+  return /\b(5\d\d|429|overloaded|timeout|timed out|ETIMEDOUT|ECONN|EAI_AGAIN|ENOTFOUND|getaddrinfo|fetch failed|socket|Connection error|APIConnection)\b/i.test(
+    haystack,
+  );
+}
+
+/**
+ * POST /chat/completions with transient retry; returns the assistant text.
+ * `messages` is untyped — judge-video sends multimodal content parts.
+ * Reply-parse errors belong to the caller and are NOT retried (not transient).
+ */
+export async function chatCompletion(
+  cfg: JudgeConfig,
+  body: { maxTokens: number; messages: unknown[]; temperature?: number },
+): Promise<string> {
+  const delays = [1000, 4000, 16000];
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= delays.length; attempt++) {
+    try {
+      const res = await fetch(`${cfg.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${cfg.apiKey}` },
+        // A hung gateway must not park a pool worker forever; the abort error
+        // matches isTransient ('timed out') and retries.
+        signal: AbortSignal.timeout(300_000),
+        body: JSON.stringify({
+          model: cfg.model,
+          // Optional: some models reject anything but their own default
+          // (kimi-k3: "only 1 is allowed"), so callers omit rather than force 0.
+          ...(body.temperature !== undefined ? { temperature: body.temperature } : {}),
+          max_tokens: body.maxTokens,
+          messages: body.messages,
+        }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+      const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+      return data.choices?.[0]?.message?.content ?? '';
+    } catch (err) {
+      lastErr = err;
+      if (attempt === delays.length || !isTransient(err)) break;
+      await new Promise((r) => setTimeout(r, delays[attempt]!));
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
+/** Simple cursor worker pool over items. */
+export async function runPool<T>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= items.length) return;
+      await fn(items[idx]!);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.max(1, Math.min(concurrency, items.length)) }, worker),
+  );
+}

--- a/tests/eval/src/loaders/vimax.ts
+++ b/tests/eval/src/loaders/vimax.ts
@@ -1,0 +1,96 @@
+/**
+ * ViMax-Bench loader. Real schema (verified against vimax_benchmark/*.json @ 05a4894):
+ *
+ *   benchmark_index.json: { total_stories, stories: [{ id, type, theme, file }] }
+ *   story file = {
+ *     story_overview: string,
+ *     consistency_type: "Type A" | "Type B" | "Type C",
+ *     metadata: { theme_key, theme_description, requested_scenes, requested_shots },
+ *     scenes: [{ scene_num, shots: [{ shot_id, first_frame, video_prompt }] }],
+ *   }
+ *
+ * Types (per the paper, arXiv 2606.07649):
+ *   A = character persistence, B = background persistence, C = multi-person interaction.
+ * Tier is derived, not stored upstream: Medium = ≤2 scenes (8–10 shots), Long = 3–4.
+ *
+ * Upstream: https://github.com/HKUDS/ViMax (MIT); pulled by scripts/fetch-vimax.ts.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export type VimaxType = 'A' | 'B' | 'C';
+export type VimaxTier = 'medium' | 'long';
+
+export interface VimaxShot {
+  shotId: string;
+  sceneNum: number;
+  firstFrame: string;
+  videoPrompt: string;
+}
+
+export interface VimaxStory {
+  id: string;
+  type: VimaxType;
+  tier: VimaxTier;
+  theme: string;
+  overview: string;
+  shots: VimaxShot[];
+}
+
+const DATASETS_DIR = path.resolve(import.meta.dirname, '..', '..', 'datasets', 'vimax');
+
+/** Job ids and shot ids become directory names — strip anything but safe chars. */
+function slug(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, '-');
+}
+
+function adaptStory(id: string, raw: unknown): VimaxStory {
+  const obj = raw as Record<string, unknown>;
+  const typeMatch = /Type\s*([ABC])/i.exec(String(obj.consistency_type ?? ''));
+  if (!typeMatch) throw new Error(`[vimax] ${id}: unparseable consistency_type`);
+  const scenes = (Array.isArray(obj.scenes) ? obj.scenes : []) as Array<Record<string, unknown>>;
+  const shots: VimaxShot[] = [];
+  for (const scene of scenes) {
+    const sceneNum = Number(scene.scene_num ?? 0);
+    const rawShots = (Array.isArray(scene.shots) ? scene.shots : []) as Array<
+      Record<string, unknown>
+    >;
+    for (const shot of rawShots) {
+      shots.push({
+        shotId: slug(String(shot.shot_id ?? `s${shots.length + 1}`)),
+        sceneNum,
+        firstFrame: String(shot.first_frame ?? ''),
+        videoPrompt: String(shot.video_prompt ?? ''),
+      });
+    }
+  }
+  if (shots.length === 0) throw new Error(`[vimax] ${id}: no shots`);
+  const meta = (obj.metadata ?? {}) as Record<string, unknown>;
+  return {
+    id: slug(id),
+    type: typeMatch[1]!.toUpperCase() as VimaxType,
+    tier: scenes.length <= 2 ? 'medium' : 'long',
+    theme: String(meta.theme_description ?? meta.theme_key ?? id),
+    overview: String(obj.story_overview ?? ''),
+    shots,
+  };
+}
+
+/**
+ * Load all fetched stories. benchmark_index.json is skipped (metadata only);
+ * every other *.json in datasets/vimax/ is one story.
+ */
+export async function loadVimax(): Promise<VimaxStory[]> {
+  const files = (await readdir(DATASETS_DIR))
+    .filter((f) => f.endsWith('.json') && f !== 'benchmark_index.json')
+    .sort();
+  if (files.length === 0) {
+    throw new Error('[vimax] no story files — run `pnpm --filter @amaster.ai/pi-eval fetch:vimax`');
+  }
+  const stories: VimaxStory[] = [];
+  for (const f of files) {
+    const raw = JSON.parse(await readFile(path.join(DATASETS_DIR, f), 'utf8'));
+    stories.push(adaptStory(path.basename(f, '.json'), raw));
+  }
+  return stories;
+}

--- a/tests/eval/src/pi-harness.ts
+++ b/tests/eval/src/pi-harness.ts
@@ -297,6 +297,26 @@ export async function drivePrompt(
   }
 
   const events = parseEvents(out.stdout);
+  // pi can exit 0 while printing a plain-text fatal (e.g. "No API key found
+  // for provider X") and emitting ZERO events. Without this, the run reads as
+  // a silent check-failed instead of the crash it is.
+  if (events.length === 0) {
+    const text = out.stdout
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('{'))
+      .join(' ')
+      .slice(0, 300);
+    return {
+      answer: '',
+      observed: '',
+      turns: 0,
+      toolCalls: 0,
+      sawToolError: false,
+      failureMode: 'crash',
+      error: text || `pi produced no events (exit ${out.code})`,
+    };
+  }
   const answerParts: string[] = [];
   const observedParts: string[] = [];
   let turns = 0;

--- a/tests/eval/video/run-video.ts
+++ b/tests/eval/video/run-video.ts
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * pi-video-gen quality eval on ViMax-Bench (HKUDS/ViMax, MIT): render pre-planned
+ * multi-shot story specs through the REAL shot-book pipeline (real `pi` CLI, real
+ * image_generate + video_render) and record artifacts for VLM judging
+ * (scripts/judge-video.ts).
+ *
+ * The shot book is converted deterministically from each ViMax story spec — the
+ * LLM only EXECUTES it (frame generation + one video_render call), so the numbers
+ * reflect render/compose/orchestration quality, not planning variance.
+ *
+ * COST WARNING: every story is 8-16 PAID video clips + ~1 image per shot. Slice
+ * with --samples/--tier/--story. See README.
+ *
+ * Usage (local — reuses your ~/.pi/agent video/image provider config):
+ *   pnpm --filter @amaster.ai/pi-eval eval:video -- --use-default-pi --samples 2 --tier medium
+ *
+ * CI shape (generated extension settings from env, mirrors integration.yml):
+ *   PI_INTEGRATION_BASE_URL=... PI_INTEGRATION_API_KEY=... PI_EVAL_IMAGE_MODEL=doubao-seedream-5-0-lite-260128 \
+ *     pnpm --filter @amaster.ai/pi-eval eval:video -- --samples 2 --models /path/to/models.json
+ */
+import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { getFlag } from '../src/judge-client.js';
+import {
+  type DriveResult,
+  drivePrompt,
+  type FailureMode,
+  parseCommonArgs,
+  setupHarness,
+  toHarnessConfig,
+} from '../src/pi-harness.js';
+import { loadVimax, type VimaxStory, type VimaxTier, type VimaxType } from '../src/loaders/vimax.js';
+
+const TOOLS = 'read,write,ls,image_generate,video_capabilities,video_render';
+const EVAL_DIR = path.resolve(import.meta.dirname, '..');
+const ARTIFACTS_DIR = path.join(EVAL_DIR, 'results', 'artifacts');
+
+interface VideoArgs {
+  samples: number;
+  tier: VimaxTier | 'all';
+  storyId: string;
+  videoModel: string;
+  imageModel: string;
+}
+
+function parseVideoArgs(): VideoArgs {
+  const argv = process.argv.slice(2);
+  return {
+    samples: Number(getFlag(argv, '--samples', '2')),
+    tier: getFlag(argv, '--tier', 'medium') as VideoArgs['tier'],
+    storyId: getFlag(argv, '--story', ''),
+    // CI-proven ids from integration.yml; override for other gateways.
+    videoModel: getFlag(argv, '--video-model', process.env.PI_EVAL_VIDEO_MODEL || 'doubao-seedance-2-0-260128'),
+    imageModel: getFlag(argv, '--image-model', process.env.PI_EVAL_IMAGE_MODEL || ''),
+  };
+}
+
+/**
+ * Gateway baseUrl for the gen extensions in isolated mode: --base-url /
+ * PI_INTEGRATION_BASE_URL, else read it off the --models file's provider.
+ */
+function resolveGatewayBaseUrl(args: ReturnType<typeof parseCommonArgs>): string {
+  if (args.baseUrl) return args.baseUrl;
+  if (args.modelsPath) {
+    try {
+      const models = JSON.parse(readFileSync(args.modelsPath, 'utf8')) as {
+        providers?: Record<string, { baseUrl?: string }>;
+      };
+      const url = models.providers?.[args.provider]?.baseUrl;
+      if (url) return url;
+    } catch {
+      // fall through to the error below
+    }
+  }
+  throw new Error(
+    'isolated mode needs a gen gateway baseUrl: --base-url (or PI_INTEGRATION_BASE_URL), ' +
+      'or a --models file whose provider carries baseUrl',
+  );
+}
+
+/**
+ * Extension settings for the isolated config dir, mirroring integration.yml's
+ * ci-gateway shape: `${ENV}` interpolation keeps secrets off disk (loadPiSettings
+ * expands them from the agent-dir layer at runtime).
+ */
+function buildSettings(args: ReturnType<typeof parseCommonArgs>, vargs: VideoArgs) {
+  if (!vargs.imageModel) {
+    throw new Error(
+      'isolated mode needs an image model: --image-model <id> or PI_EVAL_IMAGE_MODEL ' +
+        '(or use --use-default-pi to reuse your ~/.pi/agent config)',
+    );
+  }
+  const baseUrl = resolveGatewayBaseUrl(args);
+  if (!process.env[args.apiKeyEnv]) {
+    throw new Error(
+      `API key env var "${args.apiKeyEnv}" is not set — the isolated extension settings reference it by name.`,
+    );
+  }
+  const apiKey = '${' + args.apiKeyEnv + '}';
+  return {
+    'pi-image-gen': {
+      defaultModel: vargs.imageModel,
+      outputDir: path.join(ARTIFACTS_DIR, 'images'),
+      customProviders: {
+        'eval-gateway': { api: 'openai', baseUrl, apiKey },
+      },
+    },
+    'pi-video-gen': {
+      defaultModel: 'eval-video',
+      outputDir: path.join(ARTIFACTS_DIR, 'video'),
+      customProviders: {
+        'eval-gateway': {
+          api: 'newapi',
+          baseUrl,
+          apiKey,
+          models: [{ id: vargs.videoModel, alias: 'eval-video' }],
+        },
+      },
+    },
+  };
+}
+
+/** ViMax story → VideoProject shot book (skill §B schema), deterministically. */
+function toShotBook(story: VimaxStory) {
+  return {
+    title: story.theme,
+    characters: [],
+    shots: story.shots.map((s) => ({
+      id: s.shotId,
+      intent: s.videoPrompt,
+      firstFrame: s.firstFrame,
+      motion: s.videoPrompt,
+      durationSec: 5,
+      continuityGroup: `scene-${s.sceneNum}`,
+    })),
+  };
+}
+
+function buildPrompt(story: VimaxStory, shotBookPath: string, renderSpecHint: string): string {
+  return `Render a pre-planned multi-shot video from an existing shot book. This is an unattended evaluation run: all costs and confirmation gates in the video-gen skill are PRE-APPROVED — never ask for confirmation, never wait for input, never negotiate degradations (accept them and note it).
+
+Shot book (VideoProject JSON): ${shotBookPath} — read it first with the read tool.
+
+Execute exactly:
+1. Call video_capabilities and respect the active model's limits.
+2. Image stage: for each shot in order, generate its first frame with image_generate (text-to-image, 16:9) using the shot's firstFrame text VERBATIM as the prompt. Record each returned absolute image path immediately.
+3. Write render-input.json (${renderSpecHint}): {"title","aspectRatio":"16:9","shots":[{"id","videoPrompt","firstFramePath","durationSec"}...]} — videoPrompt is the shot's motion text, firstFramePath the generated frame path from step 2.
+4. Call video_render ONCE with that spec path.
+5. Reply with the final video path.
+
+Constraints: do not rewrite, reorder, add, or drop shots; no character portraits; no last frames. If image_generate fails for a shot, retry once, then continue with the remaining shots and note the failure in your final reply.`;
+}
+
+/** The render tool result carries finalVideoPath; fall back to any final_video path. */
+function extractFinalVideoPath(drive: DriveResult): string {
+  // answer is scanned too: the prompt requires the final path in the reply, and
+  // in useDefaultPi mode the render output may be lost to observed truncation.
+  const haystack = `${drive.observed}\n${drive.answer}`;
+  const m = /"finalVideoPath"\s*:\s*"([^"]+)"/.exec(haystack) ?? /(\/[^\s"']*final_video\.mp4)/.exec(haystack);
+  return m?.[1] ?? '';
+}
+
+/**
+ * Completion = the final video EXISTS ON DISK from THIS run. Both candidates
+ * require mtime >= runStart: pi-video-gen resumes jobs by directory, and a
+ * stale path can leak into this run's observed via the agent's ls/read of the
+ * old job dir. An honest this-run render always rewrites final_video.mp4
+ * (concat reruns unconditionally), so the guard costs no true positives.
+ */
+function resolveFinalVideo(story: VimaxStory, drive: DriveResult, runStart: number): string {
+  const candidates = [
+    extractFinalVideoPath(drive),
+    path.join(ARTIFACTS_DIR, 'video', story.id, 'final_video.mp4'),
+  ];
+  for (const p of candidates) {
+    if (!p) continue;
+    try {
+      if (statSync(p).mtimeMs >= runStart) return p;
+    } catch {
+      // not there
+    }
+  }
+  return '';
+}
+
+/**
+ * Execution-contract check: the LLM must render the shot book verbatim.
+ * Compares the written render-input.json's shot ids/order against the spec.
+ * Runs whether or not the render completed (a re-planned spec whose render
+ * then failed is still a violation). Stale specs from previous runs are
+ * skipped via runStart. Returns undefined when no fresh spec was produced.
+ */
+function checkSpecPreserved(
+  story: VimaxStory,
+  finalVideoPath: string,
+  runStart: number,
+): number | undefined {
+  const candidates = [
+    ...(finalVideoPath ? [path.join(path.dirname(finalVideoPath), 'render-input.json')] : []),
+    path.join(ARTIFACTS_DIR, 'video', story.id, 'render-input.json'),
+  ];
+  for (const p of candidates) {
+    try {
+      if (statSync(p).mtimeMs < runStart) continue;
+      const spec = JSON.parse(readFileSync(p, 'utf8')) as { shots?: Array<{ id?: unknown }> };
+      const ids = (spec.shots ?? []).map((s) => String(s.id ?? ''));
+      // JSON.stringify both sides: LLM-controlled ids could otherwise join to
+      // the same string as a different sequence (['a','b'] vs ['a,b']).
+      return JSON.stringify(ids) === JSON.stringify(story.shots.map((s) => s.shotId)) ? 1 : 0;
+    } catch {
+      // try the next candidate
+    }
+  }
+  return undefined;
+}
+
+interface Row {
+  story: string;
+  type: VimaxType;
+  tier: VimaxTier;
+  shots: number;
+  completed: number;
+  specPreserved?: number;
+  finalVideoPath: string;
+  turns: number;
+  toolCalls: number;
+  failureMode: FailureMode;
+  answer: string;
+  error?: string;
+}
+
+function scoreStory(story: VimaxStory, drive: DriveResult, runStart: number): Row {
+  const finalVideoPath = resolveFinalVideo(story, drive, runStart);
+  let failureMode = drive.failureMode;
+  if (failureMode === 'ok' && !finalVideoPath) {
+    failureMode = drive.sawToolError ? 'tool-error' : 'check-failed';
+  }
+  const specPreserved = checkSpecPreserved(story, finalVideoPath, runStart);
+  return {
+    story: story.id,
+    type: story.type,
+    tier: story.tier,
+    shots: story.shots.length,
+    completed: finalVideoPath ? 1 : 0,
+    ...(specPreserved !== undefined ? { specPreserved } : {}),
+    finalVideoPath,
+    turns: drive.turns,
+    toolCalls: drive.toolCalls,
+    failureMode,
+    answer: drive.answer,
+    ...(drive.error ? { error: drive.error } : {}),
+  };
+}
+
+async function main() {
+  // No hardcoded LLM default (spec): the driver model is always explicit.
+  const args = parseCommonArgs({ model: '', timeoutMs: 7_200_000 });
+  if (!args.model) {
+    throw new Error('no default LLM is hardcoded — pass --model <id> or set PI_EVAL_MODEL');
+  }
+  const vargs = parseVideoArgs();
+  const hcfg = toHarnessConfig(args);
+
+  const stories = await loadVimax();
+  let selected = vargs.storyId
+    ? stories.filter((s) => s.id === vargs.storyId)
+    : stories.filter((s) => vargs.tier === 'all' || s.tier === vargs.tier);
+  if (vargs.samples > 0) selected = selected.slice(0, vargs.samples);
+  if (selected.length === 0) throw new Error('no stories selected');
+
+  const clips = selected.reduce((a, s) => a + s.shots.length, 0);
+  process.stderr.write(
+    `[eval:video] stories=${selected.length} plannedClips=${clips} model=${args.provider}/${args.model}\n`,
+  );
+
+  const harness = await setupHarness(hcfg, {
+    pkg: 'pi-video-gen',
+    alsoInstall: ['pi-image-gen'],
+    // useDefaultPi mode writes no settings — the user's own config drives.
+    settings: hcfg.useDefaultPi ? {} : buildSettings(args, vargs),
+  });
+
+  const shotBooksDir = path.join(ARTIFACTS_DIR, 'shotbooks');
+  mkdirSync(shotBooksDir, { recursive: true });
+  const outDir = path.join(EVAL_DIR, 'results');
+  mkdirSync(outDir, { recursive: true });
+  const resultsPath = path.join(outDir, 'video-vimax.json');
+
+  const summarize = (rows: Row[]) => {
+    const completed = rows.filter((r) => r.completed === 1);
+    const failureMix: Record<string, number> = {};
+    for (const r of rows) failureMix[r.failureMode] = (failureMix[r.failureMode] ?? 0) + 1;
+    return {
+      model: `${args.provider}/${args.model}`,
+      videoModel: vargs.videoModel,
+      n: rows.length,
+      completed: completed.length,
+      completionRate: completed.length / Math.max(1, rows.length),
+      specViolations: rows.filter((r) => r.specPreserved === 0).length,
+      avgTurns: completed.reduce((a, r) => a + r.turns, 0) / Math.max(1, completed.length),
+      failureMix,
+    };
+  };
+  // Incremental write: a killed run (CI job timeout, Ctrl-C) keeps the
+  // completed stories' rows instead of losing everything.
+  const writeResults = (rows: Row[]) =>
+    writeFileSync(resultsPath, JSON.stringify({ summary: summarize(rows), rows }, null, 2));
+
+  const rows: Row[] = [];
+  try {
+    // Sequential: paid generation; a parallel fleet would also trip rate limits.
+    for (const story of selected) {
+      const shotBookPath = path.join(shotBooksDir, `${story.id}.json`);
+      writeFileSync(shotBookPath, JSON.stringify(toShotBook(story), null, 2));
+      const renderSpecHint = hcfg.useDefaultPi
+        ? `under the video-gen output dir as job '${story.id}', i.e. <outputDir>/${story.id}/render-input.json`
+        : path.join(ARTIFACTS_DIR, 'video', story.id, 'render-input.json');
+      process.stderr.write(`[eval:video] start ${story.id} (type ${story.type}, ${story.shots.length} shots)\n`);
+      const runStart = Date.now();
+      const drive = await drivePrompt(harness, hcfg, buildPrompt(story, shotBookPath, renderSpecHint), TOOLS);
+      const row = scoreStory(story, drive, runStart);
+      rows.push(row);
+      writeResults(rows);
+      process.stderr.write(
+        `[eval:video] done ${story.id}: completed=${row.completed} mode=${row.failureMode} turns=${row.turns}${row.error ? ` err=${row.error.slice(0, 80)}` : ''}\n`,
+      );
+    }
+  } finally {
+    harness.cleanup();
+  }
+
+  process.stderr.write(`[eval:video] ${JSON.stringify(summarize(rows))}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[eval:video] error: ${err.stack ?? err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds a video-generation **quality** eval to `tests/eval`, using [HKUDS/ViMax](https://github.com/HKUDS/ViMax)'s benchmark data (35 multi-shot story specs, MIT) as input — ViMax-Bench ships data only, so the scoring is ours.

- **`video/run-video.ts`** — converts each story spec deterministically into a VideoProject shot book, then drives the **real `pi` CLI** (shared pi-harness) to execute it: image stage + one `video_render` per story. The LLM only executes the plan, so scores reflect render/orchestration quality, not planning variance. Records completion (on-disk, this-run freshness via mtime guard), `specViolations` (LLM re-planned the shot book — verified against the written render-input.json), turns, failure mix. Results write incrementally per story.
- **`scripts/fetch-vimax.ts` + `src/loaders/vimax.ts`** — pinned-commit dataset fetch into gitignored `datasets/` (LoCoMo pattern).
- **`scripts/judge-video.ts`** — VLM judge: probed mid-clip frames per shot, consistency rubric keyed to the story's ViMax type (A character / B background / C multi-person) + per-shot prompt-following. Scores are for cross-provider comparison and self-regression, **not comparable to the ViMax paper** (that would need ViCLIP; documented as future work).
- **`src/judge-client.ts`** — shared judge plumbing extracted from judge-llm.ts (models.json resolution incl. `$ENV_VAR` apiKey refs, transient-retry chat call with timeout, worker pool); judge-llm behavior preserved.
- **`src/pi-harness.ts`** — pi exiting 0 with a plain-text fatal and zero events (e.g. unknown provider) is now classified `crash` instead of a silent check-failed. Benefits all runners.
- **`agentic-eval.yml`** — `video-eval` target (workflow_dispatch only) with `samples`/`tier` inputs; 45min per-story cap under the 120min job limit.

## Cost warning

Every story is 8-16 **paid** clips + ~1 image/shot. Local smoke measured ≈¥35-40/clip on the maintainer's gateway — always slice with `--samples`/`--tier`/`--story`. CI default is 2 medium stories.

## Verification

- Local end-to-end smoke: 1 medium story through the real pipeline (kimi-k3 driver, seedance via newapi); 4/9 clips before a manual cost stop; VLM judge scored the salvaged clips (consistency 2/5 type C, prompt-following 3.25/5 — plausible for portrait-free frames).
- pr-check (lint + typecheck + 1721 tests + build) green via pre-commit hook.
- Known limitation, documented in README: ViMax Type A/C stories are human-centric and hit provider privacy moderation on accounts without a portrait asset library / likeness authorization (observed during the smoke run). Skill-side guidance is intentionally **not** in this PR — pending discussion.