### PR TITLE
fix(pi-web-access): handle deepseek responses with no message item

### DIFF
--- a/packages/pi-web-access/src/__tests__/extension.test.ts
+++ b/packages/pi-web-access/src/__tests__/extension.test.ts
@@ -9,7 +9,13 @@ vi.mock('../config.js', async (importOriginal) => {
   };
 });
 
-vi.mock('../search.js', () => ({ search: vi.fn() }));
+vi.mock('../search.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../search.js')>();
+  return {
+    ...actual,
+    search: vi.fn(),
+  };
+});
 
 import { loadWebToolSettings } from '../config.js';
 import { search } from '../search.js';

--- a/packages/pi-web-access/src/__tests__/extension.test.ts
+++ b/packages/pi-web-access/src/__tests__/extension.test.ts
@@ -9,9 +9,13 @@ vi.mock('../config.js', async (importOriginal) => {
   };
 });
 
+vi.mock('../search.js', () => ({ search: vi.fn() }));
+
 import { loadWebToolSettings } from '../config.js';
+import { search } from '../search.js';
 
 const mockLoadSettings = vi.mocked(loadWebToolSettings);
+const mockSearch = vi.mocked(search);
 
 function createMockPi() {
   const tools: Array<{ name: string }> = [];
@@ -191,5 +195,53 @@ describe('piWebToolExtension - tool registration', () => {
 
     expect(pi.tools.map((t) => t.name)).toContain('web_search');
     expect(pi.tools.map((t) => t.name)).toContain('x_search');
+  });
+});
+
+describe('piWebToolExtension - web_search output formatting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadSettings.mockReturnValue({
+      search: { provider: 'deepseek' },
+      providers: { deepseek: { apiKey: 'key' } },
+    });
+  });
+
+  async function executeWebSearch() {
+    const pi = createMockPi();
+    piWebToolExtension(pi as any);
+    await pi.triggerSessionStart();
+    const tool = pi.tools.find((t) => t.name === 'web_search') as any;
+    const result = await tool.execute('id', { query: 'q' }, undefined, undefined, {});
+    return result.content[0].text as string;
+  }
+
+  it('states explicitly when the provider returns no answer and no results', async () => {
+    mockSearch.mockResolvedValue({
+      provider: 'deepseek',
+      query: 'q',
+      answer: undefined,
+      results: [],
+    });
+
+    const text = await executeWebSearch();
+
+    expect(text).toContain('## Web Search Results (deepseek)');
+    expect(text).toContain('No results returned by the provider');
+  });
+
+  it('notes the missing answer when only sources were gathered', async () => {
+    mockSearch.mockResolvedValue({
+      provider: 'deepseek',
+      query: 'q',
+      answer: undefined,
+      results: [{ title: 'https://example.com/', url: 'https://example.com/', content: '' }],
+    });
+
+    const text = await executeWebSearch();
+
+    expect(text).toContain('did not generate an answer');
+    expect(text).toContain('### Sources');
+    expect(text).toContain('[https://example.com/](https://example.com/)');
   });
 });

--- a/packages/pi-web-access/src/__tests__/search.test.ts
+++ b/packages/pi-web-access/src/__tests__/search.test.ts
@@ -59,6 +59,7 @@ describe('search', () => {
 
   afterEach(() => {
     process.env = originalEnv;
+    vi.restoreAllMocks();
   });
 
   it('uses search.provider tavily', async () => {
@@ -404,6 +405,126 @@ describe('search', () => {
         model: 'deepseek-v4-flash',
         tools: [{ type: 'web_search' }],
       }),
+    );
+  });
+
+  it('extracts deepseek sources from web_search_call actions when no message is returned', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const settings: WebToolSettings = {
+      search: { provider: 'deepseek' },
+      providers: { deepseek: { apiKey: 'deepseek-key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 'completed',
+        output: [
+          { type: 'reasoning' },
+          {
+            type: 'web_search_call',
+            status: 'completed',
+            action: { type: 'search', queries: ['q1'] },
+          },
+          {
+            type: 'web_search_call',
+            status: 'completed',
+            action: { type: 'open_page', url: 'https://example.com/page#ws_call_id=call_01_abc' },
+          },
+          {
+            type: 'web_search_call',
+            status: 'completed',
+            action: { type: 'open_page', url: 'https://example.com/page#ws_call_id=call_02_def' },
+          },
+          {
+            type: 'web_search_call',
+            status: 'failed',
+            action: { type: 'open_page', url: 'https://other.example.org/#ws_call_id=call_03_g' },
+          },
+        ],
+      }),
+    });
+
+    const result = await search({ query: 'obscure research query' }, settings);
+
+    expect(result.provider).toBe('deepseek');
+    expect(result.answer).toBeUndefined();
+    // deduped, fragment stripped, failed open_page excluded
+    expect(result.results).toEqual([
+      { title: 'https://example.com/page', url: 'https://example.com/page', content: '' },
+    ]);
+    expect(consoleError).toHaveBeenCalledOnce();
+  });
+
+  it('prefers annotation titles when deduping sources across items', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'deepseek' },
+      providers: { deepseek: { apiKey: 'deepseek-key' } },
+    };
+    // Realistic ordering: web_search_call items precede the message item.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 'completed',
+        output: [
+          {
+            type: 'web_search_call',
+            action: { type: 'open_page', url: 'https://example.com/a#ws_call_id=call_01_x' },
+          },
+          {
+            type: 'message',
+            content: [
+              {
+                type: 'output_text',
+                text: 'answer',
+                annotations: [{ type: 'url_citation', url: 'https://example.com/a', title: 'A' }],
+              },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const result = await search({ query: 'test' }, settings);
+
+    expect(result.answer).toBe('answer');
+    expect(result.results).toEqual([{ title: 'A', url: 'https://example.com/a', content: '' }]);
+  });
+
+  it('throws when deepseek response status is failed', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'deepseek' },
+      providers: { deepseek: { apiKey: 'deepseek-key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 'failed',
+        error: { message: 'internal error' },
+        output: [],
+      }),
+    });
+
+    await expect(search({ query: 'test' }, settings)).rejects.toThrow(
+      'DeepSeek API response failed: internal error',
+    );
+  });
+
+  it('throws when deepseek response is incomplete with no message', async () => {
+    const settings: WebToolSettings = {
+      search: { provider: 'deepseek' },
+      providers: { deepseek: { apiKey: 'deepseek-key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 'incomplete',
+        incomplete_details: { reason: 'max_output_tokens' },
+        output: [{ type: 'reasoning' }],
+      }),
+    });
+
+    await expect(search({ query: 'test' }, settings)).rejects.toThrow(
+      'DeepSeek API response incomplete: max_output_tokens',
     );
   });
 

--- a/packages/pi-web-access/src/__tests__/search.test.ts
+++ b/packages/pi-web-access/src/__tests__/search.test.ts
@@ -491,6 +491,7 @@ describe('search', () => {
   });
 
   it('throws when deepseek response status is failed', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const settings: WebToolSettings = {
       search: { provider: 'deepseek' },
       providers: { deepseek: { apiKey: 'deepseek-key' } },
@@ -505,11 +506,13 @@ describe('search', () => {
     });
 
     await expect(search({ query: 'test' }, settings)).rejects.toThrow(
-      'DeepSeek API response failed: internal error',
+      'DeepSeek API response failed.',
     );
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('internal error'));
   });
 
   it('throws when deepseek response is incomplete with no message', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const settings: WebToolSettings = {
       search: { provider: 'deepseek' },
       providers: { deepseek: { apiKey: 'deepseek-key' } },
@@ -524,8 +527,41 @@ describe('search', () => {
     });
 
     await expect(search({ query: 'test' }, settings)).rejects.toThrow(
-      'DeepSeek API response incomplete: max_output_tokens',
+      'DeepSeek API response did not produce an answer (status: incomplete).',
     );
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('max_output_tokens'));
+  });
+
+  it('caps extracted sources at maxResults', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const settings: WebToolSettings = {
+      search: { provider: 'deepseek' },
+      providers: { deepseek: { apiKey: 'deepseek-key' } },
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        status: 'completed',
+        output: [
+          {
+            type: 'web_search_call',
+            status: 'completed',
+            action: { type: 'open_page', url: 'https://a.example/#ws_call_id=c1' },
+          },
+          {
+            type: 'web_search_call',
+            status: 'completed',
+            action: { type: 'open_page', url: 'https://b.example/#ws_call_id=c2' },
+          },
+        ],
+      }),
+    });
+
+    const result = await search({ query: 'test', maxResults: 1 }, settings);
+
+    expect(result.results).toEqual([
+      { title: 'https://a.example/', url: 'https://a.example/', content: '' },
+    ]);
   });
 
   it('uses search.provider zai', async () => {

--- a/packages/pi-web-access/src/index.ts
+++ b/packages/pi-web-access/src/index.ts
@@ -108,6 +108,11 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
             lines.push('### Answer');
             lines.push(response.answer);
             lines.push('');
+          } else if (response.results.length > 0) {
+            lines.push(
+              '_The provider did not generate an answer. Sources gathered during the search are listed below._',
+            );
+            lines.push('');
           }
 
           if (response.results.length > 0) {
@@ -117,6 +122,11 @@ export default function piWebToolExtension(pi: ExtensionAPI): void {
               if (r.score !== undefined) lines.push(`  *Relevance: ${r.score.toFixed(2)}*`);
               if (r.content) lines.push(`  ${r.content}`);
             }
+            lines.push('');
+          }
+
+          if (!response.answer && response.results.length === 0) {
+            lines.push('No results returned by the provider. Consider rephrasing the query.');
             lines.push('');
           }
 

--- a/packages/pi-web-access/src/providers/openai.ts
+++ b/packages/pi-web-access/src/providers/openai.ts
@@ -64,7 +64,9 @@ export class OpenAIProvider extends BaseProvider {
     };
 
     if (data.status === 'failed') {
-      throw new Error(`${name} API response failed: ${data.error?.message ?? 'unknown error'}`);
+      const detail = (data.error?.message ?? 'unknown error').slice(0, 300);
+      console.error(`[pi-web-access] ${name} response failed: ${detail}`);
+      throw new Error(`${name} API response failed.`);
     }
 
     let answer = '';
@@ -110,8 +112,9 @@ export class OpenAIProvider extends BaseProvider {
     }
 
     if (!answer && data.status && data.status !== 'completed') {
-      const reason = data.incomplete_details?.reason ?? 'no answer generated';
-      throw new Error(`${name} API response ${data.status}: ${reason}`);
+      const reason = (data.incomplete_details?.reason ?? 'unknown').slice(0, 300);
+      console.error(`[pi-web-access] ${name} response ${data.status}: ${reason}`);
+      throw new Error(`${name} API response did not produce an answer (status: ${data.status}).`);
     }
 
     if (!answer) {
@@ -124,6 +127,11 @@ export class OpenAIProvider extends BaseProvider {
       );
     }
 
-    return { provider: provider.id, query: params.query, answer: answer || undefined, results };
+    return {
+      provider: provider.id,
+      query: params.query,
+      answer: answer || undefined,
+      results: results.slice(0, params.maxResults ?? 5),
+    };
   }
 }

--- a/packages/pi-web-access/src/providers/openai.ts
+++ b/packages/pi-web-access/src/providers/openai.ts
@@ -48,19 +48,41 @@ export class OpenAIProvider extends BaseProvider {
     }
 
     const data = (await response.json()) as {
-      output: Array<{
+      status?: string;
+      error?: { message?: string } | null;
+      incomplete_details?: { reason?: string } | null;
+      output?: Array<{
         type: string;
+        status?: string;
         content?: Array<{
           type: string;
           text: string;
           annotations?: Array<{ type: string; url?: string; title?: string }>;
         }>;
+        action?: { type: string; url?: string };
       }>;
     };
 
+    if (data.status === 'failed') {
+      throw new Error(`${name} API response failed: ${data.error?.message ?? 'unknown error'}`);
+    }
+
     let answer = '';
     const results: SearchResult[] = [];
-    for (const item of data.output) {
+    const seen = new Map<string, SearchResult>();
+    const addResult = (title: string, url: string) => {
+      const existing = seen.get(url);
+      if (existing) {
+        // Annotations carry real titles but arrive after web_search_call items.
+        if (existing.title === existing.url && title !== url) existing.title = title;
+        return;
+      }
+      const result: SearchResult = { title, url, content: '' };
+      seen.set(url, result);
+      results.push(result);
+    };
+
+    for (const item of data.output ?? []) {
       if (item.type === 'message' && item.content) {
         for (const block of item.content) {
           if (block.type === 'output_text') {
@@ -68,12 +90,38 @@ export class OpenAIProvider extends BaseProvider {
             if (block.annotations) {
               for (const ann of block.annotations) {
                 if (ann.type === 'url_citation' && ann.url)
-                  results.push({ title: ann.title ?? ann.url, url: ann.url, content: '' });
+                  addResult(ann.title ?? ann.url, ann.url);
               }
             }
           }
         }
       }
+      // DeepSeek never emits url_citation annotations; opened pages are the only source trail.
+      // DeepSeek appends a tracking fragment (#ws_call_id=...) that must be stripped.
+      if (
+        item.type === 'web_search_call' &&
+        item.status !== 'failed' &&
+        item.action?.type === 'open_page' &&
+        item.action.url
+      ) {
+        const url = item.action.url.split('#ws_call_id=')[0]!;
+        addResult(url, url);
+      }
+    }
+
+    if (!answer && data.status && data.status !== 'completed') {
+      const reason = data.incomplete_details?.reason ?? 'no answer generated';
+      throw new Error(`${name} API response ${data.status}: ${reason}`);
+    }
+
+    if (!answer) {
+      const types = (data.output ?? [])
+        .map((i) => i.type)
+        .join(',')
+        .slice(0, 200);
+      console.error(
+        `[pi-web-access] ${name} response returned no answer (status: ${data.status ?? 'unknown'}, output types: ${types})`,
+      );
     }
 
     return { provider: provider.id, query: params.query, answer: answer || undefined, results };


### PR DESCRIPTION
## Summary

Closes #140.

- `web_search` via the deepseek provider could return a bare header when DeepSeek finished its server-side search loop without emitting a `message` item (observed live: 21 search rounds, ~45s, `status: completed`, no answer).
- Sources are now extracted from `web_search_call` `open_page` actions — DeepSeek never emits `url_citation` annotations, so the Sources section was always empty for it. The `#ws_call_id=` tracking fragment is stripped, URLs are deduped (annotation titles win), and failed calls are skipped.
- Response `status` is now checked: `failed` throws with the provider error; any non-`completed` status without an answer throws with `incomplete_details.reason`.
- A bounded stderr diagnostic (`[pi-web-access]`, status + output item types) is logged when a completed response yields no answer.
- The tool output now states explicitly when the provider generated no answer (listing gathered sources) or returned nothing at all, instead of a bare header.

## Test plan

- [x] `pnpm vitest run` in packages/pi-web-access — 139 pass (6 new: no-message source extraction, fragment strip, dedupe with title precedence, failed/incomplete throws, two formatter notices)
- [x] Root pre-commit hook (biome + typecheck + full suite 1818 tests + build) green
- [x] Reproduced live against DeepSeek's Responses API during diagnosis; request/response captures in #140