### PR TITLE
fix(ci): bypass runner proxy for npm mirror subdomains

### DIFF
--- a/.github/actions/setup-pi-build/action.yml
+++ b/.github/actions/setup-pi-build/action.yml
@@ -43,6 +43,19 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Bypass proxy for the npm mirror
+      shell: bash
+      run: |
+        # Self-hosted runners route egress through a host-level proxy. npmmirror
+        # redirects package downloads to CDN subdomains (e.g. cdn.npmmirror.com),
+        # which the proxy refuses — breaking pnpm/action-setup and installs with
+        # "fetch failed" / 403. Send the mirror and ALL its subdomains direct.
+        # Append (don't replace) to keep the runner's existing bypasses.
+        {
+          echo "NO_PROXY=${NO_PROXY:+$NO_PROXY,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
+          echo "no_proxy=${no_proxy:+$no_proxy,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
+        } >> "$GITHUB_ENV"
+
     - name: Set up per-job pi config dir
       if: inputs.set-pi-agent-dir == 'true'
       shell: bash

--- a/.github/workflows/pi-review.yml
+++ b/.github/workflows/pi-review.yml
@@ -69,6 +69,10 @@ jobs:
       - name: Install latest Pi review runtime
         run: |
           set -euo pipefail
+          # The runner's host-level proxy refuses npmmirror CDN subdomains;
+          # bypass it for the mirror (same as setup-pi-build).
+          export NO_PROXY="${NO_PROXY:+$NO_PROXY,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
+          export no_proxy="${no_proxy:+$no_proxy,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
           npm install --global --ignore-scripts @earendil-works/pi-coding-agent@latest
           npm install --prefix "$PI_CODING_AGENT_DIR/review-runtime" --ignore-scripts pi-subagents@latest
           pi --version


### PR DESCRIPTION
## Summary

Since this morning (first failing runs ~07:22 UTC), every CI job that installs packages fails **before touching any PR code**:

- `Test` / `Typecheck` / `build checks` / `Pi runtime integration` die in `setup-pi-build` → `pnpm/action-setup` with `fetch failed` for `@pnpm/exe`, `@pnpm/linux-x64`, `pnpm` (ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE is the misleading wrapper — the root cause is the fetch failure).
- `Pi code review` dies at "Install latest Pi review runtime" with `403 Forbidden - GET https://registry.npmmirror.com/@earendil-works%2fpi-coding-agent`.

Root cause: the self-hosted runners route egress through a host-level proxy (the same proxy the existing `unset HTTP_PROXY` steps in pi-review/integration/skill-eval workflows hint at). npmmirror redirects package downloads to CDN **subdomains** (e.g. `cdn.npmmirror.com`), which the proxy refuses. The runner's `NO_PROXY` doesn't cover them. Same failure class as TGYD-helige/amaster-employee@dc2a807 ("fix(ci): bypass proxy for npm mirror CDN"), which this PR mirrors.

Fix — send the mirror and **all its subdomains** direct, appended (not replacing) so the runner's existing bypasses survive:

1. `.github/actions/setup-pi-build/action.yml` — new first step appends `registry.npmmirror.com,npmmirror.com,.npmmirror.com` to `NO_PROXY`/`no_proxy` via ``, so `pnpm/action-setup` and every later install step in Test/Typecheck/build checks/integration go direct for the mirror.
2. `.github/workflows/pi-review.yml` — same exports in "Install latest Pi review runtime" (that workflow installs outside setup-pi-build).

Not touched: `npm-publish.yml` (uses registry.npmjs.org + corepack, workflow_dispatch only); `skill-eval.yml` (passed today via warm npm cache — its install step would hit the same proxy on a cold cache, but it's out of the PR-check path; can follow the same pattern if it ever flakes).

## Verification

- This PR's own `pull_request` jobs exercise the fixed `setup-pi-build` immediately — green Test/Typecheck/build checks = the fix works.
- Caveat: `pi-review.yml` runs on `pull_request_target`, i.e. the **base branch** version — its fix only takes effect after merge, so the review job on THIS PR may still fail. It should go green on subsequent PRs.
- YAML syntax validated locally.

## Checklist

- [x] I read the applicable `AGENTS.md` files for every changed path.
- [x] This PR contains no unrelated refactors or generated files.
- [x] Behavior and configuration changes include relevant tests, or the reason they do not is explained above. (CI-env-only change; validated by the pipeline itself.)
- [x] Public tool, command, setting, or user-facing behavior changes include the corresponding documentation and prompt guidance. (No user-facing surface.)