### PR TITLE
fix(ci): bypass proxy for all npm installs in pi-review job

### DIFF
--- a/.github/workflows/pi-review.yml
+++ b/.github/workflows/pi-review.yml
@@ -47,6 +47,16 @@ jobs:
         with:
           node-version: 24
 
+      - name: Bypass proxy for the npm mirror
+        run: |
+          # Self-hosted runners route egress through a host-level proxy that
+          # refuses npmmirror's CDN subdomains — every npm/npx install in this
+          # job must reach the mirror directly (same as setup-pi-build).
+          {
+            echo "NO_PROXY=${NO_PROXY:+$NO_PROXY,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
+            echo "no_proxy=${no_proxy:+$no_proxy,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
+          } >> "$GITHUB_ENV"
+
       - name: Prepare isolated Pi directories
         run: |
           set -euo pipefail
@@ -69,10 +79,6 @@ jobs:
       - name: Install latest Pi review runtime
         run: |
           set -euo pipefail
-          # The runner's host-level proxy refuses npmmirror CDN subdomains;
-          # bypass it for the mirror (same as setup-pi-build).
-          export NO_PROXY="${NO_PROXY:+$NO_PROXY,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
-          export no_proxy="${no_proxy:+$no_proxy,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
           npm install --global --ignore-scripts @earendil-works/pi-coding-agent@latest
           npm install --prefix "$PI_CODING_AGENT_DIR/review-runtime" --ignore-scripts pi-subagents@latest
           pi --version


### PR DESCRIPTION
## Summary

Follow-up to #149. That PR fixed the proxy bypass for `setup-pi-build` and for pi-review's "Install latest Pi review runtime" step — but the review job has a second install step, "Install latest mattpocock skills for Pi" (`npx --yes skills@latest add mattpocock/skills`), which still 403s on `registry.npmmirror.com/skills` through the runner's host proxy (seen on PR #148's review job after #149 merged).

Instead of exporting per step, this PR adds one "Bypass proxy for the npm mirror" step at the top of the review job that appends `registry.npmmirror.com,npmmirror.com,.npmmirror.com` to `NO_PROXY`/`no_proxy` via `$GITHUB_ENV` — covering the runtime install, the skills install, and any future install step — and drops the now-redundant per-step exports added by #149.

Note: `pi-review.yml` runs on `pull_request_target` (base-branch workflow), so the review job on this PR still exercises master's version — it goes green on subsequent PRs after merge.

## Verification

- YAML syntax validated locally. Behavior verified indirectly: the identical `$GITHUB_ENV` append in `setup-pi-build` (#149) made Test/Typecheck/build checks/integration green on #148 and #149.

## Checklist

- [x] I read the applicable `AGENTS.md` files for every changed path.
- [x] This PR contains no unrelated refactors or generated files.
- [x] Behavior and configuration changes include relevant tests, or the reason they do not is explained above. (CI-env-only change; validated by the pipeline.)
- [x] Public tool, command, setting, or user-facing behavior changes include the corresponding documentation and prompt guidance. (No user-facing surface.)