### PR TITLE
ci(pi-video-gen): split FFmpeg platform builds into a dedicated workflow

### DIFF
--- a/.github/workflows/ffmpeg-build.yml
+++ b/.github/workflows/ffmpeg-build.yml
@@ -1,0 +1,335 @@
+name: Build pi-video-gen FFmpeg
+
+# FFmpeg platform packages (@amaster.ai/pi-video-gen-ffmpeg-*) are versioned
+# and published independently of the monorepo release: this workflow builds the
+# binaries, verifies them, and publishes the five platform packages at the
+# version committed in each platforms/ffmpeg-*/package.json. Committed versions
+# that already exist on npm are reused as-is and nothing is rebuilt. To ship
+# new FFmpeg binaries, bump those five versions in the same PR that changes
+# the build.
+
+on:
+  workflow_dispatch: {}
+  workflow_call: {}
+  push:
+    branches: [master]
+    paths:
+      - "packages/pi-video-gen/scripts/**"
+      - "packages/pi-video-gen/platforms/**"
+      - ".github/workflows/ffmpeg-build.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ffmpeg-build
+  cancel-in-progress: false
+
+jobs:
+  decide:
+    name: check for unpublished platform versions
+    runs-on:
+      - instance-hnpsq9go
+      - linux
+      - x64
+    timeout-minutes: 5
+    outputs:
+      missing: ${{ steps.check.outputs.missing }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Compare committed versions with npm
+        id: check
+        run: |
+          missing=false
+          for dir in packages/pi-video-gen/platforms/ffmpeg-*; do
+            name="$(node -p "require('./${dir}/package.json').name")"
+            version="$(node -p "require('./${dir}/package.json').version")"
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "already on npm: ${name}@${version}"
+            else
+              echo "to publish: ${name}@${version}"
+              missing=true
+            fi
+          done
+          echo "missing=${missing}" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: build pi-video-gen FFmpeg (${{ matrix.target }})
+    needs: decide
+    if: needs.decide.outputs.missing == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # darwin targets need macOS hosts; linux-* targets keep the pinned
+          # ubuntu-22.04 image for the published glibc baseline. win32-x64
+          # produces PE binaries via mingw (host-glibc-agnostic), so it runs
+          # on the accelerated self-hosted runner for reliable source
+          # downloads (ffmpeg.org, zlib.net, code.videolan.org).
+          - target: darwin-arm64
+            runner: macos-15
+          - target: darwin-x64
+            runner: macos-15-intel
+          - target: linux-x64
+            runner: ubuntu-22.04
+          - target: linux-arm64
+            runner: ubuntu-22.04
+          - target: win32-x64
+            runner: [instance-hnpsq9go, linux, x64]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Install build dependencies
+        run: |
+          case "${{ matrix.target }}" in
+            darwin-*)
+              brew install nasm pkg-config
+              ;;
+            linux-x64)
+              sudo apt-get update
+              sudo apt-get install -y nasm pkg-config
+              ;;
+            linux-arm64)
+              sudo apt-get update
+              sudo apt-get install -y gcc-aarch64-linux-gnu pkg-config qemu-user
+              ;;
+            win32-x64)
+              # The self-hosted runner has Docker access but intentionally has
+              # no passwordless sudo. Install the cross toolchain inside an
+              # ephemeral container without mutating the host.
+              win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+              docker pull ubuntu:22.04
+              docker run --detach --rm --name "$win_container" \
+                --env HTTP_PROXY --env HTTPS_PROXY --env NO_PROXY \
+                --env http_proxy --env https_proxy --env no_proxy \
+                --volume "$GITHUB_WORKSPACE:/workspace" --workdir /workspace \
+                ubuntu:22.04 sleep infinity
+              docker exec "$win_container" sh -c '
+                export DEBIAN_FRONTEND=noninteractive
+                apt-get update
+                apt-get install -y --no-install-recommends \
+                  ca-certificates curl gcc gcc-mingw-w64-x86-64 libc6-dev make nasm pkg-config wine64 xz-utils
+              '
+              docker exec "$win_container" install -d \
+                -o "$(id -u)" -g "$(id -g)" /tmp/runner-home
+              ;;
+          esac
+
+      - name: Build minimal LGPL FFmpeg
+        run: |
+          if [ "${{ matrix.target }}" = win32-x64 ]; then
+            win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            docker exec --user "$(id -u):$(id -g)" --env HOME=/tmp/runner-home \
+              "$win_container" packages/pi-video-gen/scripts/build-ffmpeg.sh win32-x64
+          else
+            packages/pi-video-gen/scripts/build-ffmpeg.sh "${{ matrix.target }}"
+          fi
+
+      - name: Build GPL FFmpeg variant (x264 for h264)
+        run: |
+          if [ "${{ matrix.target }}" = win32-x64 ]; then
+            win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            docker exec --user "$(id -u):$(id -g)" --env HOME=/tmp/runner-home --env GPL_VARIANT=1 \
+              "$win_container" packages/pi-video-gen/scripts/build-ffmpeg.sh win32-x64
+          else
+            GPL_VARIANT=1 packages/pi-video-gen/scripts/build-ffmpeg.sh "${{ matrix.target }}"
+          fi
+
+      - name: Verify FFmpeg binary
+        shell: bash
+        run: |
+          bin="packages/pi-video-gen/platforms/ffmpeg-${{ matrix.target }}/bin/ffmpeg"
+          gpl="packages/pi-video-gen/platforms/ffmpeg-${{ matrix.target }}/bin/ffmpeg-gpl"
+          probe="${bin%/*}/ffprobe"
+          gpl_probe="${gpl%/*}/ffprobe-gpl"
+          win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          run_win_container() {
+            docker exec --user "$(id -u):$(id -g)" --env HOME=/tmp/runner-home --env WINEDEBUG=-all \
+              "$win_container" "$@"
+          }
+          run_ffmpeg() {
+            executable="$1"
+            shift
+            case "${{ matrix.target }}" in
+              darwin-*|linux-x64) "$executable" "$@" ;;
+              linux-arm64) qemu-aarch64 -L /usr/aarch64-linux-gnu "$executable" "$@" ;;
+              win32-x64) run_win_container /usr/lib/wine/wine64 "${executable}.exe" "$@" ;;
+            esac
+          }
+          case "${{ matrix.target }}" in
+            darwin-*)
+              "$bin" -version
+              "$probe" -version
+              "$gpl" -version
+              "$gpl_probe" -version
+              xcrun vtool -show-build "$bin" | grep -q 'minos 11.0'
+              ;;
+            linux-x64)
+              "$bin" -version
+              "$probe" -version
+              "$gpl" -version
+              "$gpl_probe" -version
+              ldd "$bin"
+              ;;
+            linux-arm64)
+              qemu-aarch64 -L /usr/aarch64-linux-gnu "$bin" -version
+              qemu-aarch64 -L /usr/aarch64-linux-gnu "$probe" -version
+              qemu-aarch64 -L /usr/aarch64-linux-gnu "$gpl" -version
+              qemu-aarch64 -L /usr/aarch64-linux-gnu "$gpl_probe" -version
+              aarch64-linux-gnu-readelf -h "$bin" | grep -q 'AArch64'
+              ;;
+            win32-x64)
+              run_win_container /usr/lib/wine/wine64 "${bin}.exe" -version
+              run_win_container /usr/lib/wine/wine64 "${probe}.exe" -version
+              run_win_container /usr/lib/wine/wine64 "${gpl}.exe" -version
+              run_win_container /usr/lib/wine/wine64 "${gpl_probe}.exe" -version
+              run_win_container x86_64-w64-mingw32-objdump -f "${bin}.exe" | grep -q 'pei-x86-64'
+              ;;
+          esac
+          cat > timeline-smoke.srt <<'EOF'
+          1
+          00:00:00,000 --> 00:00:00,500
+          Timeline smoke
+          EOF
+          smoke_args=(
+            -nostdin -xerror
+            -loop 1 -framerate 25 -t 0.5 -i packages/pi-video-gen/preview.png
+            -loop 1 -framerate 25 -t 0.5 -i packages/pi-video-gen/preview.png
+            -loop 1 -framerate 25 -t 0.5 -i packages/pi-video-gen/preview.png
+            -f lavfi -i anullsrc=r=48000:cl=stereo
+            -f lavfi -i anullsrc=r=48000:cl=stereo
+            -f lavfi -i sine=frequency=440:sample_rate=48000
+            -i timeline-smoke.srt
+            -filter_complex "
+              [0:v]scale=64:64,zoompan=z='min(zoom+0.001,1.1)':d=1:s=64x64:fps=25,settb=AVTB[v0];
+              [1:v]scale=64:64,settb=AVTB[v1];
+              [2:v]scale=16:16,format=rgba[ovr];
+              [v0][ovr]overlay=0:0:shortest=1[vo];
+              [vo][v1]xfade=transition=fade:duration=0.1:offset=0.4[v];
+              [3:a]atrim=0:0.25[a0];
+              [4:a]atrim=0:0.25[a1];
+              [a0][a1]concat=n=2:v=0:a=1[voice];
+              [5:a]atrim=0:0.5[bgm];
+              [voice][bgm]amix=inputs=2:duration=first:normalize=0,alimiter=limit=0.95:level=false[a]"
+            -map "[v]" -map "[a]" -map 6:s
+            -t 0.8 -c:a aac -c:s mov_text -y
+          )
+          run_ffmpeg "$bin" "${smoke_args[@]}" -c:v mpeg4 \
+            "timeline-smoke-${{ matrix.target }}.mp4"
+          run_ffmpeg "$gpl" "${smoke_args[@]}" -c:v libx264 \
+            "timeline-smoke-${{ matrix.target }}-h264.mp4"
+          run_ffmpeg "$bin" \
+            -ss 0.1 -t 0.3 -i "timeline-smoke-${{ matrix.target }}.mp4" \
+            -f lavfi -i anullsrc=r=48000:cl=stereo \
+            -filter_complex "
+              [0:v]scale=64:64:force_original_aspect_ratio=increase,crop=64:64,fps=25[v];
+              [0:a]volume=0.5[src];
+              [src][1:a]amix=inputs=2:duration=first:normalize=0,alimiter=limit=0.95:level=false[a]" \
+            -map "[v]" -map "[a]" -t 0.3 -c:v mpeg4 -c:a aac -y \
+            "mixed-media-smoke-${{ matrix.target }}.mp4"
+          run_ffmpeg "$bin" -ss 0.2 \
+            -i "mixed-media-smoke-${{ matrix.target }}.mp4" \
+            -frames:v 1 -y timeline-smoke-qc.png
+
+      - name: Stop Windows build container
+        if: always() && matrix.target == 'win32-x64'
+        run: docker rm --force "pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" || true
+
+      - name: Preserve executable permissions
+        run: |
+          tar -czf "pi-video-gen-ffmpeg-${{ matrix.target }}.tar.gz" \
+            -C "packages/pi-video-gen/platforms/ffmpeg-${{ matrix.target }}" \
+            bin LICENSE GPLv2.txt ZLIB_LICENSE.txt SOURCE.md source
+
+      - name: Upload platform package payload
+        uses: actions/upload-artifact@v7
+        with:
+          name: pi-video-gen-ffmpeg-${{ matrix.target }}
+          path: pi-video-gen-ffmpeg-${{ matrix.target }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-ffmpeg:
+    name: publish FFmpeg platform packages
+    needs: [decide, build]
+    if: needs.decide.outputs.missing == 'true'
+    runs-on:
+      - instance-hnpsq9go
+      - linux
+      - x64
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v7
+
+      - name: Download FFmpeg platform artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: pi-video-gen-ffmpeg-*
+          path: .release-artifacts
+
+      - name: Prepare FFmpeg platform packages
+        run: |
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64 win32-x64; do
+            tar -xzf ".release-artifacts/pi-video-gen-ffmpeg-${target}/pi-video-gen-ffmpeg-${target}.tar.gz" \
+              -C "packages/pi-video-gen/platforms/ffmpeg-${target}"
+          done
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup pnpm
+        run: corepack install -g pnpm@10.18.3
+
+      - name: Check npm token
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN repository secret is not configured."
+            exit 1
+          fi
+
+      - name: Publish platform packages to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          published=()
+          skipped=()
+          for dir in packages/pi-video-gen/platforms/ffmpeg-*; do
+            name="$(node -p "require('./${dir}/package.json').name")"
+            version="$(node -p "require('./${dir}/package.json').version")"
+            if npm view "${name}@${version}" version >/dev/null 2>&1; then
+              echo "skip ${name}@${version} (already on npm)"
+              skipped+=("${name}@${version}")
+            else
+              (cd "$dir" && pnpm publish --access public --no-git-checks)
+              published+=("${name}@${version}")
+            fi
+          done
+          echo "published: ${published[*]:-none}"
+          echo "skipped (already on npm): ${skipped[*]:-none}"
+          if [ "${#published[@]}" -eq 0 ]; then
+            echo "::notice::All FFmpeg platform package versions already exist on npm. To ship new FFmpeg binaries, bump the version in packages/pi-video-gen/platforms/*/package.json."
+          fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,6 +16,11 @@ on:
         required: true
         default: auto
         type: string
+      build_ffmpeg:
+        description: Rebuild and publish the FFmpeg platform packages first (at their committed versions); off = reuse the versions already on npm
+        required: true
+        default: false
+        type: boolean
 permissions:
   contents: write
 
@@ -24,207 +29,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-video-ffmpeg:
-    name: build pi-video-gen FFmpeg (${{ matrix.target }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # darwin targets need macOS hosts; linux-* targets keep the pinned
-          # ubuntu-22.04 image for the published glibc baseline. win32-x64
-          # produces PE binaries via mingw (host-glibc-agnostic), so it runs
-          # on the accelerated self-hosted runner for reliable source
-          # downloads (ffmpeg.org, zlib.net, code.videolan.org).
-          - target: darwin-arm64
-            runner: macos-15
-          - target: darwin-x64
-            runner: macos-15-intel
-          - target: linux-x64
-            runner: ubuntu-22.04
-          - target: linux-arm64
-            runner: ubuntu-22.04
-          - target: win32-x64
-            runner: [instance-hnpsq9go, linux, x64]
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 45
-
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v7
-
-      - name: Install build dependencies
-        run: |
-          case "${{ matrix.target }}" in
-            darwin-*)
-              brew install nasm pkg-config
-              ;;
-            linux-x64)
-              sudo apt-get update
-              sudo apt-get install -y nasm pkg-config
-              ;;
-            linux-arm64)
-              sudo apt-get update
-              sudo apt-get install -y gcc-aarch64-linux-gnu pkg-config qemu-user
-              ;;
-            win32-x64)
-              # The self-hosted runner has Docker access but intentionally has
-              # no passwordless sudo. Install the cross toolchain inside an
-              # ephemeral container without mutating the host.
-              win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-              docker pull ubuntu:22.04
-              docker run --detach --rm --name "$win_container" \
-                --env HTTP_PROXY --env HTTPS_PROXY --env NO_PROXY \
-                --env http_proxy --env https_proxy --env no_proxy \
-                --volume "$GITHUB_WORKSPACE:/workspace" --workdir /workspace \
-                ubuntu:22.04 sleep infinity
-              docker exec "$win_container" sh -c '
-                export DEBIAN_FRONTEND=noninteractive
-                apt-get update
-                apt-get install -y --no-install-recommends \
-                  ca-certificates curl gcc gcc-mingw-w64-x86-64 libc6-dev make nasm pkg-config wine64 xz-utils
-              '
-              docker exec "$win_container" install -d \
-                -o "$(id -u)" -g "$(id -g)" /tmp/runner-home
-              ;;
-          esac
-
-      - name: Build minimal LGPL FFmpeg
-        run: |
-          if [ "${{ matrix.target }}" = win32-x64 ]; then
-            win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-            docker exec --user "$(id -u):$(id -g)" --env HOME=/tmp/runner-home \
-              "$win_container" packages/pi-video-gen/scripts/build-ffmpeg.sh win32-x64
-          else
-            packages/pi-video-gen/scripts/build-ffmpeg.sh "${{ matrix.target }}"
-          fi
-
-      - name: Build GPL FFmpeg variant (x264 for h264)
-        run: |
-          if [ "${{ matrix.target }}" = win32-x64 ]; then
-            win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-            docker exec --user "$(id -u):$(id -g)" --env HOME=/tmp/runner-home --env GPL_VARIANT=1 \
-              "$win_container" packages/pi-video-gen/scripts/build-ffmpeg.sh win32-x64
-          else
-            GPL_VARIANT=1 packages/pi-video-gen/scripts/build-ffmpeg.sh "${{ matrix.target }}"
-          fi
-
-      - name: Verify FFmpeg binary
-        shell: bash
-        run: |
-          bin="packages/pi-video-gen/platforms/ffmpeg-${{ matrix.target }}/bin/ffmpeg"
-          gpl="packages/pi-video-gen/platforms/ffmpeg-${{ matrix.target }}/bin/ffmpeg-gpl"
-          probe="${bin%/*}/ffprobe"
-          gpl_probe="${gpl%/*}/ffprobe-gpl"
-          win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          run_win_container() {
-            docker exec --user "$(id -u):$(id -g)" --env HOME=/tmp/runner-home --env WINEDEBUG=-all \
-              "$win_container" "$@"
-          }
-          run_ffmpeg() {
-            executable="$1"
-            shift
-            case "${{ matrix.target }}" in
-              darwin-*|linux-x64) "$executable" "$@" ;;
-              linux-arm64) qemu-aarch64 -L /usr/aarch64-linux-gnu "$executable" "$@" ;;
-              win32-x64) run_win_container /usr/lib/wine/wine64 "${executable}.exe" "$@" ;;
-            esac
-          }
-          case "${{ matrix.target }}" in
-            darwin-*)
-              "$bin" -version
-              "$probe" -version
-              "$gpl" -version
-              "$gpl_probe" -version
-              xcrun vtool -show-build "$bin" | grep -q 'minos 11.0'
-              ;;
-            linux-x64)
-              "$bin" -version
-              "$probe" -version
-              "$gpl" -version
-              "$gpl_probe" -version
-              ldd "$bin"
-              ;;
-            linux-arm64)
-              qemu-aarch64 -L /usr/aarch64-linux-gnu "$bin" -version
-              qemu-aarch64 -L /usr/aarch64-linux-gnu "$probe" -version
-              qemu-aarch64 -L /usr/aarch64-linux-gnu "$gpl" -version
-              qemu-aarch64 -L /usr/aarch64-linux-gnu "$gpl_probe" -version
-              aarch64-linux-gnu-readelf -h "$bin" | grep -q 'AArch64'
-              ;;
-            win32-x64)
-              run_win_container /usr/lib/wine/wine64 "${bin}.exe" -version
-              run_win_container /usr/lib/wine/wine64 "${probe}.exe" -version
-              run_win_container /usr/lib/wine/wine64 "${gpl}.exe" -version
-              run_win_container /usr/lib/wine/wine64 "${gpl_probe}.exe" -version
-              run_win_container x86_64-w64-mingw32-objdump -f "${bin}.exe" | grep -q 'pei-x86-64'
-              ;;
-          esac
-          cat > timeline-smoke.srt <<'EOF'
-          1
-          00:00:00,000 --> 00:00:00,500
-          Timeline smoke
-          EOF
-          smoke_args=(
-            -nostdin -xerror
-            -loop 1 -framerate 25 -t 0.5 -i packages/pi-video-gen/preview.png
-            -loop 1 -framerate 25 -t 0.5 -i packages/pi-video-gen/preview.png
-            -loop 1 -framerate 25 -t 0.5 -i packages/pi-video-gen/preview.png
-            -f lavfi -i anullsrc=r=48000:cl=stereo
-            -f lavfi -i anullsrc=r=48000:cl=stereo
-            -f lavfi -i sine=frequency=440:sample_rate=48000
-            -i timeline-smoke.srt
-            -filter_complex "
-              [0:v]scale=64:64,zoompan=z='min(zoom+0.001,1.1)':d=1:s=64x64:fps=25,settb=AVTB[v0];
-              [1:v]scale=64:64,settb=AVTB[v1];
-              [2:v]scale=16:16,format=rgba[ovr];
-              [v0][ovr]overlay=0:0:shortest=1[vo];
-              [vo][v1]xfade=transition=fade:duration=0.1:offset=0.4[v];
-              [3:a]atrim=0:0.25[a0];
-              [4:a]atrim=0:0.25[a1];
-              [a0][a1]concat=n=2:v=0:a=1[voice];
-              [5:a]atrim=0:0.5[bgm];
-              [voice][bgm]amix=inputs=2:duration=first:normalize=0,alimiter=limit=0.95:level=false[a]"
-            -map "[v]" -map "[a]" -map 6:s
-            -t 0.8 -c:a aac -c:s mov_text -y
-          )
-          run_ffmpeg "$bin" "${smoke_args[@]}" -c:v mpeg4 \
-            "timeline-smoke-${{ matrix.target }}.mp4"
-          run_ffmpeg "$gpl" "${smoke_args[@]}" -c:v libx264 \
-            "timeline-smoke-${{ matrix.target }}-h264.mp4"
-          run_ffmpeg "$bin" \
-            -ss 0.1 -t 0.3 -i "timeline-smoke-${{ matrix.target }}.mp4" \
-            -f lavfi -i anullsrc=r=48000:cl=stereo \
-            -filter_complex "
-              [0:v]scale=64:64:force_original_aspect_ratio=increase,crop=64:64,fps=25[v];
-              [0:a]volume=0.5[src];
-              [src][1:a]amix=inputs=2:duration=first:normalize=0,alimiter=limit=0.95:level=false[a]" \
-            -map "[v]" -map "[a]" -t 0.3 -c:v mpeg4 -c:a aac -y \
-            "mixed-media-smoke-${{ matrix.target }}.mp4"
-          run_ffmpeg "$bin" -ss 0.2 \
-            -i "mixed-media-smoke-${{ matrix.target }}.mp4" \
-            -frames:v 1 -y timeline-smoke-qc.png
-
-      - name: Stop Windows build container
-        if: always() && matrix.target == 'win32-x64'
-        run: docker rm --force "pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" || true
-
-      - name: Preserve executable permissions
-        run: |
-          tar -czf "pi-video-gen-ffmpeg-${{ matrix.target }}.tar.gz" \
-            -C "packages/pi-video-gen/platforms/ffmpeg-${{ matrix.target }}" \
-            bin LICENSE GPLv2.txt ZLIB_LICENSE.txt SOURCE.md source
-
-      - name: Upload platform package payload
-        uses: actions/upload-artifact@v7
-        with:
-          name: pi-video-gen-ffmpeg-${{ matrix.target }}
-          path: pi-video-gen-ffmpeg-${{ matrix.target }}.tar.gz
-          if-no-files-found: error
-          retention-days: 1
+  ffmpeg:
+    name: build FFmpeg platform packages
+    if: inputs.build_ffmpeg
+    uses: ./.github/workflows/ffmpeg-build.yml
+    secrets: inherit
 
   publish:
     name: publish packages
-    needs: build-video-ffmpeg
+    needs: ffmpeg
+    if: always() && (needs.ffmpeg.result == 'success' || needs.ffmpeg.result == 'skipped')
     runs-on:
       - instance-hnpsq9go
       - linux
@@ -241,49 +55,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Download darwin-arm64 FFmpeg
-        uses: actions/download-artifact@v8
-        with:
-          name: pi-video-gen-ffmpeg-darwin-arm64
-          path: .release-artifacts/darwin-arm64
-
-      - name: Download darwin-x64 FFmpeg
-        uses: actions/download-artifact@v8
-        with:
-          name: pi-video-gen-ffmpeg-darwin-x64
-          path: .release-artifacts/darwin-x64
-
-      - name: Download linux-arm64 FFmpeg
-        uses: actions/download-artifact@v8
-        with:
-          name: pi-video-gen-ffmpeg-linux-arm64
-          path: .release-artifacts/linux-arm64
-
-      - name: Download linux-x64 FFmpeg
-        uses: actions/download-artifact@v8
-        with:
-          name: pi-video-gen-ffmpeg-linux-x64
-          path: .release-artifacts/linux-x64
-
-      - name: Download win32-x64 FFmpeg
-        uses: actions/download-artifact@v8
-        with:
-          name: pi-video-gen-ffmpeg-win32-x64
-          path: .release-artifacts/win32-x64
-
-      - name: Prepare FFmpeg platform packages
-        run: |
-          tar -xzf .release-artifacts/darwin-arm64/pi-video-gen-ffmpeg-darwin-arm64.tar.gz \
-            -C packages/pi-video-gen/platforms/ffmpeg-darwin-arm64
-          tar -xzf .release-artifacts/darwin-x64/pi-video-gen-ffmpeg-darwin-x64.tar.gz \
-            -C packages/pi-video-gen/platforms/ffmpeg-darwin-x64
-          tar -xzf .release-artifacts/linux-arm64/pi-video-gen-ffmpeg-linux-arm64.tar.gz \
-            -C packages/pi-video-gen/platforms/ffmpeg-linux-arm64
-          tar -xzf .release-artifacts/linux-x64/pi-video-gen-ffmpeg-linux-x64.tar.gz \
-            -C packages/pi-video-gen/platforms/ffmpeg-linux-x64
-          tar -xzf .release-artifacts/win32-x64/pi-video-gen-ffmpeg-win32-x64.tar.gz \
-            -C packages/pi-video-gen/platforms/ffmpeg-win32-x64
 
       - name: Setup Node
         uses: actions/setup-node@v7
@@ -308,6 +79,46 @@ jobs:
             echo "NPM_TOKEN repository secret is not configured."
             exit 1
           fi
+
+      # FFmpeg platform packages are versioned and published independently by
+      # the ffmpeg-build workflow. pi-video-gen pins them via workspace:* at
+      # publish time, so their committed versions must already exist on npm.
+      - name: Verify FFmpeg platform packages are published
+        run: |
+          node <<'EOF'
+          const fs = require("node:fs");
+          const path = require("node:path");
+          const { execFileSync } = require("node:child_process");
+
+          const platformsDir = path.join(process.cwd(), "packages", "pi-video-gen", "platforms");
+          const platformPackages = fs.readdirSync(platformsDir, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory())
+            .map((entry) =>
+              JSON.parse(fs.readFileSync(path.join(platformsDir, entry.name, "package.json"), "utf8"))
+            );
+
+          let missing = false;
+          for (const pkg of platformPackages) {
+            const ref = `${pkg.name}@${pkg.version}`;
+            try {
+              execFileSync("npm", ["view", ref, "version"], { stdio: ["ignore", "ignore", "pipe"] });
+              console.log(`ok: ${ref} is published`);
+            } catch (error) {
+              const stderr = error.stderr?.toString?.() ?? "";
+              if (!stderr.includes("E404")) {
+                throw new Error(`Failed to check ${ref} on npm: ${stderr || error.message}`);
+              }
+              console.error(`missing: ${ref} is not on npm`);
+              missing = true;
+            }
+          }
+          if (missing) {
+            console.error(
+              "FFmpeg platform packages are published by the ffmpeg-build workflow; run it and let it finish before publishing the monorepo packages."
+            );
+            process.exit(1);
+          }
+          EOF
 
       - name: Ensure release branch
         run: |
@@ -347,12 +158,10 @@ jobs:
             .filter((entry) => entry.isDirectory())
             .map((entry) => path.join(packagesDir, entry.name, "package.json"))
             .filter((file) => fs.existsSync(file));
-          const platformPackagesDir = path.join(packagesDir, "pi-video-gen", "platforms");
-          const platformPackageFiles = fs.readdirSync(platformPackagesDir, { withFileTypes: true })
-            .filter((entry) => entry.isDirectory())
-            .map((entry) => path.join(platformPackagesDir, entry.name, "package.json"))
-            .filter((file) => fs.existsSync(file));
-          const packageFiles = [...topLevelPackageFiles, ...platformPackageFiles];
+          // FFmpeg platform packages under packages/pi-video-gen/platforms are
+          // versioned and published independently by the ffmpeg-build workflow;
+          // the monorepo release must not rewrite or republish them.
+          const packageFiles = topLevelPackageFiles;
 
           const packages = packageFiles.map((file) => ({
             file,

--- a/packages/pi-video-gen/platforms/ffmpeg-darwin-arm64/package.json
+++ b/packages/pi-video-gen/platforms/ffmpeg-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-video-gen-ffmpeg-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "description": "LGPL FFmpeg + GPL FFmpeg (libx264) runtime for pi-video-gen on darwin arm64",
   "license": "SEE LICENSE IN SOURCE.md",
   "files": [

--- a/packages/pi-video-gen/platforms/ffmpeg-darwin-x64/package.json
+++ b/packages/pi-video-gen/platforms/ffmpeg-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-video-gen-ffmpeg-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "description": "LGPL FFmpeg + GPL FFmpeg (libx264) runtime for pi-video-gen on darwin x64",
   "license": "SEE LICENSE IN SOURCE.md",
   "files": [

--- a/packages/pi-video-gen/platforms/ffmpeg-linux-arm64/package.json
+++ b/packages/pi-video-gen/platforms/ffmpeg-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-video-gen-ffmpeg-linux-arm64",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "description": "LGPL FFmpeg + GPL FFmpeg (libx264) runtime for pi-video-gen on linux arm64",
   "license": "SEE LICENSE IN SOURCE.md",
   "files": [

--- a/packages/pi-video-gen/platforms/ffmpeg-linux-x64/package.json
+++ b/packages/pi-video-gen/platforms/ffmpeg-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-video-gen-ffmpeg-linux-x64",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "description": "LGPL FFmpeg + GPL FFmpeg (libx264) runtime for pi-video-gen on linux x64",
   "license": "SEE LICENSE IN SOURCE.md",
   "files": [

--- a/packages/pi-video-gen/platforms/ffmpeg-win32-x64/package.json
+++ b/packages/pi-video-gen/platforms/ffmpeg-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amaster.ai/pi-video-gen-ffmpeg-win32-x64",
-  "version": "0.1.0",
+  "version": "0.1.8",
   "description": "LGPL FFmpeg + GPL FFmpeg (libx264) runtime for pi-video-gen on win32 x64",
   "license": "SEE LICENSE IN SOURCE.md",
   "files": [

--- a/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
+++ b/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
@@ -9,6 +9,10 @@ const publishWorkflow = readFileSync(
   join(packageRoot, '..', '..', '.github', 'workflows', 'npm-publish.yml'),
   'utf-8',
 );
+const ffmpegBuildWorkflow = readFileSync(
+  join(packageRoot, '..', '..', '.github', 'workflows', 'ffmpeg-build.yml'),
+  'utf-8',
+);
 const mainPackage = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf-8')) as {
   files: string[];
   optionalDependencies?: Record<string, string>;
@@ -76,50 +80,69 @@ describe('pi-video-gen package artifacts', () => {
   });
 
   it('builds against declared platform baselines and verifies release binaries', () => {
-    expect(publishWorkflow).toContain('fail-fast: false');
-    expect(publishWorkflow).toContain('runner: ubuntu-22.04');
-    expect(publishWorkflow).toMatch(
+    expect(ffmpegBuildWorkflow).toContain('fail-fast: false');
+    expect(ffmpegBuildWorkflow).toContain('runner: ubuntu-22.04');
+    expect(ffmpegBuildWorkflow).toMatch(
       /- target: win32-x64\n\s+runner: \[instance-hnpsq9go, linux, x64\]/,
     );
-    expect(publishWorkflow).not.toContain('sudo -n');
-    expect(publishWorkflow).toContain('docker run --detach');
-    expect(publishWorkflow).toContain('ubuntu:22.04 sleep infinity');
-    expect(publishWorkflow).toContain('docker exec --user');
-    expect(publishWorkflow).toContain('gcc gcc-mingw-w64-x86-64');
-    expect(publishWorkflow).toContain('libc6-dev');
-    expect(publishWorkflow).toContain('/tmp/runner-home');
-    expect(publishWorkflow).toContain('/usr/lib/wine/wine64');
-    expect(publishWorkflow).toContain('Verify FFmpeg binary');
-    expect(publishWorkflow).toContain('vtool -show-build');
-    expect(publishWorkflow).not.toContain('vars.X264_SHA256');
-    expect(publishWorkflow).toContain('timeline-smoke');
-    expect(publishWorkflow).not.toContain('timeline-smoke.jpg');
-    expect(publishWorkflow).toContain('-i packages/pi-video-gen/preview.png');
-    expect(publishWorkflow).toContain('-nostdin -xerror');
-    expect(publishWorkflow).toContain('atrim=0:0.2');
-    expect(publishWorkflow).toContain('zoompan=');
-    expect(publishWorkflow).toContain('xfade=');
-    expect(publishWorkflow).toContain('overlay=');
-    expect(publishWorkflow).toContain('concat=n=2:v=0:a=1');
-    expect(publishWorkflow).toContain('amix=inputs=2');
-    expect(publishWorkflow).toContain('mov_text');
-    expect(publishWorkflow).toContain('timeline-smoke-qc.png');
-    expect(publishWorkflow).toContain('mixed-media-smoke');
-    expect(publishWorkflow).toContain('volume=0.5[src]');
-    expect(publishWorkflow).toContain('duration=first:normalize=0');
-    expect(publishWorkflow).toContain('alimiter=limit=0.95:level=false');
-    expect(publishWorkflow).toContain('libx264');
+    expect(ffmpegBuildWorkflow).not.toContain('sudo -n');
+    expect(ffmpegBuildWorkflow).toContain('docker run --detach');
+    expect(ffmpegBuildWorkflow).toContain('ubuntu:22.04 sleep infinity');
+    expect(ffmpegBuildWorkflow).toContain('docker exec --user');
+    expect(ffmpegBuildWorkflow).toContain('gcc gcc-mingw-w64-x86-64');
+    expect(ffmpegBuildWorkflow).toContain('libc6-dev');
+    expect(ffmpegBuildWorkflow).toContain('/tmp/runner-home');
+    expect(ffmpegBuildWorkflow).toContain('/usr/lib/wine/wine64');
+    expect(ffmpegBuildWorkflow).toContain('Verify FFmpeg binary');
+    expect(ffmpegBuildWorkflow).toContain('vtool -show-build');
+    expect(ffmpegBuildWorkflow).not.toContain('vars.X264_SHA256');
+    expect(ffmpegBuildWorkflow).toContain('timeline-smoke');
+    expect(ffmpegBuildWorkflow).not.toContain('timeline-smoke.jpg');
+    expect(ffmpegBuildWorkflow).toContain('-i packages/pi-video-gen/preview.png');
+    expect(ffmpegBuildWorkflow).toContain('-nostdin -xerror');
+    expect(ffmpegBuildWorkflow).toContain('atrim=0:0.2');
+    expect(ffmpegBuildWorkflow).toContain('zoompan=');
+    expect(ffmpegBuildWorkflow).toContain('xfade=');
+    expect(ffmpegBuildWorkflow).toContain('overlay=');
+    expect(ffmpegBuildWorkflow).toContain('concat=n=2:v=0:a=1');
+    expect(ffmpegBuildWorkflow).toContain('amix=inputs=2');
+    expect(ffmpegBuildWorkflow).toContain('mov_text');
+    expect(ffmpegBuildWorkflow).toContain('timeline-smoke-qc.png');
+    expect(ffmpegBuildWorkflow).toContain('mixed-media-smoke');
+    expect(ffmpegBuildWorkflow).toContain('volume=0.5[src]');
+    expect(ffmpegBuildWorkflow).toContain('duration=first:normalize=0');
+    expect(ffmpegBuildWorkflow).toContain('alimiter=limit=0.95:level=false');
+    expect(ffmpegBuildWorkflow).toContain('libx264');
   });
 
   it('executes cross-compiled release binaries before publishing them', () => {
-    expect(publishWorkflow).toContain('qemu-aarch64 -L /usr/aarch64-linux-gnu "$bin" -version');
-    expect(publishWorkflow).toContain(
+    expect(ffmpegBuildWorkflow).toContain('qemu-aarch64 -L /usr/aarch64-linux-gnu "$bin" -version');
+    expect(ffmpegBuildWorkflow).toContain(
       `run_win_container /usr/lib/wine/wine64 "\${bin}.exe" -version`,
     );
-    expect(publishWorkflow).toContain(`probe="\${bin%/*}/ffprobe"`);
-    expect(publishWorkflow).toContain(`gpl_probe="\${gpl%/*}/ffprobe-gpl"`);
-    expect(publishWorkflow).not.toContain(`\${bin/ffmpeg/ffprobe}`);
-    expect(publishWorkflow).not.toContain(`\${gpl/ffmpeg/ffprobe}`);
+    expect(ffmpegBuildWorkflow).toContain(`probe="\${bin%/*}/ffprobe"`);
+    expect(ffmpegBuildWorkflow).toContain(`gpl_probe="\${gpl%/*}/ffprobe-gpl"`);
+    expect(ffmpegBuildWorkflow).not.toContain(`\${bin/ffmpeg/ffprobe}`);
+    expect(ffmpegBuildWorkflow).not.toContain(`\${gpl/ffmpeg/ffprobe}`);
+  });
+
+  it('publishes FFmpeg platform packages from the dedicated ffmpeg-build workflow only', () => {
+    // ffmpeg-build.yml builds the binaries and publishes the five platform
+    // packages at their committed versions. npm-publish.yml never builds
+    // FFmpeg itself: it may invoke ffmpeg-build.yml as a reusable workflow
+    // (build_ffmpeg input), and otherwise reuses the committed platform
+    // versions already published on npm.
+    expect(ffmpegBuildWorkflow).toContain('workflow_dispatch');
+    expect(ffmpegBuildWorkflow).toContain('workflow_call');
+    expect(ffmpegBuildWorkflow).toContain('packages/pi-video-gen/scripts/**');
+    expect(ffmpegBuildWorkflow).toContain('packages/pi-video-gen/platforms/**');
+    expect(ffmpegBuildWorkflow).toContain('pnpm publish --access public --no-git-checks');
+    expect(publishWorkflow).not.toContain('build-video-ffmpeg');
+    expect(publishWorkflow).not.toContain('pi-video-gen-ffmpeg-');
+    expect(publishWorkflow).not.toContain('platformPackageFiles');
+    expect(publishWorkflow).toContain('Verify FFmpeg platform packages are published');
+    expect(publishWorkflow).toContain('build_ffmpeg');
+    expect(publishWorkflow).toContain('uses: ./.github/workflows/ffmpeg-build.yml');
   });
 
   for (const target of targets) {


### PR DESCRIPTION
## Problem

Every monorepo release ran the full FFmpeg build matrix first: five targets compiled from source (~45 min each) plus smoke verification, and the five `@amaster.ai/pi-video-gen-ffmpeg-*` platform packages were republished under each new monorepo version even though the binaries were byte-identical. Users also re-downloaded the FFmpeg runtime on every pi-video-gen upgrade.

## Solution

Decouple the FFmpeg platform packages from the monorepo release cycle.

**New `ffmpeg-build.yml`** — single source of truth for building and publishing the platform packages:
- Same 5-target build matrix and verification/smoke steps as before, moved verbatim
- Publishes the platform packages at the versions **committed** in `platforms/ffmpeg-*/package.json`; versions that already exist on npm are skipped, so re-runs are idempotent
- A `decide` job short-circuits the entire matrix when there is nothing new to publish (no wasted 45-min builds)
- Triggers: `workflow_dispatch`, pushes to master touching `packages/pi-video-gen/{scripts,platforms}/**`, and `workflow_call`

**`npm-publish.yml`** — no longer builds FFmpeg:
- The `build-video-ffmpeg` job and all artifact download/extract steps are removed
- A guard step fails early if any committed platform version is missing on npm, with an actionable message
- The versioning script no longer rewrites or republishes the platform packages
- New `build_ffmpeg` dispatch input (default off): when enabled, the release invokes `ffmpeg-build.yml` as a reusable workflow first, so shipping new FFmpeg binaries is a one-dispatch operation; when off, the release reuses the latest platform packages already on npm

**pi-video-gen**:
- Platform packages pinned at `0.1.8` — identical to what is already published on npm (no changes to `scripts/` or `platforms/` since v0.1.8), so nothing needs to be rebuilt or republished
- `optionalDependencies: workspace:*` is unchanged: pnpm rewrites it to the committed platform version at publish time, so each pi-video-gen release automatically pins whatever FFmpeg package version is current
- `package-artifacts` tests now assert against `ffmpeg-build.yml` and guard the decoupling

## Shipping new FFmpeg binaries after this PR

Change `build-ffmpeg.sh` **and** bump the five platform package versions in the same PR, then either:
- let `ffmpeg-build` run automatically on merge, or
- tick `build_ffmpeg` when dispatching the next npm publish

The next monorepo release then pins the new platform version with no further changes.

## Verification

- pi-video-gen unit tests: 361 passed (incl. updated `package-artifacts` suite)
- Both workflow files parse cleanly
- Pre-commit hooks (lint + typecheck + test + build) ran green on this commit