### PR TITLE
fix(ci): unpack published FFmpeg binaries for npm-publish checks

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -129,7 +129,9 @@ jobs:
           name="$(node -p "require('./${platform_dir}/package.json').name")"
           version="$(node -p "require('./${platform_dir}/package.json').version")"
           tarball="$(npm pack "${name}@${version}" --silent)"
-          tar -xzf "${tarball}" -C "${platform_dir}" --strip-components=1
+          mkdir -p "${platform_dir}/bin"
+          tar -xzf "${tarball}" -C "${platform_dir}/bin" --strip-components=2 package/bin
+          rm -f "${tarball}"
           "${platform_dir}/bin/ffmpeg" -version
           "${platform_dir}/bin/ffprobe" -version
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -120,6 +120,19 @@ jobs:
           }
           EOF
 
+      # The pi-video-gen test suites execute real FFmpeg binaries (ffmpeg +
+      # ffprobe). Unpack the exact published linux-x64 platform package the
+      # release will pin, so checks validate the binaries users will install.
+      - name: Unpack published FFmpeg binaries for checks
+        run: |
+          platform_dir="packages/pi-video-gen/platforms/ffmpeg-linux-x64"
+          name="$(node -p "require('./${platform_dir}/package.json').name")"
+          version="$(node -p "require('./${platform_dir}/package.json').version")"
+          tarball="$(npm pack "${name}@${version}" --silent)"
+          tar -xzf "${tarball}" -C "${platform_dir}" --strip-components=1
+          "${platform_dir}/bin/ffmpeg" -version
+          "${platform_dir}/bin/ffprobe" -version
+
       - name: Ensure release branch
         run: |
           if [ "${GITHUB_REF_NAME}" != "master" ]; then

--- a/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
+++ b/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
@@ -142,7 +142,7 @@ describe('pi-video-gen package artifacts', () => {
     expect(publishWorkflow).not.toContain('platformPackageFiles');
     expect(publishWorkflow).toContain('Verify FFmpeg platform packages are published');
     expect(publishWorkflow).toContain('Unpack published FFmpeg binaries for checks');
-    expect(publishWorkflow).toContain('npm pack');
+    expect(publishWorkflow).toContain('npm pack "${name}@${version}" --silent');
     expect(publishWorkflow).toContain('build_ffmpeg');
     expect(publishWorkflow).toContain('uses: ./.github/workflows/ffmpeg-build.yml');
   });

--- a/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
+++ b/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
@@ -141,6 +141,8 @@ describe('pi-video-gen package artifacts', () => {
     expect(publishWorkflow).not.toContain('pi-video-gen-ffmpeg-');
     expect(publishWorkflow).not.toContain('platformPackageFiles');
     expect(publishWorkflow).toContain('Verify FFmpeg platform packages are published');
+    expect(publishWorkflow).toContain('Unpack published FFmpeg binaries for checks');
+    expect(publishWorkflow).toContain('npm pack');
     expect(publishWorkflow).toContain('build_ffmpeg');
     expect(publishWorkflow).toContain('uses: ./.github/workflows/ffmpeg-build.yml');
   });


### PR DESCRIPTION
## Problem

After #152, the npm-publish `Run checks` step lost its FFmpeg test fixture: the old flow extracted freshly built binaries into `packages/pi-video-gen/platforms/ffmpeg-linux-x64/bin/`, and the pi-video-gen test suites resolved them through the workspace link. Without them, resolution falls back to PATH, and the self-hosted runner has `ffmpeg` but no `ffprobe` — 49 tests fail with `ffprobe is not runnable (source tried: path)` ([run](https://github.com/TGYD-helige/pi/actions/runs/31873306184/job/94985102944)).

## Fix

Right after the platform-version guard, `npm pack` the exact published `linux-x64` platform package version the release is about to pin, and unpack it into the workspace platform dir:

- The compose/timeline suites once again run against real binaries — the **same bytes users will install**, so checks double as a smoke test of the published artifact
- The `ffmpeg -version` / `ffprobe -version` probes fail loudly if the published tarball is broken
- No rebuild: the binaries come from the already-published npm package (name and version are read from the committed `package.json`, so this follows future version bumps automatically)

## Verification

- `npm pack @amaster.ai/pi-video-gen-ffmpeg-linux-x64@0.1.8` produces a tarball with `bin/ffmpeg` + `bin/ffprobe`; `--strip-components=1` maps them into the platform dir
- package-artifacts tests: 10/10 pass (new assertions for this step)
- Pre-commit hooks (lint + typecheck + test + build) ran green