### PR TITLE
ci: add skill evaluation gate

### DIFF
--- a/.github/scripts/skill-eval.mjs
+++ b/.github/scripts/skill-eval.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync, spawn } from 'node:child_process';
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -20,6 +21,9 @@ export function selectSkillChanges(changedFiles, hasPath) {
   ].sort();
 
   return roots.flatMap((path) => {
+    if (!changedFiles.some((file) => file.startsWith(`${path}/`) && file !== `${path}/evals.json`)) {
+      return [];
+    }
     const skillFile = `${path}/SKILL.md`;
     const inBase = hasPath('base', skillFile);
     const inHead = hasPath('head', skillFile);
@@ -68,8 +72,8 @@ export function validateEvalSet(value) {
     ids.add(id);
     requireString(item.prompt, `evals[${index}].prompt`);
     requireString(item.expected_output, `evals[${index}].expected_output`);
-    if (!Array.isArray(item.expectations) || item.expectations.length === 0) {
-      throw new Error(`evals[${index}].expectations must be a non-empty array`);
+    if (!Array.isArray(item.expectations) || item.expectations.length === 0 || item.expectations.length > 20) {
+      throw new Error(`evals[${index}].expectations must be a non-empty array with at most 20 entries`);
     }
     for (const [expectationIndex, expectation] of item.expectations.entries()) {
       const label = `evals[${index}].expectations[${expectationIndex}]`;
@@ -94,14 +98,14 @@ export function selectRegressionEvalSet(base, head) {
 }
 
 export function gradeExpectations(answer, expectations) {
-  const haystack = answer.toLocaleLowerCase();
+  const haystack = answer.toLowerCase();
   const graded = expectations.map((expectation) => {
     const includes = expectation.includes ?? [];
     const includesAny = expectation.includes_any ?? [];
     const excludes = expectation.excludes ?? [];
-    const missing = includes.filter((value) => !haystack.includes(value.toLocaleLowerCase()));
-    const matchedAny = includesAny.filter((value) => haystack.includes(value.toLocaleLowerCase()));
-    const unexpected = excludes.filter((value) => haystack.includes(value.toLocaleLowerCase()));
+    const missing = includes.filter((value) => !haystack.includes(value.toLowerCase()));
+    const matchedAny = includesAny.filter((value) => haystack.includes(value.toLowerCase()));
+    const unexpected = excludes.filter((value) => haystack.includes(value.toLowerCase()));
     const passed = missing.length === 0 && (includesAny.length === 0 || matchedAny.length > 0) && unexpected.length === 0;
 
     const evidence = passed
@@ -176,8 +180,8 @@ export function evaluateGate({
   return { passed: reasons.length === 0, candidateScore, baselineScore, delta, reasons };
 }
 
-export function formatComment(results, { runUrl, artifactName }) {
-  const passed = results.length > 0 && results.every((result) => result.gate.passed);
+export function formatComment(results, { runUrl, artifactName, error }) {
+  const passed = !error && results.length > 0 && results.every((result) => result.gate.passed);
   const lines = [
     `### ${passed ? '✅ Skill Eval — passed' : '❌ Skill Eval — failed'}`,
     '',
@@ -194,6 +198,7 @@ export function formatComment(results, { runUrl, artifactName }) {
     result.gate.reasons.map((reason) => `- \`${result.skill}\`: ${reason}`),
   );
   if (failures.length) lines.push('', '**Failures**', '', ...failures);
+  if (error) lines.push('', '**Infrastructure failure**', '', error);
   lines.push(
     '',
     'New skills require score ≥ 0.800 and delta ≥ +0.100. Modified skills must not regress on any master eval.',
@@ -289,7 +294,6 @@ function runPi({ cwd, skillDir, prompt, timeoutMs }) {
 
     const child = spawn('pi', args, { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = '';
-    let stderr = '';
     let killedForSize = false;
     const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs);
     child.stdout.on('data', (chunk) => {
@@ -299,9 +303,7 @@ function runPi({ cwd, skillDir, prompt, timeoutMs }) {
         child.kill('SIGKILL');
       }
     });
-    child.stderr.on('data', (chunk) => {
-      if (stderr.length < 16_000) stderr += chunk;
-    });
+    child.stderr.resume();
     child.on('error', (error) => {
       clearTimeout(timer);
       resolve({ answer: '', failure_mode: 'crash', error: error.message.slice(0, 300), duration_ms: Date.now() - started });
@@ -310,7 +312,7 @@ function runPi({ cwd, skillDir, prompt, timeoutMs }) {
       clearTimeout(timer);
       const answer = stdout.trim().slice(0, 20_000);
       const failure =
-        killedForSize ? 'Pi output exceeded 256 KiB' : signal === 'SIGKILL' ? `Pi timed out after ${timeoutMs}ms` : code !== 0 ? `Pi exited ${code}: ${stderr.slice(-200)}` : !answer ? 'Pi returned no assistant text' : '';
+        killedForSize ? 'Pi output exceeded 256 KiB' : signal === 'SIGKILL' ? `Pi timed out after ${timeoutMs}ms` : code !== 0 ? `Pi exited with code ${code}` : !answer ? 'Pi returned no assistant text' : '';
       resolve({
         answer,
         failure_mode: failure ? 'crash' : 'ok',
@@ -332,13 +334,19 @@ function writeRun(workspace, evalItem, configuration, runNumber, run) {
   mkdirSync(outputsDir, { recursive: true });
   writeFileSync(
     path.join(runDir, 'eval_metadata.json'),
-    `${JSON.stringify({ eval_id: evalItem.id, eval_name: evalItem.id, prompt: evalItem.prompt }, null, 2)}\n`,
+    `${JSON.stringify({
+      eval_id: evalItem.id,
+      eval_name: evalItem.id,
+      prompt: evalItem.prompt,
+      expected_output: evalItem.expected_output,
+    }, null, 2)}\n`,
   );
   writeFileSync(path.join(outputsDir, 'response.md'), `${run.answer || `Evaluation failed: ${run.error ?? 'unknown error'}`}\n`);
   writeFileSync(
     path.join(runDir, 'grading.json'),
     `${JSON.stringify(
       {
+        expected_output: evalItem.expected_output,
         expectations: run.grading.expectations,
         summary: {
           passed: run.grading.passed,
@@ -372,10 +380,15 @@ function stats(values) {
   };
 }
 
+function viewerConfiguration(type, configuration) {
+  if (type === 'added') return configuration === 'candidate' ? 'with_skill' : 'without_skill';
+  return configuration === 'candidate' ? 'new_skill' : 'old_skill';
+}
+
 function buildBenchmark({ skill, skillPath, type, runs, runCount, gate }) {
-  const candidate = type === 'added' ? 'with_skill' : 'new_skill';
-  const baseline = type === 'added' ? 'without_skill' : 'old_skill';
-  const label = (configuration) => (configuration === 'candidate' ? candidate : baseline);
+  const candidate = viewerConfiguration(type, 'candidate');
+  const baseline = viewerConfiguration(type, 'baseline');
+  const label = (configuration) => viewerConfiguration(type, configuration);
   const grouped = Object.fromEntries(
     [candidate, baseline].map((configuration) => {
       const values = runs.filter((run) => label(run.configuration) === configuration);
@@ -441,11 +454,10 @@ async function evaluateSkill({ change, base, head, tempRoot, outputRoot, cwd, ru
   if (change.type === 'modified') {
     baselineDir = path.join(tempRoot, 'baseline', change.path);
     materializeSkill(base, change.path, baselineDir);
-    if (revisionHasPath(base, evalPath)) {
-      const baseEvals = validateEvalSet(readJsonAt(base, evalPath));
-      evalSet = selectRegressionEvalSet(baseEvals, headEvals);
-      baseEvalIds = baseEvals.evals.map((item) => String(item.id));
-    }
+    if (!revisionHasPath(base, evalPath)) throw new Error(`modified skills require ${evalPath} on the base revision`);
+    const baseEvals = validateEvalSet(readJsonAt(base, evalPath));
+    evalSet = selectRegressionEvalSet(baseEvals, headEvals);
+    baseEvalIds = baseEvals.evals.map((item) => String(item.id));
   }
 
   const workspace = path.join(outputRoot, safeSegment(skill));
@@ -482,9 +494,7 @@ async function evaluateSkill({ change, base, head, tempRoot, outputRoot, cwd, ru
           grading,
         };
         runs.push(run);
-        const viewerConfig = configuration === 'candidate'
-          ? change.type === 'added' ? 'with_skill' : 'new_skill'
-          : change.type === 'added' ? 'without_skill' : 'old_skill';
+        const viewerConfig = viewerConfiguration(change.type, configuration);
         writeRun(workspace, evalItem, viewerConfig, runNumber, run);
       }
     }
@@ -503,10 +513,37 @@ async function evaluateSkill({ change, base, head, tempRoot, outputRoot, cwd, ru
   return { skill, type: change.type, path: change.path, gate };
 }
 
+function findSkillChanges(base, head) {
+  const changedFiles = git(['diff', '--name-only', '--no-renames', '-z', base, head])
+    .split('\0')
+    .filter(Boolean);
+  return selectSkillChanges(changedFiles, (revision, file) =>
+    revisionHasPath(revision === 'base' ? base : head, file),
+  );
+}
+
+function writeReport({ outputRoot, base, head, results, error }) {
+  const summary = { base, head, skills: results, ...(error ? { error: 'evaluation infrastructure failed' } : {}) };
+  writeFileSync(path.join(outputRoot, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
+  const comment = formatComment(results, {
+    runUrl: process.env.SKILL_EVAL_RUN_URL || '#',
+    artifactName: process.env.SKILL_EVAL_ARTIFACT || 'skill-eval-results',
+    error,
+  });
+  writeFileSync(path.join(outputRoot, 'comment.md'), comment);
+  if (process.env.GITHUB_STEP_SUMMARY) writeFileSync(process.env.GITHUB_STEP_SUMMARY, comment, { flag: 'a' });
+}
+
 async function main() {
   const base = process.env.SKILL_EVAL_BASE_SHA;
   const head = process.env.SKILL_EVAL_HEAD_SHA;
   if (!base || !head) throw new Error('SKILL_EVAL_BASE_SHA and SKILL_EVAL_HEAD_SHA are required');
+  const changes = findSkillChanges(base, head);
+  if (process.argv.includes('--detect')) {
+    process.stdout.write(changes.map((change) => `${change.type}\t${change.path}`).join('\n'));
+    return;
+  }
+
   const runCount = Number(process.env.SKILL_EVAL_RUNS || '3');
   const timeoutMs = Number(process.env.SKILL_EVAL_TIMEOUT_MS || '120000');
   if (!Number.isInteger(runCount) || runCount < 1 || runCount > 5) throw new Error('SKILL_EVAL_RUNS must be 1..5');
@@ -515,33 +552,29 @@ async function main() {
   const cwd = process.cwd();
   const outputRoot = path.resolve(process.env.SKILL_EVAL_OUTPUT_DIR || 'skill-eval-results');
   mkdirSync(outputRoot, { recursive: true });
-  const changedFiles = git(['diff', '--name-only', '--no-renames', '-z', base, head])
-    .split('\0')
-    .filter(Boolean);
-  const changes = selectSkillChanges(changedFiles, (revision, file) =>
-    revisionHasPath(revision === 'base' ? base : head, file),
-  );
   if (!changes.length) throw new Error('no added or modified skills found');
   if (changes.length > 3) throw new Error('a single PR may evaluate at most 3 skills');
 
   const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'pi-skill-eval-'));
+  const results = [];
   try {
-    const results = [];
     for (const change of changes) {
       process.stderr.write(`[skill-eval] ${change.type} ${change.path}\n`);
       results.push(
         await evaluateSkill({ change, base, head, tempRoot, outputRoot, cwd, runCount, timeoutMs }),
       );
     }
-    const summary = { base, head, skills: results };
-    writeFileSync(path.join(outputRoot, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
-    const comment = formatComment(results, {
-      runUrl: process.env.SKILL_EVAL_RUN_URL || '#',
-      artifactName: process.env.SKILL_EVAL_ARTIFACT || 'skill-eval-results',
-    });
-    writeFileSync(path.join(outputRoot, 'comment.md'), comment);
-    if (process.env.GITHUB_STEP_SUMMARY) writeFileSync(process.env.GITHUB_STEP_SUMMARY, comment, { flag: 'a' });
+    writeReport({ outputRoot, base, head, results });
     if (results.some((result) => !result.gate.passed)) process.exitCode = 1;
+  } catch (error) {
+    writeReport({
+      outputRoot,
+      base,
+      head,
+      results,
+      error: 'Evaluation infrastructure failed before all skills completed. See the workflow logs.',
+    });
+    throw error;
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -559,8 +592,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
       `[Workflow logs](${process.env.SKILL_EVAL_RUN_URL || '#'})`,
       '',
     ].join('\n');
-    writeFileSync(path.join(outputRoot, 'comment.md'), comment);
-    writeFileSync(path.join(outputRoot, 'summary.json'), `${JSON.stringify({ error: 'evaluation infrastructure failed' }, null, 2)}\n`);
+    if (!existsSync(path.join(outputRoot, 'comment.md'))) writeFileSync(path.join(outputRoot, 'comment.md'), comment);
+    if (!existsSync(path.join(outputRoot, 'summary.json'))) {
+      writeFileSync(path.join(outputRoot, 'summary.json'), `${JSON.stringify({ error: 'evaluation infrastructure failed' }, null, 2)}\n`);
+    }
     console.error(`[skill-eval] ${error instanceof Error ? error.message : error}`);
     process.exitCode = 1;
   });

--- a/.github/scripts/skill-eval.mjs
+++ b/.github/scripts/skill-eval.mjs
@@ -1,0 +1,567 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawn } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SKILL_PATH = /^(packages\/[^/]+\/skills\/[^/]+)(?:\/|$)/;
+
+export function selectSkillChanges(changedFiles, hasPath) {
+  const roots = [
+    ...new Set(changedFiles.map((file) => SKILL_PATH.exec(file)?.[1]).filter(Boolean)),
+  ].sort();
+
+  return roots.flatMap((path) => {
+    const skillFile = `${path}/SKILL.md`;
+    const inBase = hasPath('base', skillFile);
+    const inHead = hasPath('head', skillFile);
+    if (!inHead) return [];
+    return [{ type: inBase ? 'modified' : 'added', path }];
+  });
+}
+
+function requireString(value, label, max = 20_000) {
+  if (typeof value !== 'string' || !value.trim() || value.length > max) {
+    throw new Error(`${label} must be a non-empty string up to ${max} characters`);
+  }
+}
+
+function requireStringList(value, label) {
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.length === 0 || value.length > 20) {
+    throw new Error(`${label} must be a non-empty array with at most 20 entries`);
+  }
+  for (const [index, item] of value.entries()) requireString(item, `${label}[${index}]`, 500);
+}
+
+export function validateEvalSet(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('evals.json must contain an object');
+  }
+  requireString(value.skill_name, 'skill_name', 64);
+  if (!/^[a-z0-9-]+$/.test(value.skill_name)) {
+    throw new Error('skill_name must use lowercase letters, digits, and hyphens');
+  }
+  if (!Array.isArray(value.evals) || value.evals.length < 3 || value.evals.length > 5) {
+    throw new Error('evals must contain between 3 and 5 cases');
+  }
+
+  const ids = new Set();
+  for (const [index, item] of value.evals.entries()) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      throw new Error(`evals[${index}] must be an object`);
+    }
+    const id = String(item.id ?? '');
+    requireString(id, `evals[${index}].id`, 80);
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(id)) {
+      throw new Error('eval id must use lowercase letters, digits, and hyphens');
+    }
+    if (ids.has(id)) throw new Error(`duplicate eval id "${id}"`);
+    ids.add(id);
+    requireString(item.prompt, `evals[${index}].prompt`);
+    requireString(item.expected_output, `evals[${index}].expected_output`);
+    if (!Array.isArray(item.expectations) || item.expectations.length === 0) {
+      throw new Error(`evals[${index}].expectations must be a non-empty array`);
+    }
+    for (const [expectationIndex, expectation] of item.expectations.entries()) {
+      const label = `evals[${index}].expectations[${expectationIndex}]`;
+      if (!expectation || typeof expectation !== 'object' || Array.isArray(expectation)) {
+        throw new Error(`${label} must be an object`);
+      }
+      requireString(expectation.text, `${label}.text`, 500);
+      requireStringList(expectation.includes, `${label}.includes`);
+      requireStringList(expectation.includes_any, `${label}.includes_any`);
+      requireStringList(expectation.excludes, `${label}.excludes`);
+      if (!expectation.includes && !expectation.includes_any && !expectation.excludes) {
+        throw new Error(`${label} must define includes, includes_any, or excludes`);
+      }
+    }
+  }
+  return value;
+}
+
+export function selectRegressionEvalSet(base, head) {
+  if (base.skill_name !== head.skill_name) throw new Error('base and head skill_name must match');
+  return base;
+}
+
+export function gradeExpectations(answer, expectations) {
+  const haystack = answer.toLocaleLowerCase();
+  const graded = expectations.map((expectation) => {
+    const includes = expectation.includes ?? [];
+    const includesAny = expectation.includes_any ?? [];
+    const excludes = expectation.excludes ?? [];
+    const missing = includes.filter((value) => !haystack.includes(value.toLocaleLowerCase()));
+    const matchedAny = includesAny.filter((value) => haystack.includes(value.toLocaleLowerCase()));
+    const unexpected = excludes.filter((value) => haystack.includes(value.toLocaleLowerCase()));
+    const passed = missing.length === 0 && (includesAny.length === 0 || matchedAny.length > 0) && unexpected.length === 0;
+
+    const evidence = passed
+      ? [
+          includes.length ? `included: ${includes.join(', ')}` : '',
+          includesAny.length ? `included one of: ${includesAny.join(', ')}` : '',
+          excludes.length ? `excluded: ${excludes.join(', ')}` : '',
+        ]
+          .filter(Boolean)
+          .join('; ')
+      : [
+          missing.length ? `missing: ${missing.join(', ')}` : '',
+          includesAny.length && matchedAny.length === 0
+            ? `missing every alternative: ${includesAny.join(', ')}`
+            : '',
+          unexpected.length ? `unexpected: ${unexpected.join(', ')}` : '',
+        ]
+          .filter(Boolean)
+          .join('; ');
+    return { text: expectation.text, passed, evidence };
+  });
+  const passed = graded.filter((expectation) => expectation.passed).length;
+  return { passed, total: graded.length, score: passed / graded.length, expectations: graded };
+}
+
+const mean = (values) => values.reduce((sum, value) => sum + value, 0) / values.length;
+
+function scoresFor(runs, configuration, evalIds) {
+  const allowed = evalIds ? new Set(evalIds.map(String)) : undefined;
+  return runs.filter(
+    (run) => run.configuration === configuration && (!allowed || allowed.has(String(run.eval_id))),
+  );
+}
+
+export function evaluateGate({
+  type,
+  runs,
+  baseEvalIds = [],
+  minScore = 0.8,
+  minDelta = 0.1,
+  minCases = 3,
+}) {
+  const reasons = [];
+  const failedRuns = runs.filter((run) => run.failure_mode !== 'ok');
+  if (failedRuns.length) reasons.push(`${failedRuns.length} run(s) failed before grading`);
+
+  const gateIds = type === 'modified' && baseEvalIds.length ? baseEvalIds : undefined;
+  const candidate = scoresFor(runs, 'candidate', gateIds);
+  const baseline = scoresFor(runs, 'baseline', gateIds);
+  if (!candidate.length || !baseline.length) reasons.push('candidate and baseline runs are both required');
+
+  const candidateScore = candidate.length ? mean(candidate.map((run) => run.score)) : 0;
+  const baselineScore = baseline.length ? mean(baseline.map((run) => run.score)) : 0;
+  const delta = candidateScore - baselineScore;
+
+  if (type === 'added') {
+    const evalCount = new Set(candidate.map((run) => String(run.eval_id))).size;
+    if (evalCount < minCases) reasons.push(`new skills require at least ${minCases} eval cases`);
+    if (candidateScore < minScore) reasons.push(`candidate score ${candidateScore.toFixed(3)} is below ${minScore.toFixed(3)}`);
+    if (delta < minDelta) reasons.push(`candidate delta ${delta.toFixed(3)} is below +${minDelta.toFixed(3)}`);
+  } else {
+    if (delta < 0) reasons.push(`candidate aggregate regressed by ${delta.toFixed(3)}`);
+    for (const evalId of new Set(candidate.map((run) => String(run.eval_id)))) {
+      const candidateEval = candidate.filter((run) => String(run.eval_id) === evalId);
+      const baselineEval = baseline.filter((run) => String(run.eval_id) === evalId);
+      if (baselineEval.length && mean(candidateEval.map((run) => run.score)) < mean(baselineEval.map((run) => run.score))) {
+        reasons.push(`${evalId} regressed`);
+      }
+    }
+  }
+
+  return { passed: reasons.length === 0, candidateScore, baselineScore, delta, reasons };
+}
+
+export function formatComment(results, { runUrl, artifactName }) {
+  const passed = results.length > 0 && results.every((result) => result.gate.passed);
+  const lines = [
+    `### ${passed ? '✅ Skill Eval — passed' : '❌ Skill Eval — failed'}`,
+    '',
+    '| skill | change | candidate | baseline | delta | gate |',
+    '|---|---|---:|---:|---:|:---:|',
+  ];
+  for (const result of results) {
+    const { gate } = result;
+    lines.push(
+      `| \`${result.skill}\` | ${result.type} | ${gate.candidateScore.toFixed(3)} | ${gate.baselineScore.toFixed(3)} | ${gate.delta >= 0 ? '+' : ''}${gate.delta.toFixed(3)} | ${gate.passed ? '✅' : '❌'} |`,
+    );
+  }
+  const failures = results.flatMap((result) =>
+    result.gate.reasons.map((reason) => `- \`${result.skill}\`: ${reason}`),
+  );
+  if (failures.length) lines.push('', '**Failures**', '', ...failures);
+  lines.push(
+    '',
+    'New skills require score ≥ 0.800 and delta ≥ +0.100. Modified skills must not regress on any master eval.',
+    '',
+    `[Workflow logs](${runUrl}) · Artifact: \`${artifactName}\``,
+    '',
+    '<sub>Pi skill eval bot</sub>',
+  );
+  return `${lines.join('\n')}\n`;
+}
+
+function git(args, options = {}) {
+  return execFileSync('git', args, {
+    encoding: options.encoding ?? 'utf8',
+    maxBuffer: options.maxBuffer ?? 10 * 1024 * 1024,
+  });
+}
+
+function revisionHasPath(revision, file) {
+  try {
+    git(['cat-file', '-e', `${revision}:${file}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readJsonAt(revision, file) {
+  try {
+    return JSON.parse(git(['show', `${revision}:${file}`]));
+  } catch (error) {
+    throw new Error(`cannot read ${file} at ${revision}: ${error instanceof Error ? error.message : error}`);
+  }
+}
+
+function materializeSkill(revision, skillRoot, destination) {
+  const listing = git(['ls-tree', '-r', '-z', revision, '--', skillRoot]);
+  let total = 0;
+  for (const record of listing.split('\0').filter(Boolean)) {
+    const match = /^(\d+) (\w+) ([0-9a-f]+)\t(.+)$/.exec(record);
+    if (!match || match[2] !== 'blob' || !match[1].startsWith('100')) {
+      throw new Error(`unsupported git entry under ${skillRoot}`);
+    }
+    const [, , , oid, file] = match;
+    const relative = path.relative(skillRoot, file);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error(`unsafe skill path: ${file}`);
+    }
+    const size = Number(git(['cat-file', '-s', oid]));
+    if (!Number.isSafeInteger(size) || size > 1024 * 1024) {
+      throw new Error(`${file} exceeds the 1 MiB skill-eval file limit`);
+    }
+    total += size;
+    if (total > 5 * 1024 * 1024) throw new Error(`${skillRoot} exceeds the 5 MiB skill-eval limit`);
+    const target = path.join(destination, relative);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, git(['cat-file', 'blob', oid], { encoding: null, maxBuffer: size + 1024 }));
+  }
+  if (!revisionHasPath(revision, `${skillRoot}/SKILL.md`)) {
+    throw new Error(`${skillRoot}/SKILL.md is missing at ${revision}`);
+  }
+}
+
+function skillName(skillFile) {
+  const frontmatter = /^---\s*\n([\s\S]*?)\n---/.exec(readFileSync(skillFile, 'utf8'))?.[1] ?? '';
+  const name = /^name:\s*["']?([^\s"']+)["']?\s*$/m.exec(frontmatter)?.[1];
+  if (!name || !/^[a-z0-9-]+$/.test(name)) throw new Error(`${skillFile} has an invalid name`);
+  return name;
+}
+
+function runPi({ cwd, skillDir, prompt, timeoutMs }) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const args = [
+      '--provider',
+      process.env.SKILL_EVAL_PROVIDER || 'deepseek-integration',
+      '--model',
+      process.env.SKILL_EVAL_MODEL || 'deepseek-v4-flash',
+      '--thinking',
+      process.env.SKILL_EVAL_THINKING || 'high',
+      '--system-prompt',
+      'Answer the user request directly. Do not call or simulate tools. Follow any appended skill instructions as the governing workflow.',
+      '--no-session',
+      '--no-context-files',
+      '--approve',
+      '--offline',
+      '--no-extensions',
+      '--no-skills',
+      '--no-tools',
+    ];
+    if (skillDir) args.push('--append-system-prompt', path.join(skillDir, 'SKILL.md'));
+    args.push('--mode', 'text', '-p', prompt);
+
+    const child = spawn('pi', args, { cwd, env: process.env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    let killedForSize = false;
+    const timer = setTimeout(() => child.kill('SIGKILL'), timeoutMs);
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+      if (Buffer.byteLength(stdout) > 256 * 1024) {
+        killedForSize = true;
+        child.kill('SIGKILL');
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      if (stderr.length < 16_000) stderr += chunk;
+    });
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      resolve({ answer: '', failure_mode: 'crash', error: error.message.slice(0, 300), duration_ms: Date.now() - started });
+    });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      const answer = stdout.trim().slice(0, 20_000);
+      const failure =
+        killedForSize ? 'Pi output exceeded 256 KiB' : signal === 'SIGKILL' ? `Pi timed out after ${timeoutMs}ms` : code !== 0 ? `Pi exited ${code}: ${stderr.slice(-200)}` : !answer ? 'Pi returned no assistant text' : '';
+      resolve({
+        answer,
+        failure_mode: failure ? 'crash' : 'ok',
+        ...(failure ? { error: failure } : {}),
+        duration_ms: Date.now() - started,
+      });
+    });
+  });
+}
+
+function safeSegment(value) {
+  return String(value).replace(/[^a-zA-Z0-9._-]+/g, '-').slice(0, 100);
+}
+
+function writeRun(workspace, evalItem, configuration, runNumber, run) {
+  const evalDir = path.join(workspace, `eval-${safeSegment(evalItem.id)}`);
+  const runDir = path.join(evalDir, configuration, `run-${runNumber}`);
+  const outputsDir = path.join(runDir, 'outputs');
+  mkdirSync(outputsDir, { recursive: true });
+  writeFileSync(
+    path.join(runDir, 'eval_metadata.json'),
+    `${JSON.stringify({ eval_id: evalItem.id, eval_name: evalItem.id, prompt: evalItem.prompt }, null, 2)}\n`,
+  );
+  writeFileSync(path.join(outputsDir, 'response.md'), `${run.answer || `Evaluation failed: ${run.error ?? 'unknown error'}`}\n`);
+  writeFileSync(
+    path.join(runDir, 'grading.json'),
+    `${JSON.stringify(
+      {
+        expectations: run.grading.expectations,
+        summary: {
+          passed: run.grading.passed,
+          failed: run.grading.total - run.grading.passed,
+          total: run.grading.total,
+          pass_rate: run.grading.score,
+        },
+        execution_metrics: { errors_encountered: run.failure_mode === 'ok' ? 0 : 1 },
+        timing: { total_duration_seconds: run.duration_ms / 1000 },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    path.join(runDir, 'timing.json'),
+    `${JSON.stringify({ duration_ms: run.duration_ms, total_duration_seconds: run.duration_ms / 1000 }, null, 2)}\n`,
+  );
+}
+
+function stats(values) {
+  const average = values.length ? mean(values) : 0;
+  const variance = values.length > 1
+    ? values.reduce((sum, value) => sum + (value - average) ** 2, 0) / (values.length - 1)
+    : 0;
+  return {
+    mean: average,
+    stddev: Math.sqrt(variance),
+    min: values.length ? Math.min(...values) : 0,
+    max: values.length ? Math.max(...values) : 0,
+  };
+}
+
+function buildBenchmark({ skill, skillPath, type, runs, runCount, gate }) {
+  const candidate = type === 'added' ? 'with_skill' : 'new_skill';
+  const baseline = type === 'added' ? 'without_skill' : 'old_skill';
+  const label = (configuration) => (configuration === 'candidate' ? candidate : baseline);
+  const grouped = Object.fromEntries(
+    [candidate, baseline].map((configuration) => {
+      const values = runs.filter((run) => label(run.configuration) === configuration);
+      return [
+        configuration,
+        {
+          pass_rate: stats(values.map((run) => run.score)),
+          time_seconds: stats(values.map((run) => run.duration_ms / 1000)),
+        },
+      ];
+    }),
+  );
+  const timeDelta = grouped[candidate].time_seconds.mean - grouped[baseline].time_seconds.mean;
+  return {
+    metadata: {
+      skill_name: skill,
+      skill_path: skillPath,
+      executor_model: process.env.SKILL_EVAL_MODEL || 'deepseek-v4-flash',
+      timestamp: new Date().toISOString(),
+      evals_run: [...new Set(runs.map((run) => run.eval_id))],
+      runs_per_configuration: runCount,
+    },
+    runs: runs.map((run) => ({
+      eval_id: run.eval_id,
+      eval_name: run.eval_id,
+      configuration: label(run.configuration),
+      run_number: run.run_number,
+      result: {
+        pass_rate: run.score,
+        passed: run.grading.passed,
+        failed: run.grading.total - run.grading.passed,
+        total: run.grading.total,
+        time_seconds: run.duration_ms / 1000,
+        tool_calls: 0,
+        errors: run.failure_mode === 'ok' ? 0 : 1,
+      },
+      expectations: run.grading.expectations,
+      notes: run.error ? [run.error] : [],
+    })),
+    run_summary: {
+      ...grouped,
+      delta: {
+        pass_rate: `${gate.delta >= 0 ? '+' : ''}${gate.delta.toFixed(3)}`,
+        time_seconds: `${timeDelta >= 0 ? '+' : ''}${timeDelta.toFixed(3)}`,
+      },
+    },
+    notes: gate.reasons,
+  };
+}
+
+async function evaluateSkill({ change, base, head, tempRoot, outputRoot, cwd, runCount, timeoutMs }) {
+  const candidateDir = path.join(tempRoot, 'candidate', change.path);
+  materializeSkill(head, change.path, candidateDir);
+  const skill = skillName(path.join(candidateDir, 'SKILL.md'));
+  const evalPath = `${change.path}/evals.json`;
+  if (!revisionHasPath(head, evalPath)) throw new Error(`${evalPath} is required`);
+  const headEvals = validateEvalSet(readJsonAt(head, evalPath));
+  if (headEvals.skill_name !== skill) throw new Error(`${evalPath} skill_name must be "${skill}"`);
+
+  let evalSet = headEvals;
+  let baseEvalIds = [];
+  let baselineDir;
+  if (change.type === 'modified') {
+    baselineDir = path.join(tempRoot, 'baseline', change.path);
+    materializeSkill(base, change.path, baselineDir);
+    if (revisionHasPath(base, evalPath)) {
+      const baseEvals = validateEvalSet(readJsonAt(base, evalPath));
+      evalSet = selectRegressionEvalSet(baseEvals, headEvals);
+      baseEvalIds = baseEvals.evals.map((item) => String(item.id));
+    }
+  }
+
+  const workspace = path.join(outputRoot, safeSegment(skill));
+  mkdirSync(workspace, { recursive: true });
+  const runs = [];
+  for (const evalItem of evalSet.evals) {
+    for (let runNumber = 1; runNumber <= runCount; runNumber++) {
+      const [candidateRun, baselineRun] = await Promise.all([
+        runPi({ cwd, skillDir: candidateDir, prompt: evalItem.prompt, timeoutMs }),
+        runPi({ cwd, skillDir: baselineDir, prompt: evalItem.prompt, timeoutMs }),
+      ]);
+      for (const [configuration, result] of [
+        ['candidate', candidateRun],
+        ['baseline', baselineRun],
+      ]) {
+        const grading = result.failure_mode === 'ok'
+          ? gradeExpectations(result.answer, evalItem.expectations)
+          : {
+              passed: 0,
+              total: evalItem.expectations.length,
+              score: 0,
+              expectations: evalItem.expectations.map((expectation) => ({
+                text: expectation.text,
+                passed: false,
+                evidence: result.error ?? 'evaluation failed',
+              })),
+            };
+        const run = {
+          ...result,
+          configuration,
+          eval_id: String(evalItem.id),
+          run_number: runNumber,
+          score: grading.score,
+          grading,
+        };
+        runs.push(run);
+        const viewerConfig = configuration === 'candidate'
+          ? change.type === 'added' ? 'with_skill' : 'new_skill'
+          : change.type === 'added' ? 'without_skill' : 'old_skill';
+        writeRun(workspace, evalItem, viewerConfig, runNumber, run);
+      }
+    }
+  }
+
+  const gate = evaluateGate({ type: change.type, runs, baseEvalIds });
+  const benchmark = buildBenchmark({
+    skill,
+    skillPath: change.path,
+    type: change.type,
+    runs,
+    runCount,
+    gate,
+  });
+  writeFileSync(path.join(workspace, 'benchmark.json'), `${JSON.stringify(benchmark, null, 2)}\n`);
+  return { skill, type: change.type, path: change.path, gate };
+}
+
+async function main() {
+  const base = process.env.SKILL_EVAL_BASE_SHA;
+  const head = process.env.SKILL_EVAL_HEAD_SHA;
+  if (!base || !head) throw new Error('SKILL_EVAL_BASE_SHA and SKILL_EVAL_HEAD_SHA are required');
+  const runCount = Number(process.env.SKILL_EVAL_RUNS || '3');
+  const timeoutMs = Number(process.env.SKILL_EVAL_TIMEOUT_MS || '120000');
+  if (!Number.isInteger(runCount) || runCount < 1 || runCount > 5) throw new Error('SKILL_EVAL_RUNS must be 1..5');
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > 600000) throw new Error('SKILL_EVAL_TIMEOUT_MS must be 1000..600000');
+
+  const cwd = process.cwd();
+  const outputRoot = path.resolve(process.env.SKILL_EVAL_OUTPUT_DIR || 'skill-eval-results');
+  mkdirSync(outputRoot, { recursive: true });
+  const changedFiles = git(['diff', '--name-only', '--no-renames', '-z', base, head])
+    .split('\0')
+    .filter(Boolean);
+  const changes = selectSkillChanges(changedFiles, (revision, file) =>
+    revisionHasPath(revision === 'base' ? base : head, file),
+  );
+  if (!changes.length) throw new Error('no added or modified skills found');
+  if (changes.length > 3) throw new Error('a single PR may evaluate at most 3 skills');
+
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'pi-skill-eval-'));
+  try {
+    const results = [];
+    for (const change of changes) {
+      process.stderr.write(`[skill-eval] ${change.type} ${change.path}\n`);
+      results.push(
+        await evaluateSkill({ change, base, head, tempRoot, outputRoot, cwd, runCount, timeoutMs }),
+      );
+    }
+    const summary = { base, head, skills: results };
+    writeFileSync(path.join(outputRoot, 'summary.json'), `${JSON.stringify(summary, null, 2)}\n`);
+    const comment = formatComment(results, {
+      runUrl: process.env.SKILL_EVAL_RUN_URL || '#',
+      artifactName: process.env.SKILL_EVAL_ARTIFACT || 'skill-eval-results',
+    });
+    writeFileSync(path.join(outputRoot, 'comment.md'), comment);
+    if (process.env.GITHUB_STEP_SUMMARY) writeFileSync(process.env.GITHUB_STEP_SUMMARY, comment, { flag: 'a' });
+    if (results.some((result) => !result.gate.passed)) process.exitCode = 1;
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    const outputRoot = path.resolve(process.env.SKILL_EVAL_OUTPUT_DIR || 'skill-eval-results');
+    mkdirSync(outputRoot, { recursive: true });
+    const comment = [
+      '### ❌ Skill Eval — failed',
+      '',
+      'Evaluation infrastructure failed before producing scores. See the workflow logs.',
+      '',
+      `[Workflow logs](${process.env.SKILL_EVAL_RUN_URL || '#'})`,
+      '',
+    ].join('\n');
+    writeFileSync(path.join(outputRoot, 'comment.md'), comment);
+    writeFileSync(path.join(outputRoot, 'summary.json'), `${JSON.stringify({ error: 'evaluation infrastructure failed' }, null, 2)}\n`);
+    console.error(`[skill-eval] ${error instanceof Error ? error.message : error}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/skill-eval.test.mjs
+++ b/.github/scripts/skill-eval.test.mjs
@@ -4,7 +4,7 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { test } from 'vitest';
+import { describe, it } from 'vitest';
 import {
   evaluateGate,
   formatComment,
@@ -14,10 +14,15 @@ import {
   validateEvalSet,
 } from './skill-eval.mjs';
 
-test('classifies changed skill directories against the base and head revisions', () => {
+describe('skill-eval', () => {
+it('classifies changed skill directories against the base and head revisions', () => {
   const filesByRevision = {
-    base: new Set(['packages/pi-demo/skills/existing/SKILL.md']),
+    base: new Set([
+      'packages/pi-demo/skills/eval-only/SKILL.md',
+      'packages/pi-demo/skills/existing/SKILL.md',
+    ]),
     head: new Set([
+      'packages/pi-demo/skills/eval-only/SKILL.md',
       'packages/pi-demo/skills/existing/SKILL.md',
       'packages/pi-demo/skills/new-skill/SKILL.md',
     ]),
@@ -26,8 +31,10 @@ test('classifies changed skill directories against the base and head revisions',
   assert.deepEqual(
     selectSkillChanges(
       [
+        'packages/pi-demo/skills/eval-only/evals.json',
         'packages/pi-demo/skills/existing/references/guide.md',
         'packages/pi-demo/skills/new-skill/SKILL.md',
+        'packages/pi-demo/skills/README.md',
         'packages/pi-demo/src/index.ts',
       ],
       (revision, path) => filesByRevision[revision].has(path),
@@ -46,7 +53,7 @@ const evalCase = (id, prompt = `prompt ${id}`) => ({
   expectations: [{ text: `checks ${id}`, includes: [`needle-${id}`] }],
 });
 
-test('bounds each eval set to three through five cases', () => {
+it('bounds each eval set to three through five cases', () => {
   assert.throws(
     () => validateEvalSet({ skill_name: 'demo', evals: [evalCase('a'), evalCase('b')] }),
     /between 3 and 5 cases/,
@@ -66,7 +73,19 @@ test('bounds each eval set to three through five cases', () => {
   );
 });
 
-test('uses the trusted base eval set when an existing skill changes', () => {
+it('bounds each eval case to twenty expectations', () => {
+  const evals = [evalCase('a'), evalCase('b'), evalCase('c')];
+  evals[0].expectations = Array.from({ length: 21 }, (_, index) => ({
+    text: `expectation ${index}`,
+    includes: [`needle-${index}`],
+  }));
+  assert.throws(
+    () => validateEvalSet({ skill_name: 'demo', evals }),
+    /at most 20 entries/,
+  );
+});
+
+it('uses the trusted base eval set when an existing skill changes', () => {
   const base = {
     skill_name: 'demo',
     evals: [evalCase('existing'), evalCase('safety'), evalCase('routing')],
@@ -98,7 +117,7 @@ test('uses the trusted base eval set when an existing skill changes', () => {
   );
 });
 
-test('grades declarative expectations without executing eval-controlled code', () => {
+it('grades declarative expectations without executing eval-controlled code', () => {
   assert.deepEqual(
     gradeExpectations('Use VIDEO_COMPOSE locally. Do not call a paid model.', [
       { text: 'routes locally', includes: ['video_compose', 'locally'] },
@@ -118,7 +137,7 @@ test('grades declarative expectations without executing eval-controlled code', (
   );
 });
 
-test('requires new skills to clear both the absolute score and improvement delta', () => {
+it('requires new skills to clear both the absolute score and improvement delta', () => {
   const runs = [
     { configuration: 'candidate', eval_id: 'a', score: 1, failure_mode: 'ok' },
     { configuration: 'candidate', eval_id: 'b', score: 0.8, failure_mode: 'ok' },
@@ -139,7 +158,7 @@ test('requires new skills to clear both the absolute score and improvement delta
   );
 });
 
-test('rejects a modified skill when any base eval regresses', () => {
+it('rejects a modified skill when any base eval regresses', () => {
   const result = evaluateGate({
     type: 'modified',
     baseEvalIds: ['routing', 'safety'],
@@ -154,7 +173,7 @@ test('rejects a modified skill when any base eval regresses', () => {
   assert.match(result.reasons.join('\n'), /routing regressed/);
 });
 
-test('formats one PR comment with gate results and artifact links', () => {
+it('formats one PR comment with gate results and artifact links', () => {
   const comment = formatComment(
     [
       {
@@ -172,8 +191,16 @@ test('formats one PR comment with gate results and artifact links', () => {
   assert.match(comment, /actions\/runs\/42/);
 });
 
-test('runs a changed skill through Pi and writes the PR comment artifact', () => {
+it('runs changed skills through Pi and preserves completed results on a later failure', () => {
   const root = mkdtempSync(path.join(os.tmpdir(), 'pi-skill-eval-test-'));
+  const gitEnv = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+  );
+  const git = (args, options = {}) => execFileSync('git', args, {
+    cwd: root,
+    env: gitEnv,
+    ...options,
+  });
   try {
     const skillDir = path.join(root, 'packages/pi-demo/skills/demo');
     mkdirSync(skillDir, { recursive: true });
@@ -182,23 +209,29 @@ test('runs a changed skill through Pi and writes the PR comment artifact', () =>
       path.join(skillDir, 'evals.json'),
       JSON.stringify({ skill_name: 'demo', evals: [evalCase('a'), evalCase('b'), evalCase('c')] }),
     );
-    execFileSync('git', ['init', '-q'], { cwd: root });
-    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
-    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
-    execFileSync('git', ['add', '.'], { cwd: root });
-    execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
-    const base = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+    const incompleteSkillDir = path.join(root, 'packages/pi-demo/skills/zzz-incomplete');
+    mkdirSync(incompleteSkillDir, { recursive: true });
+    writeFileSync(
+      path.join(incompleteSkillDir, 'SKILL.md'),
+      '---\nname: zzz-incomplete\ndescription: incomplete\n---\nbase\n',
+    );
+    git(['init', '-q']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'Test']);
+    git(['add', '.']);
+    git(['commit', '-qm', 'base']);
+    const base = git(['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
     writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: demo\ndescription: demo\n---\nhead\n');
-    execFileSync('git', ['add', '.'], { cwd: root });
-    execFileSync('git', ['commit', '-qm', 'head'], { cwd: root });
-    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+    git(['add', '.']);
+    git(['commit', '-qm', 'head']);
+    const head = git(['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
 
     const bin = path.join(root, 'bin');
     mkdirSync(bin);
     const fakePi = path.join(bin, 'pi');
     writeFileSync(
       fakePi,
-      `#!/usr/bin/env node\nconst prompt = process.argv[process.argv.indexOf('-p') + 1];\nconst hasInjectedSkill = process.argv.includes('--append-system-prompt');\nconst ids = ['a','b','c'].filter((id) => prompt.includes('prompt ' + id));\nconsole.log(hasInjectedSkill ? ids.map((id) => 'needle-' + id).join(' ') : '');\n`,
+      `#!/usr/bin/env node\nif (process.env.FAKE_PI_FAIL === '1') { console.error('sensitive-provider-body'); process.exit(2); }\nconst prompt = process.argv[process.argv.indexOf('-p') + 1];\nconst hasInjectedSkill = process.argv.includes('--append-system-prompt');\nconst ids = ['a','b','c'].filter((id) => prompt.includes('prompt ' + id));\nconsole.log(hasInjectedSkill ? ids.map((id) => 'needle-' + id).join(' ') : '');\n`,
     );
     chmodSync(fakePi, 0o755);
 
@@ -208,8 +241,8 @@ test('runs a changed skill through Pi and writes the PR comment artifact', () =>
       cwd: root,
       encoding: 'utf8',
       env: {
-        ...process.env,
-        PATH: `${bin}:${process.env.PATH}`,
+        ...gitEnv,
+        PATH: `${bin}:${gitEnv.PATH}`,
         SKILL_EVAL_BASE_SHA: base,
         SKILL_EVAL_HEAD_SHA: head,
         SKILL_EVAL_OUTPUT_DIR: outputDir,
@@ -221,21 +254,79 @@ test('runs a changed skill through Pi and writes the PR comment artifact', () =>
     assert.equal(run.status, 0, run.stderr);
     assert.match(readFileSync(path.join(outputDir, 'comment.md'), 'utf8'), /✅ Skill Eval — passed/);
     assert.equal(JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8')).skills[0].skill, 'demo');
+    const metadata = JSON.parse(
+      readFileSync(path.join(outputDir, 'demo/eval-a/new_skill/run-1/eval_metadata.json'), 'utf8'),
+    );
+    assert.equal(metadata.eval_id, 'a');
+    assert.equal(metadata.expected_output, 'expected a');
     assert.equal(
       JSON.parse(
-        readFileSync(
-          path.join(outputDir, 'demo/eval-a/new_skill/run-1/eval_metadata.json'),
-          'utf8',
-        ),
-      ).eval_id,
-      'a',
+        readFileSync(path.join(outputDir, 'demo/eval-a/new_skill/run-1/grading.json'), 'utf8'),
+      ).expected_output,
+      'expected a',
     );
+
+    const sanitizedOutputDir = path.join(root, 'sanitized-results');
+    const failedPiRun = spawnSync(process.execPath, [script], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...gitEnv,
+        PATH: `${bin}:${gitEnv.PATH}`,
+        FAKE_PI_FAIL: '1',
+        SKILL_EVAL_BASE_SHA: base,
+        SKILL_EVAL_HEAD_SHA: head,
+        SKILL_EVAL_OUTPUT_DIR: sanitizedOutputDir,
+        SKILL_EVAL_RUNS: '1',
+      },
+    });
+    assert.equal(failedPiRun.status, 1);
+    const failureArtifacts = [
+      'demo/eval-a/new_skill/run-1/outputs/response.md',
+      'demo/eval-a/new_skill/run-1/grading.json',
+      'demo/benchmark.json',
+    ].map((relative) => readFileSync(path.join(sanitizedOutputDir, relative), 'utf8')).join('\n');
+    assert.doesNotMatch(failureArtifacts, /sensitive-provider-body/);
+
+    writeFileSync(
+      path.join(incompleteSkillDir, 'SKILL.md'),
+      '---\nname: zzz-incomplete\ndescription: incomplete\n---\nhead\n',
+    );
+    writeFileSync(
+      path.join(incompleteSkillDir, 'evals.json'),
+      JSON.stringify({ skill_name: 'zzz-incomplete', evals: [evalCase('x'), evalCase('y'), evalCase('z')] }),
+    );
+    git(['add', '.']);
+    git(['commit', '-qm', 'add incomplete eval set while changing skill']);
+    const failingHead = git(['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+    const partialOutputDir = path.join(root, 'partial-results');
+    const failedRun = spawnSync(process.execPath, [script], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...gitEnv,
+        PATH: `${bin}:${gitEnv.PATH}`,
+        SKILL_EVAL_BASE_SHA: base,
+        SKILL_EVAL_HEAD_SHA: failingHead,
+        SKILL_EVAL_OUTPUT_DIR: partialOutputDir,
+        SKILL_EVAL_RUNS: '1',
+      },
+    });
+    assert.equal(failedRun.status, 1);
+    const partialSummary = JSON.parse(readFileSync(path.join(partialOutputDir, 'summary.json'), 'utf8'));
+    assert.equal(partialSummary.skills.length, 1);
+    assert.equal(partialSummary.skills[0].skill, 'demo');
+    assert.equal(partialSummary.error, 'evaluation infrastructure failed');
+    const partialComment = readFileSync(path.join(partialOutputDir, 'comment.md'), 'utf8');
+    assert.match(partialComment, /Skill Eval — failed/);
+    assert.match(partialComment, /`demo`/);
+    assert.match(partialComment, /Infrastructure failure/);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
 });
 
-test('validates every bundled skill eval set', () => {
+it('validates every bundled skill eval set', () => {
   for (const relative of [
     '../../packages/pi-image-gen/skills/image-gen/evals.json',
     '../../packages/pi-video-gen/skills/video-gen/evals.json',
@@ -245,7 +336,7 @@ test('validates every bundled skill eval set', () => {
   }
 });
 
-test('uses trusted base code, comments before enforcing, and never executes PR code', () => {
+it('uses trusted base code, comments before enforcing, and never executes PR code', () => {
   const workflow = readFileSync(
     fileURLToPath(new URL('../workflows/skill-eval.yml', import.meta.url)),
     'utf8',
@@ -255,6 +346,9 @@ test('uses trusted base code, comments before enforcing, and never executes PR c
   assert.match(workflow, /pull-requests: write/);
   assert.match(workflow, /continue-on-error: true/);
   assert.match(workflow, /peter-evans\/create-or-update-comment@v4/);
+  assert.match(workflow, /skill-eval\.mjs --detect/);
+  assert.match(workflow, /timeout-minutes: 120/);
   assert.ok(workflow.indexOf('Post PR comment') < workflow.indexOf('Enforce gate outcome'));
   assert.doesNotMatch(workflow, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/);
+});
 });

--- a/.github/scripts/skill-eval.test.mjs
+++ b/.github/scripts/skill-eval.test.mjs
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'vitest';
+import {
+  evaluateGate,
+  formatComment,
+  gradeExpectations,
+  selectRegressionEvalSet,
+  selectSkillChanges,
+  validateEvalSet,
+} from './skill-eval.mjs';
+
+test('classifies changed skill directories against the base and head revisions', () => {
+  const filesByRevision = {
+    base: new Set(['packages/pi-demo/skills/existing/SKILL.md']),
+    head: new Set([
+      'packages/pi-demo/skills/existing/SKILL.md',
+      'packages/pi-demo/skills/new-skill/SKILL.md',
+    ]),
+  };
+
+  assert.deepEqual(
+    selectSkillChanges(
+      [
+        'packages/pi-demo/skills/existing/references/guide.md',
+        'packages/pi-demo/skills/new-skill/SKILL.md',
+        'packages/pi-demo/src/index.ts',
+      ],
+      (revision, path) => filesByRevision[revision].has(path),
+    ),
+    [
+      { type: 'modified', path: 'packages/pi-demo/skills/existing' },
+      { type: 'added', path: 'packages/pi-demo/skills/new-skill' },
+    ],
+  );
+});
+
+const evalCase = (id, prompt = `prompt ${id}`) => ({
+  id,
+  prompt,
+  expected_output: `expected ${id}`,
+  expectations: [{ text: `checks ${id}`, includes: [`needle-${id}`] }],
+});
+
+test('bounds each eval set to three through five cases', () => {
+  assert.throws(
+    () => validateEvalSet({ skill_name: 'demo', evals: [evalCase('a'), evalCase('b')] }),
+    /between 3 and 5 cases/,
+  );
+  assert.doesNotThrow(() =>
+    validateEvalSet({
+      skill_name: 'demo',
+      evals: ['a', 'b', 'c', 'd', 'e'].map((id) => evalCase(id)),
+    }),
+  );
+  assert.throws(
+    () => validateEvalSet({
+      skill_name: 'demo',
+      evals: [evalCase('<img>'), evalCase('b'), evalCase('c')],
+    }),
+    /eval id must use/,
+  );
+});
+
+test('uses the trusted base eval set when an existing skill changes', () => {
+  const base = {
+    skill_name: 'demo',
+    evals: [evalCase('existing'), evalCase('safety'), evalCase('routing')],
+  };
+  const head = {
+    skill_name: 'demo',
+    evals: [
+      evalCase('existing', 'updated for the next PR'),
+      evalCase('safety'),
+      evalCase('routing'),
+      evalCase('new'),
+    ],
+  };
+
+  assert.deepEqual(
+    selectRegressionEvalSet(validateEvalSet(base), validateEvalSet(head)),
+    base,
+  );
+
+  assert.throws(
+    () => selectRegressionEvalSet(
+      validateEvalSet(base),
+      validateEvalSet({
+        skill_name: 'renamed',
+        evals: [evalCase('existing'), evalCase('safety'), evalCase('routing')],
+      }),
+    ),
+    /skill_name must match/,
+  );
+});
+
+test('grades declarative expectations without executing eval-controlled code', () => {
+  assert.deepEqual(
+    gradeExpectations('Use VIDEO_COMPOSE locally. Do not call a paid model.', [
+      { text: 'routes locally', includes: ['video_compose', 'locally'] },
+      { text: 'avoids paid generation', excludes: ['video_generate', 'video_render'] },
+      { text: 'names a local signal', includes_any: ['ffmpeg', 'local'] },
+    ]),
+    {
+      passed: 3,
+      total: 3,
+      score: 1,
+      expectations: [
+        { text: 'routes locally', passed: true, evidence: 'included: video_compose, locally' },
+        { text: 'avoids paid generation', passed: true, evidence: 'excluded: video_generate, video_render' },
+        { text: 'names a local signal', passed: true, evidence: 'included one of: ffmpeg, local' },
+      ],
+    },
+  );
+});
+
+test('requires new skills to clear both the absolute score and improvement delta', () => {
+  const runs = [
+    { configuration: 'candidate', eval_id: 'a', score: 1, failure_mode: 'ok' },
+    { configuration: 'candidate', eval_id: 'b', score: 0.8, failure_mode: 'ok' },
+    { configuration: 'candidate', eval_id: 'c', score: 0.9, failure_mode: 'ok' },
+    { configuration: 'baseline', eval_id: 'a', score: 0.7, failure_mode: 'ok' },
+    { configuration: 'baseline', eval_id: 'b', score: 0.7, failure_mode: 'ok' },
+    { configuration: 'baseline', eval_id: 'c', score: 0.6, failure_mode: 'ok' },
+  ];
+  assert.equal(evaluateGate({ type: 'added', runs }).passed, true);
+  assert.match(
+    evaluateGate({
+      type: 'added',
+      runs: runs.map((run) =>
+        run.configuration === 'baseline' ? { ...run, score: run.score + 0.2 } : run,
+      ),
+    }).reasons.join('\n'),
+    /delta/,
+  );
+});
+
+test('rejects a modified skill when any base eval regresses', () => {
+  const result = evaluateGate({
+    type: 'modified',
+    baseEvalIds: ['routing', 'safety'],
+    runs: [
+      { configuration: 'candidate', eval_id: 'routing', score: 0.5, failure_mode: 'ok' },
+      { configuration: 'baseline', eval_id: 'routing', score: 1, failure_mode: 'ok' },
+      { configuration: 'candidate', eval_id: 'safety', score: 1, failure_mode: 'ok' },
+      { configuration: 'baseline', eval_id: 'safety', score: 0.5, failure_mode: 'ok' },
+    ],
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.reasons.join('\n'), /routing regressed/);
+});
+
+test('formats one PR comment with gate results and artifact links', () => {
+  const comment = formatComment(
+    [
+      {
+        skill: 'video-gen',
+        type: 'modified',
+        gate: { passed: false, candidateScore: 0.75, baselineScore: 1, delta: -0.25, reasons: ['routing regressed'] },
+      },
+    ],
+    { runUrl: 'https://github.example/actions/runs/42', artifactName: 'skill-eval-42' },
+  );
+  assert.match(comment, /❌ Skill Eval — failed/);
+  assert.match(comment, /\| `video-gen` \| modified \| 0\.750 \| 1\.000 \| -0\.250 \| ❌ \|/);
+  assert.match(comment, /routing regressed/);
+  assert.match(comment, /skill-eval-42/);
+  assert.match(comment, /actions\/runs\/42/);
+});
+
+test('runs a changed skill through Pi and writes the PR comment artifact', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'pi-skill-eval-test-'));
+  try {
+    const skillDir = path.join(root, 'packages/pi-demo/skills/demo');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: demo\ndescription: demo\n---\nbase\n');
+    writeFileSync(
+      path.join(skillDir, 'evals.json'),
+      JSON.stringify({ skill_name: 'demo', evals: [evalCase('a'), evalCase('b'), evalCase('c')] }),
+    );
+    execFileSync('git', ['init', '-q'], { cwd: root });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+    execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+    execFileSync('git', ['add', '.'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'base'], { cwd: root });
+    const base = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+    writeFileSync(path.join(skillDir, 'SKILL.md'), '---\nname: demo\ndescription: demo\n---\nhead\n');
+    execFileSync('git', ['add', '.'], { cwd: root });
+    execFileSync('git', ['commit', '-qm', 'head'], { cwd: root });
+    const head = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+
+    const bin = path.join(root, 'bin');
+    mkdirSync(bin);
+    const fakePi = path.join(bin, 'pi');
+    writeFileSync(
+      fakePi,
+      `#!/usr/bin/env node\nconst prompt = process.argv[process.argv.indexOf('-p') + 1];\nconst hasInjectedSkill = process.argv.includes('--append-system-prompt');\nconst ids = ['a','b','c'].filter((id) => prompt.includes('prompt ' + id));\nconsole.log(hasInjectedSkill ? ids.map((id) => 'needle-' + id).join(' ') : '');\n`,
+    );
+    chmodSync(fakePi, 0o755);
+
+    const outputDir = path.join(root, 'results');
+    const script = fileURLToPath(new URL('./skill-eval.mjs', import.meta.url));
+    const run = spawnSync(process.execPath, [script], {
+      cwd: root,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        SKILL_EVAL_BASE_SHA: base,
+        SKILL_EVAL_HEAD_SHA: head,
+        SKILL_EVAL_OUTPUT_DIR: outputDir,
+        SKILL_EVAL_RUNS: '1',
+        SKILL_EVAL_RUN_URL: 'https://github.example/actions/runs/42',
+        SKILL_EVAL_ARTIFACT: 'skill-eval-42',
+      },
+    });
+    assert.equal(run.status, 0, run.stderr);
+    assert.match(readFileSync(path.join(outputDir, 'comment.md'), 'utf8'), /✅ Skill Eval — passed/);
+    assert.equal(JSON.parse(readFileSync(path.join(outputDir, 'summary.json'), 'utf8')).skills[0].skill, 'demo');
+    assert.equal(
+      JSON.parse(
+        readFileSync(
+          path.join(outputDir, 'demo/eval-a/new_skill/run-1/eval_metadata.json'),
+          'utf8',
+        ),
+      ).eval_id,
+      'a',
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('validates every bundled skill eval set', () => {
+  for (const relative of [
+    '../../packages/pi-image-gen/skills/image-gen/evals.json',
+    '../../packages/pi-video-gen/skills/video-gen/evals.json',
+  ]) {
+    const file = fileURLToPath(new URL(relative, import.meta.url));
+    assert.doesNotThrow(() => validateEvalSet(JSON.parse(readFileSync(file, 'utf8'))), relative);
+  }
+});
+
+test('uses trusted base code, comments before enforcing, and never executes PR code', () => {
+  const workflow = readFileSync(
+    fileURLToPath(new URL('../workflows/skill-eval.yml', import.meta.url)),
+    'utf8',
+  );
+  assert.match(workflow, /pull_request_target:/);
+  assert.match(workflow, /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/);
+  assert.match(workflow, /pull-requests: write/);
+  assert.match(workflow, /continue-on-error: true/);
+  assert.match(workflow, /peter-evans\/create-or-update-comment@v4/);
+  assert.ok(workflow.indexOf('Post PR comment') < workflow.indexOf('Enforce gate outcome'));
+  assert.doesNotMatch(workflow, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/);
+});

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -28,7 +28,7 @@ jobs:
       - instance-hnpsq9go
       - linux
       - x64
-    timeout-minutes: 45
+    timeout-minutes: 120
 
     steps:
       # Secrets are available to pull_request_target, so only trusted base code
@@ -49,17 +49,17 @@ jobs:
       - name: Detect skill changes
         id: changes
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SKILL_EVAL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SKILL_EVAL_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          files="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" -- 'packages/*/skills/**')"
-          if [ -n "$files" ]; then
+          changes="$(node .github/scripts/skill-eval.mjs --detect)"
+          if [ -n "$changes" ]; then
             echo 'has_skills=true' >> "$GITHUB_OUTPUT"
-            printf '%s\n' "$files"
+            printf '%s\n' "$changes"
           else
             echo 'has_skills=false' >> "$GITHUB_OUTPUT"
-            echo 'No version-controlled skill changes.'
+            echo 'No added or modified skill content.'
           fi
 
       - name: Set up Node.js

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -1,0 +1,226 @@
+name: Skill Eval
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: skill-eval-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+  PI_OFFLINE: '1'
+  SKILL_EVAL_MODEL: deepseek-v4-flash
+  SKILL_EVAL_RUNS: '3'
+  SKILL_EVAL_TIMEOUT_MS: '120000'
+
+jobs:
+  evaluate:
+    name: skill eval
+    if: github.event.pull_request.draft == false
+    runs-on:
+      - instance-hnpsq9go
+      - linux
+      - x64
+    timeout-minutes: 45
+
+    steps:
+      # Secrets are available to pull_request_target, so only trusted base code
+      # is checked out and executed. PR skill files are read later as git blobs.
+      - name: Check out trusted base revision
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+
+      - name: Fetch PR revision as data
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/pull/${{ github.event.pull_request.number }}/head:refs/remotes/pull/${{ github.event.pull_request.number }}/head"
+          git cat-file -e "${{ github.event.pull_request.head.sha }}^{commit}"
+
+      - name: Detect skill changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          files="$(git diff --name-only --no-renames "$BASE_SHA" "$HEAD_SHA" -- 'packages/*/skills/**')"
+          if [ -n "$files" ]; then
+            echo 'has_skills=true' >> "$GITHUB_OUTPUT"
+            printf '%s\n' "$files"
+          else
+            echo 'has_skills=false' >> "$GITHUB_OUTPUT"
+            echo 'No version-controlled skill changes.'
+          fi
+
+      - name: Set up Node.js
+        if: steps.changes.outputs.has_skills == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Verify eval credentials
+        if: steps.changes.outputs.has_skills == 'true'
+        env:
+          PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
+          PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
+        run: |
+          set -euo pipefail
+          test -n "$PI_INTEGRATION_BASE_URL" || { echo '::error::PI_INTEGRATION_BASE_URL is not configured'; exit 1; }
+          test -n "$PI_INTEGRATION_API_KEY" || { echo '::error::PI_INTEGRATION_API_KEY is not configured'; exit 1; }
+
+      - name: Install pinned Pi and prepare isolated config
+        if: steps.changes.outputs.has_skills == 'true'
+        env:
+          PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
+        run: |
+          set -euo pipefail
+          npm install --global --ignore-scripts @earendil-works/pi-coding-agent@0.83.0
+          echo "PI_CODING_AGENT_DIR=$RUNNER_TEMP/pi-skill-eval-agent" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/pi-skill-eval-agent"
+          PI_CODING_AGENT_DIR="$RUNNER_TEMP/pi-skill-eval-agent" node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const models = {
+            providers: {
+              'deepseek-integration': {
+                baseUrl: process.env.PI_INTEGRATION_BASE_URL,
+                api: 'openai-completions',
+                apiKey: '$PI_INTEGRATION_API_KEY',
+                authHeader: true,
+                models: [{
+                  id: process.env.SKILL_EVAL_MODEL,
+                  name: 'DS V4 Flash',
+                  reasoning: true,
+                  input: ['text'],
+                  contextWindow: 1000000,
+                  maxTokens: 384000,
+                  thinkingLevelMap: { minimal: null, low: null, medium: null, high: 'high', xhigh: 'max', max: 'max' },
+                  compat: {
+                    thinkingFormat: 'deepseek',
+                    requiresReasoningContentOnAssistantMessages: true,
+                    supportsDeveloperRole: false,
+                  },
+                }],
+              },
+            },
+          };
+          fs.writeFileSync(
+            path.join(process.env.PI_CODING_AGENT_DIR, 'models.json'),
+            `${JSON.stringify(models, null, 2)}\n`,
+            { mode: 0o600 },
+          );
+          NODE
+          pi --version
+
+      - name: Run paired skill evaluation
+        id: eval
+        if: steps.changes.outputs.has_skills == 'true'
+        continue-on-error: true
+        env:
+          PI_INTEGRATION_API_KEY: ${{ secrets.PI_INTEGRATION_API_KEY }}
+          SKILL_EVAL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SKILL_EVAL_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          SKILL_EVAL_OUTPUT_DIR: skill-eval-results
+          SKILL_EVAL_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SKILL_EVAL_ARTIFACT: skill-eval-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+          unset http_proxy https_proxy all_proxy no_proxy
+          node .github/scripts/skill-eval.mjs
+
+      - name: Generate static eval viewer
+        if: always() && steps.changes.outputs.has_skills == 'true'
+        run: |
+          set -euo pipefail
+          viewer="$RUNNER_TEMP/anthropic-skill-eval-viewer"
+          mkdir -p "$viewer"
+          base='https://raw.githubusercontent.com/anthropics/skills/f17010c9bb483898c1d9c9f42dde2b3a98889434/skills/skill-creator/eval-viewer'
+          curl --fail --silent --show-error --location "$base/generate_review.py" -o "$viewer/generate_review.py"
+          curl --fail --silent --show-error --location "$base/viewer.html" -o "$viewer/viewer.html"
+          echo 'fc9d1b9243fe5ab6012ebd579bd76d0035de1b79fd3b969de114defab26478fb  '"$viewer/generate_review.py" | shasum -a 256 -c -
+          echo 'a53213426ee1100441d701a3a0d49cda7a842f992d2c36463f4d3cc0258575fa  '"$viewer/viewer.html" | shasum -a 256 -c -
+
+          VIEWER_DIR="$viewer" python3 <<'PY'
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ['VIEWER_DIR'])
+          generator = root / 'generate_review.py'
+          source = generator.read_text()
+          needle = '    data_json = json.dumps(embedded)\n'
+          replacement = r'    data_json = json.dumps(embedded).replace("<", "\\u003c")' + '\n'
+          if source.count(needle) != 1:
+              raise SystemExit('unexpected Anthropic viewer generator shape')
+          generator.write_text(source.replace(needle, replacement))
+
+          viewer = root / 'viewer.html'
+          html = '\n'.join(
+              line for line in viewer.read_text().splitlines()
+              if 'fonts.googleapis.com' not in line
+              and 'fonts.gstatic.com' not in line
+              and 'cdn.sheetjs.com' not in line
+          )
+          csp = "<meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'; img-src data:; style-src 'unsafe-inline'; script-src 'unsafe-inline'\">"
+          html = html.replace('<meta charset="UTF-8">', '<meta charset="UTF-8">\n  ' + csp)
+          viewer.write_text(html + '\n')
+          PY
+
+          for benchmark in skill-eval-results/*/benchmark.json; do
+            [ -f "$benchmark" ] || continue
+            workspace="$(dirname "$benchmark")"
+            python3 "$viewer/generate_review.py" "$workspace" \
+              --skill-name "$(basename "$workspace")" \
+              --benchmark "$benchmark" \
+              --static "$workspace/review.html"
+          done
+
+      - name: Format PR comment body
+        if: always() && steps.changes.outputs.has_skills == 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -f skill-eval-results/comment.md ]; then
+            mkdir -p skill-eval-results
+            printf '%s\n' \
+              '### ❌ Skill Eval — failed' \
+              '' \
+              'Evaluation stopped before producing a report. See the workflow logs.' \
+              > skill-eval-results/comment.md
+          fi
+          {
+            echo 'BODY<<SKILLEVALEOF'
+            cat skill-eval-results/comment.md
+            echo 'SKILLEVALEOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Post PR comment
+        if: always() && steps.changes.outputs.has_skills == 'true'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ env.BODY }}
+
+      - name: Upload eval artifacts
+        if: always() && steps.changes.outputs.has_skills == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-eval-${{ github.run_id }}
+          path: skill-eval-results
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Enforce gate outcome
+        if: always() && steps.changes.outputs.has_skills == 'true' && steps.eval.outcome != 'success'
+        run: |
+          echo 'skill eval failed; see the PR comment and uploaded artifacts' >&2
+          exit 1

--- a/packages/pi-image-gen/skills/image-gen/evals.json
+++ b/packages/pi-image-gen/skills/image-gen/evals.json
@@ -1,0 +1,62 @@
+{
+  "skill_name": "image-gen",
+  "evals": [
+    {
+      "id": "distinct-assets-vs-variants",
+      "prompt": "I need three different deliverables: a rainforest website hero, a white-background product shot, and a profile avatar. I was thinking of making one image request with n=3. Explain the exact tool-call strategy you would use, but do not call any tools.",
+      "expected_output": "Use one image_generate call per distinct asset and explain that n creates variants of one prompt.",
+      "expectations": [
+        {
+          "text": "Uses the image generation tool",
+          "includes": ["image_generate"]
+        },
+        {
+          "text": "Makes separate calls for distinct assets",
+          "includes_any": ["three separate", "3 separate", "one call per asset", "separate call for each"]
+        },
+        {
+          "text": "Explains that n represents variants",
+          "includes": ["variants"]
+        }
+      ]
+    },
+    {
+      "id": "edit-target-and-style-reference",
+      "prompt": "I have two files: portrait.png is the photo I want edited, and lighting.jpg is only a lighting/style reference. Replace the portrait background with a rainy night street while keeping the person's face, pose, and clothing unchanged. Describe the image inputs and prompt you would send, but do not call any tools.",
+      "expected_output": "Label portrait.png as the edit target and lighting.jpg as a style reference, with explicit preservation constraints.",
+      "expectations": [
+        {
+          "text": "Labels the portrait as the edit target",
+          "includes": ["portrait.png", "edit target"]
+        },
+        {
+          "text": "Labels the lighting image as a style reference",
+          "includes": ["lighting.jpg", "style reference"]
+        },
+        {
+          "text": "Preserves the requested invariants",
+          "includes": ["face", "pose", "clothing"]
+        }
+      ]
+    },
+    {
+      "id": "repo-native-svg-boundary",
+      "prompt": "A TypeScript web app already has a monochrome SVG icon set. I need one more 16px settings icon that inherits currentColor and matches the existing stroke style. Should this use raster image generation? Give the implementation direction, but do not edit files or call tools.",
+      "expected_output": "Keep the asset repo-native and extend the SVG icon set instead of using image_generate.",
+      "expectations": [
+        {
+          "text": "Keeps the icon as SVG or vector source",
+          "includes_any": ["existing SVG", "SVG icon", "vector"]
+        },
+        {
+          "text": "Preserves currentColor behavior",
+          "includes": ["currentColor"]
+        },
+        {
+          "text": "Rejects raster generation for this task",
+          "includes_any": ["do not use image_generate", "should not use image_generate", "not use raster", "avoid raster"]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/pi-video-gen/skills/video-gen/evals.json
+++ b/packages/pi-video-gen/skills/video-gen/evals.json
@@ -1,0 +1,65 @@
+{
+  "skill_name": "video-gen",
+  "evals": [
+    {
+      "id": "compatible-mp4-concat",
+      "prompt": "I have three compatible MP4 clips and only want them joined in order without transitions, overlays, trimming, or re-encoding. Describe the exact Pi video workflow, output mode, and whether a paid-model confirmation is needed. Do not call tools or create files.",
+      "expected_output": "Route to the local video_compose C0 flow with copy mode and no paid-model confirmation.",
+      "expectations": [
+        {
+          "text": "Routes to video_compose",
+          "includes": ["video_compose"]
+        },
+        {
+          "text": "Uses lossless copy mode",
+          "includes_any": ["mode: copy", "mode `copy`", "\"copy\""]
+        },
+        {
+          "text": "Treats the operation as local rather than paid generation",
+          "includes": ["local"],
+          "includes_any": ["no paid", "does not need paid", "no paid-model"]
+        }
+      ]
+    },
+    {
+      "id": "single-ai-shot",
+      "prompt": "Create one five-second AI-generated shot of a paper boat moving through a rainy gutter. No multi-shot film is needed. Explain which Pi video flow and preflight you would use and what confirmation is required, but do not call tools.",
+      "expected_output": "Use video_capabilities, then one video_generate call after explicit paid confirmation.",
+      "expectations": [
+        {
+          "text": "Chooses the single-shot generation tool",
+          "includes": ["video_generate"]
+        },
+        {
+          "text": "Runs capability preflight",
+          "includes": ["video_capabilities"]
+        },
+        {
+          "text": "Requires confirmation before the paid call",
+          "includes": ["paid"],
+          "includes_any": ["confirmation", "confirm", "go-ahead", "approval"]
+        }
+      ]
+    },
+    {
+      "id": "multi-shot-film",
+      "prompt": "I want a short three-shot AI film with a recurring character and visual continuity between shots. Describe the planning, frame, confirmation, and render stages in Pi, including how many times the final render tool is invoked. Do not call tools.",
+      "expected_output": "Use a shot book, generate character/shot frames with image_generate, obtain confirmations, then call video_render once.",
+      "expectations": [
+        {
+          "text": "Uses a shot book for the multi-shot plan",
+          "includes_any": ["shot book", "shot-book"]
+        },
+        {
+          "text": "Generates frames through image_generate",
+          "includes": ["image_generate"]
+        },
+        {
+          "text": "Calls video_render only once",
+          "includes": ["video_render"],
+          "includes_any": ["call once", "once", "one call"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a trusted-base GitHub Actions gate for added and modified skills
- run paired Pi evaluations and post the score comparison as a PR comment
- attach a pinned, hardened Anthropic eval viewer as a workflow artifact
- add colocated evaluation sets for the image-gen and video-gen skills

## Evaluation policy

- New skills compare the candidate against a no-skill baseline. They require a score of at least `0.800` and a delta of at least `+0.100`.
- Modified skills compare the PR skill against the master version on the master evaluation set. Neither the aggregate score nor any individual eval may regress.
- Evaluation sets contain 3–5 declarative cases, and one PR may evaluate at most three skills.

## Security

The workflow uses `pull_request_target` but checks out and executes only the trusted base revision. PR skill files are materialized from Git blobs as untrusted data, all Pi tools and extensions are disabled, and model output is bounded. The Anthropic viewer is pinned by commit and checksum, stripped of remote assets, and generated with script-safe JSON embedding and a restrictive CSP.

## Validation

- `pnpm test` — 1,731 tests passed
- `pnpm typecheck`
- `pnpm lint`
- 10 focused skill-eval tests
- Anthropic static viewer smoke test
- live Pi A/B smoke: image-gen scored `1.000` with the skill and `0.333` without it

## Bootstrap note

Because `pull_request_target` workflows are loaded from the base branch, this workflow starts evaluating PRs after it lands on `master`. The runner requires `PI_INTEGRATION_BASE_URL` and `PI_INTEGRATION_API_KEY` repository secrets.
