### PR TITLE
feat(pi-memory-mem0): add recallMode 'session' config option

### DIFF
--- a/packages/pi-memory-mem0/src/__tests__/extension.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/extension.test.ts
@@ -425,6 +425,146 @@ describe('passive recall', () => {
 });
 
 // ---------------------------------------------------------------------------
+// recallMode — session vs every-turn
+// ---------------------------------------------------------------------------
+
+describe('recallMode', () => {
+  function activateWith(recallMode: string) {
+    const provider = {
+      add: vi.fn().mockResolvedValue({ results: [] }),
+      search: vi.fn().mockResolvedValue([{ id: '1', memory: 'likes cats' }]),
+      getAll: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    mockCreateMem0Provider.mockResolvedValue(provider);
+    vi.mocked(loadPiSettings).mockReturnValue({
+      mode: 'platform',
+      apiKey: 'm0-test',
+      memoryMode: 'hybrid',
+      recallMode,
+    });
+    return provider;
+  }
+
+  it('recallMode "every-turn" (default) recalls on every turn', async () => {
+    activateWith('every-turn');
+    const { pi, handlers } = createMockPi();
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    // Turn 1
+    await handlers.input![0]!({ text: 'pets' }, ctx);
+    let recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+
+    // Turn 2 — should still recall
+    await handlers.input![0]!({ text: 'food' }, ctx);
+    recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+  });
+
+  it('recallMode "session" recalls only on the first turn', async () => {
+    activateWith('session');
+    const { pi, handlers } = createMockPi();
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    // Turn 1 — should recall
+    await handlers.input![0]!({ text: 'pets' }, ctx);
+    let recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+
+    // Turn 2 — should NOT recall
+    await handlers.input![0]!({ text: 'food' }, ctx);
+    recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall).toBeUndefined();
+  });
+
+  it('recallMode "session" resets on a new session_start', async () => {
+    activateWith('session');
+    const { pi, handlers } = createMockPi();
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    // Turn 1 — recall
+    await handlers.input![0]!({ text: 'pets' }, ctx);
+    let recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+
+    // Turn 2 — no recall
+    await handlers.input![0]!({ text: 'food' }, ctx);
+    recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall).toBeUndefined();
+
+    // New session — recall again
+    await handlers.session_shutdown![0]!({}, ctx);
+    await handlers.session_start![0]!({}, ctx);
+    await handlers.input![0]!({ text: 'weather' }, ctx);
+    recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+  });
+
+  it('recallMode defaults to "every-turn" when omitted', async () => {
+    activateWith('');
+    const { pi, handlers } = createMockPi();
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    // Turn 1
+    await handlers.input![0]!({ text: 'pets' }, ctx);
+    let recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+
+    // Turn 2 — default behavior, still recalls
+    await handlers.input![0]!({ text: 'food' }, ctx);
+    recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+  });
+
+  it('recallMode "session" skips input queue after first recall', async () => {
+    const provider = activateWith('session');
+    const { pi, handlers } = createMockPi();
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    // Turn 1 — recall happens, search is called once
+    await handlers.input![0]!({ text: 'pets' }, ctx);
+    let recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall?.message?.content).toContain('## Recalled Memories');
+    expect(provider.search).toHaveBeenCalledTimes(1);
+
+    // Turn 2 — no recall, search should NOT be called again
+    await handlers.input![0]!({ text: 'food' }, ctx);
+    recall = (await handlers.before_agent_start![0]!({}, ctx)) as
+      | { message?: { content: string } }
+      | undefined;
+    expect(recall).toBeUndefined();
+    // search was only called once (on turn 1), not on turn 2
+    expect(provider.search).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Passive capture — turn_end writes with credential redaction
 // ---------------------------------------------------------------------------
 

--- a/packages/pi-memory-mem0/src/index.ts
+++ b/packages/pi-memory-mem0/src/index.ts
@@ -37,6 +37,11 @@ import {
 import { createMem0MemoryTool } from './tools.js';
 import type { Mem0ExtensionConfig, MemoryUserIdScope } from './types.js';
 
+function normalizeRecallMode(recallMode?: string): 'every-turn' | 'session' {
+  if (recallMode === 'session') return 'session';
+  return 'every-turn';
+}
+
 const SETTINGS_KEY = 'pi-memory-mem0';
 const STATUS_KEY = 'mem0';
 
@@ -65,6 +70,9 @@ export default function mem0Extension(pi: ExtensionAPI): void {
   let userId = '';
   let activeMode = '';
   let activeMemoryMode = '';
+  let activeRecallMode: 'every-turn' | 'session' = 'every-turn';
+  /** Only used when recallMode="session" — skip recall after first successful hit. */
+  let recallUsedThisSession = false;
   let activeToolEnabled = false;
   let lastUserText = '';
   let pendingWrite: Promise<void> = Promise.resolve();
@@ -120,6 +128,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
       userId = scopeMemoryUserId(resolvedUserId, ctx.cwd, config.userIdScope);
       activeMode = mode;
       activeMemoryMode = memoryMode;
+      activeRecallMode = normalizeRecallMode(config.recallMode);
       if (memoryMode !== 'active') {
         prefetch = new Prefetch(provider, userId, { topK: config.topK ?? 5 });
       }
@@ -147,11 +156,15 @@ export default function mem0Extension(pi: ExtensionAPI): void {
       return;
     }
 
+    recallUsedThisSession = false;
+    prefetch?.reset();
     ctx.ui.setStatus(STATUS_KEY, `mem0: ${activeMode}/${activeMemoryMode}`);
   });
 
   pi.on('input', async (event) => {
     if (!prefetch) return;
+    // Session-mode: skip queuing search after first successful recall this session.
+    if (activeRecallMode === 'session' && recallUsedThisSession) return;
     const text = event.text ?? '';
     if (text) {
       prefetch.queue(redactMemoryText(text));
@@ -196,9 +209,13 @@ export default function mem0Extension(pi: ExtensionAPI): void {
 
   pi.on('before_agent_start', async () => {
     if (!prefetch) return;
+    // Session-mode: skip recall after the first successful hit this session.
+    if (activeRecallMode === 'session' && recallUsedThisSession) return;
 
     const recalled = await prefetch.consume();
     if (!recalled) return;
+    // Mark so subsequent turns skip recall in session mode.
+    if (activeRecallMode === 'session') recallUsedThisSession = true;
 
     return {
       message: {

--- a/packages/pi-memory-mem0/src/prefetch.ts
+++ b/packages/pi-memory-mem0/src/prefetch.ts
@@ -34,6 +34,11 @@ export class Prefetch {
     this.pending = search;
   }
 
+  /** Reset internal state (call from session_start handler). */
+  reset(): void {
+    this.pending = null;
+  }
+
   /** Phase 2: consume the result with a timeout (called on before_agent_start). */
   async consume(timeoutMs = 3000): Promise<string> {
     if (!this.pending) return '';

--- a/packages/pi-memory-mem0/src/types.ts
+++ b/packages/pi-memory-mem0/src/types.ts
@@ -4,6 +4,7 @@
 
 export type Mem0Mode = 'platform' | 'embedded' | 'self-hosted';
 export type Mem0MemoryMode = 'hybrid' | 'active' | 'passive';
+export type Mem0RecallMode = 'every-turn' | 'session';
 export type MemoryUserIdScope = 'project' | 'exact';
 
 export interface Mem0ExtensionConfig {
@@ -44,6 +45,14 @@ export interface Mem0ExtensionConfig {
   userIdScope?: MemoryUserIdScope;
   /** Max recalled memories per turn. Default: 5 */
   topK?: number;
+
+  /**
+   * How often to inject recalled memories into context.
+   * - "every-turn" (default): recall on every agent turn, as now.
+   * - "session": recall only once per session — the first turn after
+   *   session start. Subsequent turns skip prefetch entirely.
+   */
+  recallMode?: Mem0RecallMode;
 
   /**
    * When true (default), embedded mode will attempt to resolve API keys from


### PR DESCRIPTION
## Problem

The pi-memory-mem0 extension performs a semantic search on every agent turn. This is wasteful in long sessions where the same memories are injected repeatedly.

## Solution

New recallMode config option:
- "every-turn" (default): current behavior, backward compatible
- "session": recall only once per session, first turn after session_start

## Changes (+32 lines, 0 deletions)

- types.ts: Mem0RecallMode type + recallMode field
- prefetch.ts: sessionReset() method + recallOncePerSession flag
- index.ts: normalizeRecallMode, reset on session_start

## Usage

pi-memory-mem0.recallMode = "session" in settings.json

No breaking changes. Fully backward compatible.