### PR TITLE
fix(pi-image-gen): opt out of provider watermarks

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -164,7 +164,7 @@ export ARK_API_KEY=...
 { "pi-image-gen": { "defaultModel": "seedream" } }
 ```
 
-> Supported `size` values are model-dependent, and the tool schema tells the agent the exact form for the active model: a tier token (`1K`/`1.5K`/`2K`/`3K`/`4K` — the list differs per model) or an explicit `"<w>x<h>"` pixel string, never mixed. Seedream 5.0 / 4.5 enforce a 2K pixel floor (`1024x1024` fails with `InvalidParameter`); 5.0 pro accepts `1K`/`1.5K`/`2K` down to 921,600 px; 4.0 accepts 1K. Full sizing matrix in the [official docs](https://www.volcengine.com/docs/82379/1824121). Seedream has **no `n` parameter** — the API generates one image per request (multi-image is the `sequential_image_generation` mechanism, not exposed here), so `n` is hidden for these models.
+> Supported `size` values are model-dependent, and the tool schema tells the agent the exact form for the active model: a tier token (`1K`/`1.5K`/`2K`/`3K`/`4K` — the list differs per model) or an explicit `"<w>x<h>"` pixel string, never mixed. Seedream 5.0 / 4.5 enforce a 2K pixel floor (`1024x1024` fails with `InvalidParameter`); 5.0 pro accepts `1K`/`1.5K`/`2K` down to 921,600 px; 4.0 accepts 1K. Full sizing matrix in the [official docs](https://www.volcengine.com/docs/82379/1824121). Seedream has **no `n` parameter** — the API generates one image per request (multi-image is the `sequential_image_generation` mechanism, not exposed here), so `n` is hidden for these models. The extension always sends `watermark: false` — Seedream's watermark switch defaults to `true` and would otherwise stamp an "AI 生成" badge in the corner of every image.
 
 The default base URL is `https://ark.cn-beijing.volces.com/api/v3`. To use a different region (e.g. `ap-southeast`), override it:
 

--- a/packages/pi-image-gen/src/__tests__/ark.test.ts
+++ b/packages/pi-image-gen/src/__tests__/ark.test.ts
@@ -95,6 +95,8 @@ describe('ark provider (Volcengine Seedream)', () => {
       model: 'doubao-seedream-5-0-260128',
       prompt: '一只猫',
       size: '2048x2048',
+      // Watermark defaults to true upstream — we always opt out.
+      watermark: false,
     });
     // Seedream documents no `n` parameter — it must not reach the wire.
     expect(calls[0]?.body.n).toBeUndefined();

--- a/packages/pi-image-gen/src/__tests__/dashscope.test.ts
+++ b/packages/pi-image-gen/src/__tests__/dashscope.test.ts
@@ -74,4 +74,9 @@ describe('dashscope provider (Alibaba Qwen-Image)', () => {
     const body = await runCapture('2048x2048');
     expect((body.parameters as Record<string, unknown>).size).toBe('2048*2048');
   });
+
+  it('always opts out of the watermark', async () => {
+    const body = await runCapture('2048x2048');
+    expect((body.parameters as Record<string, unknown>).watermark).toBe(false);
+  });
 });

--- a/packages/pi-image-gen/src/providers/ark.ts
+++ b/packages/pi-image-gen/src/providers/ark.ts
@@ -39,6 +39,9 @@ export const arkAdapter: ImageProviderAdapter = {
     const body: Record<string, unknown> = {
       model: remoteModelId,
       prompt: params.prompt,
+      // Seedream's watermark switch defaults to true, stamping an "AI 生成"
+      // badge in the corner — opt out explicitly.
+      watermark: false,
     };
     if (params.size) body.size = params.size;
     // Seedream sizing is driven by `size` resolution tiers (1K/2K/4K), not an

--- a/packages/pi-image-gen/src/providers/dashscope.ts
+++ b/packages/pi-image-gen/src/providers/dashscope.ts
@@ -74,6 +74,9 @@ export const dashscopeAdapter: ImageProviderAdapter = {
           input: { messages: [{ role: 'user', content: userContent }] },
           parameters: {
             n: params.n ?? 1,
+            // Defaults to false upstream today, but pass it explicitly so a
+            // flipped default can't start stamping "Qwen-Image" badges.
+            watermark: false,
             ...(params.size ? { size: normalizeDashScopeSize(params.size) } : {}),
           },
         }),


### PR DESCRIPTION
## Summary
- Seedream (Volcengine Ark): `watermark` defaults to `true` upstream and stamps an "AI 生成" badge in the corner of every image — the adapter now always sends `watermark: false` ([docs](https://docs.volcengine.com/docs/82379/1541523))
- Qwen-Image (DashScope): `watermark` already defaults to `false`, but the adapter now passes it explicitly so a flipped upstream default can't start stamping badges either
- Other providers checked, no action needed: OpenAI has no watermark parameter, Gemini's SynthID is mandatory/invisible, OpenRouter is a pure proxy

## Test plan
- [x] `ark.test.ts` asserts `watermark: false` reaches the wire
- [x] `dashscope.test.ts` gains an "always opts out of the watermark" case
- [x] Full pre-commit gate green: lint + typecheck + 1812 tests + build