### PR TITLE
feat(pi-video-gen): structured prompt fields with plugin-side assembly

### DIFF
--- a/packages/pi-video-gen/README.md
+++ b/packages/pi-video-gen/README.md
@@ -165,16 +165,34 @@ the binaries.
 | Tool | What it does |
 |---|---|
 | `video_compose` | **Local video assembly, no paid video models.** C0 (`compose-input.json`) concatenates compatible clips. Timeline media, overlays, transitions, subtitles, source audio, and BGM render locally. Narration is an explicit network feature: setting `voice` to `edge-tts:<voice-name>` sends narration text to Microsoft Edge TTS. |
-| `video_generate` | One short clip from a prompt (+ optional first/last frame images). Paid, minutes per clip. Interrupted after receiving a task id? Resume with the returned `jobId`; an ambiguous submit is parked and never resubmitted automatically. |
+| `video_generate` | One short clip from a structured prompt (style/scene/visuals/action/effects/audio + optional first/last frame images). Paid, minutes per clip. Interrupted after receiving a task id? Resume with the returned `jobId`; an ambiguous submit is parked and never resubmitted automatically. |
 | `video_render` | Multi-shot film from `<jobDir>/render-input.json`: snapshots + hashes all frames, submits one paid task per shot (resume-aware, finished shots never re-bill), downloads clips, ffmpeg-concats into `final_video.mp4`. |
 | `video_capabilities` | Read-only: active model's capability table + registered models. Call before composing prompts or shot books. |
+
+## Structured prompts
+
+Both paid tools take structured prompt fields, never a pre-joined string. The
+plugin assembles the labeled prompt text (`[Style]` / `[Character]` / `[Scene]`
+/ `[Visuals]` / `[Action]` / `[Effects]` / `[Audio]` + consistency/negative
+directives), so every shot reliably carries the film-level directives:
+
+- **Film level** — `style` (genre/quality/texture), `characters`
+  (`{id, description}` registry), `consistency` (identity/no-drift directive),
+  `negative` (e.g. "no text, watermarks, or subtitles").
+- **Shot level** (`prompt` object) — `visuals` (camera/framing) and `action`
+  are always required; `scene` plus film-level `style` are **required when no
+  first frame anchors the shot** (text-to-video must not go out action-only);
+  `effects` carries time-varying content a static frame cannot express
+  (transformations, lighting shifts, atmosphere); `audio` takes
+  `[Sound Effect] … / [Speaker] …` cues; `visibleCharacters` inlines the
+  referenced character descriptions.
 
 ## Commands
 
 | Command | What it does |
 |---|---|
 | `/video-gen compose <spec>` | Same as the `video_compose` tool |
-| `/video-gen generate <prompt>` | Same as the `video_generate` tool |
+| `/video-gen generate --visuals ".." --action ".." [--style ".." --scene ".."]` | Structured-prompt flags for the `video_generate` tool (also `--effects/--audio/--consistency/--negative/--first-frame/--last-frame/--duration/--ratio`; quote values may escape their delimiter as `\"`). The `characters` registry is tool/render-spec only — not available via flags |
 | `/video-gen render <spec>` | Same as the `video_render` tool |
 | `/video-gen recover <jobId>` | List ambiguous render shots; explicitly `reset` a confirmed-absent task or `adopt <taskId>` found in the provider console |
 | `/video-gen models` | List registered models + key readiness |
@@ -186,8 +204,8 @@ the binaries.
 Driven by the `video-gen` skill in conversation:
 
 1. **Shot book** — the agent authors a shot book (characters + shots with
-   first/last-frame descriptions, motion, audio, continuity) and you review it
-   in chat. Default small: 1 scene, 3–5 shots.
+   first/last-frame descriptions, visuals+action, effects, audio, continuity)
+   and you review it in chat. Default small: 1 scene, 3–5 shots.
 2. **Frames** — the agent generates character portraits and per-shot frames via
    `image_generate` (pi-image-gen), tracking real returned paths in
    `assets.json`.
@@ -216,3 +234,11 @@ console before starting another generation. Single-job resume independently
 recomputes the request fingerprint from its frozen `input.json`; an inspect 404
 keeps the remote handle and parks the job as ambiguous instead of declaring it
 safe to resubmit.
+
+**Upgrading from the pre-structured format**: render jobs whose
+`render-input.json` still uses the old `videoPrompt` string can no longer be
+parsed or resumed (the structured `prompt` object replaced it deliberately,
+with no compatibility layer). If an in-flight paid task is stranded by the
+upgrade, download its clip manually from the provider console — task URLs
+expire (Ark: 24h). Single-clip jobs are unaffected: their frozen `input.json`
+is read, not re-parsed.

--- a/packages/pi-video-gen/skills/video-gen/SKILL.md
+++ b/packages/pi-video-gen/skills/video-gen/SKILL.md
@@ -183,9 +183,12 @@ Author as JSON in conversation; save to `<jobDir>/project.json` for the record.
   "shots": [{
     "id": "s1",
     "intent": "Wide shot, rainy alley. <Alice> enters from the left, stops under the streetlamp…",
+    "scene": "Rainy alley at night, neon signs, wet pavement",   // optional: the shot's setting
     "firstFrame": "…pure static description of the FIRST frame…",
     "lastFrame": "…(optional) pure static description of the LAST frame…",
-    "motion": "Static camera. A woman with long blonde hair and a red scarf walks in from the left…",
+    "visuals": "Static camera, wide shot from across the street…",   // camera + framing only
+    "action": "A woman with long blonde hair and a red scarf walks in from the left…",
+    "effects": "…(optional) time-varying visuals: rain picks up, neon reflections intensify…",
     "audio": "[Sound Effect] rain, distant traffic. [Speaker] Alice (soft): \"We're here.\"",
     "visibleCharacters": ["alice"],
     "durationSec": 5,
@@ -205,8 +208,16 @@ Field rules:
 - **firstFrame / lastFrame are pure static snapshots** — no ongoing actions
   ("he is sitting, leaning forward", NOT "he is about to stand"). Include shot
   size, angle, composition, who is where and facing which way.
-- **motion = camera movement + in-frame movement**, named separately. Refer to
-  characters by visible traits ("the woman in the red scarf"), never by name.
+- **visuals = camera + framing only** (movement, shot size, angle, focus);
+  **action = in-frame movement only**. Split them — they become separate
+  labeled sections in the assembled prompt. Refer to characters by visible
+  traits ("the woman in the red scarf"), never by name.
+- **scene is the shot's setting**, copied verbatim into the render spec's
+  `prompt.scene`. Optional when the first frame fully anchors the setting;
+  write it when the setting carries mood/lighting the frame may not convey.
+- **effects is for what a static frame cannot carry**: transformations,
+  lighting/atmosphere shifts, particles, slow motion. Omit when the shot is
+  visually static.
 - **lastFrame needed when**: composition/focus changes drastically, a character
   enters or turns to face camera, a major reveal happens. Otherwise omit it.
 - **Few camera positions.** Default: one `continuityGroup` for everything. New
@@ -273,15 +284,38 @@ Write `<outputDir>/<jobId>/render-input.json` (jobId: letters/digits/dash/unders
 ```jsonc
 {
   "title": "…", "aspectRatio": "16:9",
+  "style": "Cartoon, warm palette, soft shading",        // film-level look — from the shot book's style
+  "characters": [                                        // film-level registry — id + appearance/outfit merged
+    { "id": "alice", "description": "long blonde hair, blue eyes, slender; red scarf, black leather jacket" }
+  ],
+  "consistency": "Faces, hair and outfits stay identical across the shot, no morphing or drift.",
+  "negative": "no text, watermarks, or subtitles",
   "shots": [{
     "id": "s1",
-    "videoPrompt": "<motion> + <audio cues>",
+    "prompt": {                                          // from the shot book's fields, verbatim
+      "scene": "Rainy alley at night, neon signs, wet pavement",   // omit when the first frame says it all
+      "visuals": "Static camera, wide shot from across the street",
+      "action": "The woman in the red scarf walks in from the left, stops under the streetlamp",
+      "effects": "Rain picks up halfway through; neon reflections ripple in puddles",
+      "audio": "[Sound Effect] rain, distant traffic. [Speaker] Alice (soft): \"We're here.\"",
+      "visibleCharacters": ["alice"]
+    },
     "firstFramePath": "<project>/path/from/assets.json.png",
     "lastFramePath": "<project>/optional.png",
     "durationSec": 5
   }]
 }
 ```
+
+The plugin assembles each shot's labeled prompt (`[Style]` / `[Character]` /
+`[Scene]` / `[Visuals]` / `[Action]` / `[Effects]` / `[Audio]` + consistency and
+negative directives) — never pre-join a prompt string yourself. Validation
+fails the run before any paid call when: `visuals`/`action` are empty,
+`visibleCharacters` references an id missing from `characters`, or a shot
+without `firstFramePath` lacks `style`/`scene` (text-to-video must not go out
+action-only). Film-level `style`/`consistency`/`negative` apply to every shot —
+write them once; shot-level `scene` repeats per shot even when consecutive
+shots share a location (each shot is submitted independently).
 
 Every reference-frame path must resolve to a regular png/jpg/webp file inside
 the session cwd. Absolute paths are accepted only when they remain inside that

--- a/packages/pi-video-gen/src/__tests__/extension.test.ts
+++ b/packages/pi-video-gen/src/__tests__/extension.test.ts
@@ -15,7 +15,7 @@ const suiteDir = join(tmpdir(), 'pi-video-gen-extension');
 
 type ToolDef = {
   name: string;
-  parameters: { properties?: Record<string, unknown> };
+  parameters: { properties?: Record<string, unknown>; required?: string[] };
   promptGuidelines?: string[];
   execute: (...args: unknown[]) => Promise<{
     isError?: true;
@@ -59,6 +59,12 @@ function notifiedText(ctx: ReturnType<typeof fakeCtx>): string {
   return ctx.ui.notify.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
 }
 
+/** Valid text-only generate params (style+scene are required without a frame). */
+const VALID_GENERATE_PARAMS = {
+  style: 'cinematic',
+  prompt: { scene: 'open sea', visuals: 'static wide shot', action: 'waves rolling' },
+};
+
 async function startSession(cwd: string, trusted = false) {
   await handlers.get('session_start')?.(undefined, fakeCtx(cwd, trusted));
 }
@@ -98,10 +104,28 @@ describe('pi-video-gen extension', () => {
   });
 
   it('exposes lastFrame in the schema for Seedance 2.0 (supportsFirstLastFrame)', () => {
-    const params = tools.get('video_generate')!.parameters.properties ?? {};
-    expect(Object.keys(params)).toContain('lastFrame');
-    expect(Object.keys(params)).toContain('prompt');
-    expect(Object.keys(params)).toContain('jobId');
+    const params = tools.get('video_generate')!.parameters;
+    const props = params.properties ?? {};
+    expect(Object.keys(props)).toContain('lastFrame');
+    expect(Object.keys(props)).toContain('prompt');
+    expect(Object.keys(props)).toContain('jobId');
+    expect(Object.keys(props)).toContain('style');
+    expect(Object.keys(props)).toContain('characters');
+    // prompt is optional at the schema level so a resume call may pass only jobId;
+    // fresh-submit validation enforces it inside execute().
+    expect(params.required ?? []).not.toContain('prompt');
+    const promptProps =
+      (props.prompt as { properties?: Record<string, unknown> } | undefined)?.properties ?? {};
+    expect(Object.keys(promptProps)).toEqual(
+      expect.arrayContaining([
+        'scene',
+        'visuals',
+        'action',
+        'effects',
+        'audio',
+        'visibleCharacters',
+      ]),
+    );
   });
 
   it('keeps compose identity entirely in the immutable spec path', () => {
@@ -150,7 +174,7 @@ describe('pi-video-gen extension', () => {
   it('video_generate fails with key guidance when no api key is configured', async () => {
     const result = await tools
       .get('video_generate')!
-      .execute('call-1', { prompt: 'waves' }, undefined, undefined, fakeCtx(cwd));
+      .execute('call-1', VALID_GENERATE_PARAMS, undefined, undefined, fakeCtx(cwd));
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toMatch(/api key/i);
   });
@@ -177,7 +201,7 @@ describe('pi-video-gen extension', () => {
     try {
       const first = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves' }, undefined, undefined, fakeCtx(cwd));
+        .execute('c1', VALID_GENERATE_PARAMS, undefined, undefined, fakeCtx(cwd));
       expect(first.isError).toBe(true);
       const jobId = String(first.details?.jobId);
       expect(jobId).toMatch(/^gen-/);
@@ -192,7 +216,7 @@ describe('pi-video-gen extension', () => {
 
       const resumed = await tools
         .get('video_generate')!
-        .execute('c2', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+        .execute('c2', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
       expect(resumed.isError).toBe(true);
       expect(resumed.content[0]!.text).toMatch(/ambiguous|MAY exist/i);
       expect(submits).toBe(1);
@@ -213,7 +237,13 @@ describe('pi-video-gen extension', () => {
 
     const result = await tools
       .get('video_generate')!
-      .execute('call-1', { prompt: 'waves', durationSec: 99 }, undefined, undefined, fakeCtx(cwd));
+      .execute(
+        'call-1',
+        { ...VALID_GENERATE_PARAMS, durationSec: 99 },
+        undefined,
+        undefined,
+        fakeCtx(cwd),
+      );
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toMatch(/durationSec must be 4-15s/);
   });
@@ -229,6 +259,95 @@ describe('pi-video-gen extension', () => {
     expect(text).toMatch(/image_generate/);
     expect(text).toMatch(/CJK font/);
     expect(text).toMatch(/not trusted/);
+  });
+
+  it('/video-gen generate rejects freeform text and points at flag usage', async () => {
+    const ctx = fakeCtx(cwd);
+    await commands.get('video-gen')!.handler('generate a cat in the rain', ctx);
+    expect(notifiedText(ctx)).toMatch(/Unrecognized text/);
+    expect(notifiedText(ctx)).toMatch(/--visuals/);
+  });
+
+  it('/video-gen generate rejects unknown flags and non-integer durations', async () => {
+    const ctx = fakeCtx(cwd);
+    await commands.get('video-gen')!.handler('generate --visuals "v" --action "a" --bogus x', ctx);
+    expect(notifiedText(ctx)).toMatch(/Unknown flag\(s\): --bogus/);
+
+    const ctx2 = fakeCtx(cwd);
+    await commands
+      .get('video-gen')!
+      .handler('generate --visuals "v" --action "a" --duration 4.5', ctx2);
+    expect(notifiedText(ctx2)).toMatch(/--duration must be an integer/);
+  });
+
+  it('/video-gen generate surfaces structured-prompt validation errors', async () => {
+    mkdirSync(join(home, '.pi', 'agent'), { recursive: true });
+    writeFileSync(
+      join(home, '.pi', 'agent', 'settings.json'),
+      JSON.stringify({ 'pi-video-gen': { providers: { ark: { apiKey: 'k' } } } }),
+    );
+    await startSession(cwd);
+
+    const ctx = fakeCtx(cwd);
+    await commands.get('video-gen')!.handler('generate --action "waves rolling"', ctx);
+    expect(notifiedText(ctx)).toMatch(/visuals is required/);
+
+    const ctx2 = fakeCtx(cwd);
+    await commands
+      .get('video-gen')!
+      .handler('generate --visuals "static wide shot" --action "waves rolling"', ctx2);
+    expect(notifiedText(ctx2)).toMatch(/style.*required for text-to-video/);
+  });
+
+  it('/video-gen generate assembles the flags into the submitted prompt', async () => {
+    mkdirSync(join(home, '.pi', 'agent'), { recursive: true });
+    writeFileSync(
+      join(home, '.pi', 'agent', 'settings.json'),
+      JSON.stringify({ 'pi-video-gen': { providers: { ark: { apiKey: 'k' } } } }),
+    );
+    await startSession(cwd);
+
+    let submitted: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: unknown, init?: RequestInit) => {
+        const u = String(url);
+        if (init?.method === 'POST') {
+          submitted = JSON.parse(String(init.body));
+          return new Response(JSON.stringify({ id: 'task-1' }), { status: 200 });
+        }
+        if (u.includes('/contents/generations/tasks/')) {
+          return new Response(
+            JSON.stringify({
+              status: 'succeeded',
+              content: { video_url: 'https://93.184.216.34/v.mp4' },
+            }),
+            { status: 200 },
+          );
+        }
+        const header = Buffer.alloc(16);
+        header.write('ftyp', 4, 'ascii');
+        return new Response(new Uint8Array(header), { status: 200 });
+      }),
+    );
+    try {
+      const ctx = fakeCtx(cwd);
+      // escaped quotes inside --audio: dialogue lines carry them by convention
+      await commands
+        .get('video-gen')!
+        .handler(
+          'generate --style "cinematic" --scene "open sea" --visuals "static wide shot" --action "waves rolling" --audio "[Speaker] Alice (soft): \\"We\'re here.\\"" --negative "no text" --duration 5',
+          ctx,
+        );
+      expect(notifiedText(ctx)).toMatch(/Video clip ready/);
+      const content = (submitted!.content as { type: string; text: string }[])[0]!;
+      expect(content.text).toBe(
+        '[Style] cinematic\n[Scene] open sea\n[Visuals] static wide shot\n[Action] waves rolling\n[Audio] [Speaker] Alice (soft): "We\'re here."\nNegative: no text',
+      );
+      expect(submitted!.duration).toBe(5);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('/video-gen doctor reports the active custom provider and its key', async () => {
@@ -271,7 +390,7 @@ describe('pi-video-gen extension', () => {
 
     const result = await tools
       .get('video_generate')!
-      .execute('call-1', { prompt: 'waves' }, undefined, undefined, fakeCtx(cwd));
+      .execute('call-1', VALID_GENERATE_PARAMS, undefined, undefined, fakeCtx(cwd));
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toContain('pi-video-gen.customProviders.proxy.apiKey');
     expect(result.content[0]!.text).not.toContain('pi-video-gen.providers.kling.apiKey');
@@ -314,15 +433,16 @@ describe('pi-video-gen extension', () => {
       }),
     );
     try {
-      const result = await tools
-        .get('video_generate')!
-        .execute(
-          'c1',
-          { prompt: 'waves', firstFrame: framePath },
-          undefined,
-          undefined,
-          fakeCtx(cwd),
-        );
+      const result = await tools.get('video_generate')!.execute(
+        'c1',
+        {
+          prompt: { visuals: 'static wide shot', action: 'waves rolling' },
+          firstFrame: framePath,
+        },
+        undefined,
+        undefined,
+        fakeCtx(cwd),
+      );
       expect(result.isError).toBeUndefined();
       const submit = seen[0]!.body!;
       const content = submit.content as { type: string; role?: string }[];
@@ -374,15 +494,16 @@ describe('pi-video-gen extension', () => {
       }),
     );
     try {
-      const result = await tools
-        .get('video_generate')!
-        .execute(
-          'c1',
-          { prompt: 'waves', firstFrame: 'frame.png' },
-          undefined,
-          undefined,
-          fakeCtx(cwd),
-        );
+      const result = await tools.get('video_generate')!.execute(
+        'c1',
+        {
+          prompt: { visuals: 'static wide shot', action: 'waves rolling' },
+          firstFrame: 'frame.png',
+        },
+        undefined,
+        undefined,
+        fakeCtx(cwd),
+      );
       expect(result.isError).toBeUndefined(); // would fail with unreadable image if not resolved
       expect((submitted!.content as { role?: string }[])[1]?.role).toBe('first_frame');
     } finally {
@@ -420,7 +541,7 @@ describe('pi-video-gen extension', () => {
 
     const result = await tools
       .get('video_generate')!
-      .execute('c1', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+      .execute('c1', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toMatch(/Restore the previous settings/);
     expect(result.content[0]!.text).toContain('https://old-endpoint.example/v3');
@@ -454,9 +575,26 @@ describe('pi-video-gen extension', () => {
 
     const result = await tools
       .get('video_generate')!
-      .execute('c1', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+      .execute('c1', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toMatch(/before task-identity freezing/);
+  });
+
+  it('resume accepts a call carrying only jobId (no prompt)', async () => {
+    mkdirSync(join(home, '.pi', 'agent'), { recursive: true });
+    writeFileSync(
+      join(home, '.pi', 'agent', 'settings.json'),
+      JSON.stringify({ 'pi-video-gen': { providers: { ark: { apiKey: 'k' } } } }),
+    );
+    await startSession(cwd);
+
+    // No manifest on disk — reaching the "no resumable job" error proves the
+    // prompt-less call passed structured-prompt validation into the resume path.
+    const result = await tools
+      .get('video_generate')!
+      .execute('c1', { jobId: 'gen-nonexistent' }, undefined, undefined, fakeCtx(cwd));
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/No resumable job found/);
   });
 
   it('single-job resume refuses a job symlink that escapes the output directory', async () => {
@@ -489,7 +627,7 @@ describe('pi-video-gen extension', () => {
     ac.abort();
     const result = await tools
       .get('video_generate')!
-      .execute('c1', { prompt: 'waves', jobId }, ac.signal, undefined, fakeCtx(cwd));
+      .execute('c1', { ...VALID_GENERATE_PARAMS, jobId }, ac.signal, undefined, fakeCtx(cwd));
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toMatch(/outside|refus/i);
     expect(JSON.parse(readFileSync(join(outside, 'manifest.json'), 'utf-8'))).toEqual(original);
@@ -526,7 +664,9 @@ describe('pi-video-gen extension', () => {
     mkdirSync(jobDir, { recursive: true });
     writeFileSync(
       join(jobDir, 'render-input.json'),
-      JSON.stringify({ shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }] }),
+      JSON.stringify({
+        shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
+      }),
     );
 
     vi.stubGlobal(
@@ -638,7 +778,13 @@ describe('pi-video-gen extension', () => {
     await startSession(cwd);
     const result = await tools
       .get('video_generate')!
-      .execute('c1', { prompt: 'waves', durationSec: 4.5 }, undefined, undefined, fakeCtx(cwd));
+      .execute(
+        'c1',
+        { ...VALID_GENERATE_PARAMS, durationSec: 4.5 },
+        undefined,
+        undefined,
+        fakeCtx(cwd),
+      );
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toMatch(/whole number of seconds|integer number/);
   });
@@ -682,7 +828,13 @@ describe('pi-video-gen extension', () => {
     try {
       const result = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves', firstFrame: frame }, undefined, undefined, fakeCtx(cwd));
+        .execute(
+          'c1',
+          { prompt: { visuals: 'static wide shot', action: 'waves rolling' }, firstFrame: frame },
+          undefined,
+          undefined,
+          fakeCtx(cwd),
+        );
       expect(result.isError).toBeUndefined();
 
       // find the job dir created under .video-gen/single/
@@ -710,7 +862,7 @@ describe('pi-video-gen extension', () => {
       writeFileSync(snap, 'tampered');
       const resume = await tools
         .get('video_generate')!
-        .execute('c2', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+        .execute('c2', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
       expect(resume.isError).toBe(true);
       expect(resume.content[0]!.text).toMatch(/no longer trustworthy/);
     } finally {
@@ -738,7 +890,7 @@ describe('pi-video-gen extension', () => {
     );
     const first = await tools
       .get('video_generate')!
-      .execute('c1', { prompt: 'waves' }, interrupted.signal, undefined, fakeCtx(cwd));
+      .execute('c1', VALID_GENERATE_PARAMS, interrupted.signal, undefined, fakeCtx(cwd));
     const jobId = String(first.details?.jobId);
     const inputPath = join(cwd, '.video-gen', 'single', jobId, 'input.json');
     const input = JSON.parse(readFileSync(inputPath, 'utf-8'));
@@ -758,7 +910,7 @@ describe('pi-video-gen extension', () => {
     try {
       const resumed = await tools
         .get('video_generate')!
-        .execute('c2', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+        .execute('c2', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
 
       expect(resumed.isError).toBe(true);
       expect(resumed.content[0]!.text).toMatch(/frozen input|request identity/i);
@@ -806,7 +958,7 @@ describe('pi-video-gen extension', () => {
     try {
       const result = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+        .execute('c1', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
       expect(result.isError).toBeUndefined();
       expect(result.content[0]!.text).toContain('already rendered');
     } finally {
@@ -830,7 +982,7 @@ describe('pi-video-gen extension', () => {
     );
     const failed = await tools
       .get('video_generate')!
-      .execute('c2', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+      .execute('c2', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
     expect(failed.isError).toBe(true);
     expect(failed.content[0]!.text).toMatch(/failed permanently/);
   });
@@ -863,7 +1015,7 @@ describe('pi-video-gen extension', () => {
     try {
       const first = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves' }, undefined, undefined, fakeCtx(cwd));
+        .execute('c1', VALID_GENERATE_PARAMS, undefined, undefined, fakeCtx(cwd));
       expect(first.isError).toBe(true);
       const jobId = String(first.details?.jobId);
       const manifestPath = join(cwd, '.video-gen', 'single', jobId, 'manifest.json');
@@ -874,7 +1026,7 @@ describe('pi-video-gen extension', () => {
 
       const resumed = await tools
         .get('video_generate')!
-        .execute('c2', { prompt: 'waves', jobId }, undefined, undefined, fakeCtx(cwd));
+        .execute('c2', { ...VALID_GENERATE_PARAMS, jobId }, undefined, undefined, fakeCtx(cwd));
       expect(resumed.isError).toBeUndefined();
       expect(resumed.content[0]!.text).toContain('Video clip ready');
     } finally {
@@ -900,7 +1052,7 @@ describe('pi-video-gen extension', () => {
     try {
       const result = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves' }, undefined, undefined, fakeCtx(cwd));
+        .execute('c1', VALID_GENERATE_PARAMS, undefined, undefined, fakeCtx(cwd));
       const jobId = String(result.details?.jobId);
       const manifest = JSON.parse(
         readFileSync(join(cwd, '.video-gen', 'single', jobId, 'manifest.json'), 'utf-8'),
@@ -942,7 +1094,7 @@ describe('pi-video-gen extension', () => {
     try {
       const result = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves' }, undefined, undefined, fakeCtx(cwd));
+        .execute('c1', VALID_GENERATE_PARAMS, undefined, undefined, fakeCtx(cwd));
       expect(Buffer.byteLength(JSON.stringify(result.details))).toBeLessThanOrEqual(2 * 1024);
       expect(result.details).toEqual({ truncated: true });
     } finally {
@@ -979,7 +1131,7 @@ describe('pi-video-gen extension', () => {
     try {
       const result = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves' }, controller.signal, undefined, fakeCtx(cwd));
+        .execute('c1', VALID_GENERATE_PARAMS, controller.signal, undefined, fakeCtx(cwd));
       expect(result.isError).toBe(true);
       expect(result.content[0]!.text).toContain('was cancelled');
       expect(cancelSignal?.aborted).toBe(false);
@@ -1016,7 +1168,7 @@ describe('pi-video-gen extension', () => {
     try {
       const result = await tools
         .get('video_generate')!
-        .execute('c1', { prompt: 'waves' }, undefined, undefined, fakeCtx(cwd));
+        .execute('c1', VALID_GENERATE_PARAMS, undefined, undefined, fakeCtx(cwd));
       const surface = `${result.content[0]!.text}\n${stderr.mock.calls.flat().join('\n')}`;
       expect(surface).not.toContain('secret-prompt');
       expect(surface).not.toContain('token=abc');
@@ -1185,8 +1337,8 @@ describe('pi-video-gen extension', () => {
       specPath,
       JSON.stringify({
         shots: [
-          { id: 's1', videoPrompt: 'one', firstFramePath: f1 },
-          { id: 's2', videoPrompt: 'two', firstFramePath: f2 },
+          { id: 's1', prompt: { visuals: 'v1', action: 'one' }, firstFramePath: f1 },
+          { id: 's2', prompt: { visuals: 'v2', action: 'two' }, firstFramePath: f2 },
         ],
       }),
     );

--- a/packages/pi-video-gen/src/__tests__/extension.test.ts
+++ b/packages/pi-video-gen/src/__tests__/extension.test.ts
@@ -280,6 +280,32 @@ describe('pi-video-gen extension', () => {
     expect(notifiedText(ctx2)).toMatch(/--duration must be an integer/);
   });
 
+  it('/video-gen generate rejects an unterminated quoted value before any submit', async () => {
+    const ctx = fakeCtx(cwd);
+    await commands.get('video-gen')!.handler('generate --visuals "wide --action waves', ctx);
+    expect(notifiedText(ctx)).toMatch(/Unterminated quoted value/);
+  });
+
+  it('video_generate rejects an empty-string aspectRatio instead of fingerprinting it', async () => {
+    mkdirSync(join(home, '.pi', 'agent'), { recursive: true });
+    writeFileSync(
+      join(home, '.pi', 'agent', 'settings.json'),
+      JSON.stringify({ 'pi-video-gen': { providers: { ark: { apiKey: 'k' } } } }),
+    );
+    await startSession(cwd);
+    const result = await tools
+      .get('video_generate')!
+      .execute(
+        'c1',
+        { ...VALID_GENERATE_PARAMS, aspectRatio: '' },
+        undefined,
+        undefined,
+        fakeCtx(cwd),
+      );
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toMatch(/aspectRatio must be a non-empty string/);
+  });
+
   it('/video-gen generate surfaces structured-prompt validation errors', async () => {
     mkdirSync(join(home, '.pi', 'agent'), { recursive: true });
     writeFileSync(

--- a/packages/pi-video-gen/src/__tests__/prompt.test.ts
+++ b/packages/pi-video-gen/src/__tests__/prompt.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import { assemblePrompt, validateFilmPrompt, validateShotPrompt } from '../prompt.js';
+
+describe('assemblePrompt', () => {
+  it('assembles all sections in the fixed labeled order', () => {
+    const text = assemblePrompt(
+      {
+        style: 'cinematic, 8K, film grain',
+        characters: [
+          { id: 'alice', description: 'long blonde hair, red scarf' },
+          { id: 'bob', description: 'tall, black coat' },
+        ],
+        consistency: 'Faces and outfits stay identical, no morphing.',
+        negative: 'no text, watermarks, or subtitles',
+      },
+      {
+        scene: 'rainy alley at night',
+        visuals: 'Slow push-in, medium close-up',
+        action: 'Alice walks in from the left',
+        effects: 'rain picks up, neon reflections intensify',
+        audio: '[Sound Effect] rain, distant traffic',
+        visibleCharacters: ['alice'],
+      },
+    );
+    expect(text).toBe(
+      [
+        '[Style] cinematic, 8K, film grain',
+        '[Character] alice: long blonde hair, red scarf',
+        '[Scene] rainy alley at night',
+        '[Visuals] Slow push-in, medium close-up',
+        '[Action] Alice walks in from the left',
+        '[Effects] rain picks up, neon reflections intensify',
+        '[Audio] [Sound Effect] rain, distant traffic',
+        'Faces and outfits stay identical, no morphing.',
+        'Negative: no text, watermarks, or subtitles',
+      ].join('\n'),
+    );
+  });
+
+  it('omits absent optional sections and non-visible characters', () => {
+    const text = assemblePrompt(
+      {
+        style: 'cinematic',
+        characters: [{ id: 'bob', description: 'tall, black coat' }],
+      },
+      { visuals: 'static wide', action: 'waves rolling' },
+    );
+    expect(text).toBe('[Style] cinematic\n[Visuals] static wide\n[Action] waves rolling');
+  });
+
+  it('skips visibleCharacters ids missing from the registry (validation rejects them earlier)', () => {
+    const text = assemblePrompt(
+      { characters: [{ id: 'alice', description: 'red scarf' }] },
+      { visuals: 'v', action: 'a', visibleCharacters: ['ghost'] },
+    );
+    expect(text).toBe('[Visuals] v\n[Action] a');
+  });
+});
+
+describe('validateShotPrompt', () => {
+  const film = { style: 'cinematic', characters: [{ id: 'alice', description: 'red scarf' }] };
+
+  it('requires visuals and action', () => {
+    expect(
+      validateShotPrompt(film, { visuals: '', action: 'a' }, { hasFirstFrame: true }, 'prompt'),
+    ).toMatch(/visuals is required/);
+    expect(
+      validateShotPrompt(film, { visuals: 'v', action: '  ' }, { hasFirstFrame: true }, 'prompt'),
+    ).toMatch(/action is required/);
+  });
+
+  it('rejects a non-object prompt', () => {
+    expect(
+      validateShotPrompt(film, 'freeform' as never, { hasFirstFrame: true }, 'prompt'),
+    ).toMatch(/must be an object/);
+  });
+
+  it('requires style and scene when no first frame anchors the shot', () => {
+    expect(
+      validateShotPrompt(
+        { characters: film.characters },
+        { visuals: 'v', action: 'a', scene: 's' },
+        { hasFirstFrame: false },
+        'prompt',
+      ),
+    ).toMatch(/style.*required for text-to-video/);
+    expect(
+      validateShotPrompt(
+        film,
+        { visuals: 'v', action: 'a' },
+        { hasFirstFrame: false },
+        'shots[0].prompt',
+      ),
+    ).toMatch(/scene is required when no first frame/);
+  });
+
+  it('accepts a frame-anchored shot without style/scene', () => {
+    expect(
+      validateShotPrompt({}, { visuals: 'v', action: 'a' }, { hasFirstFrame: true }, 'prompt'),
+    ).toBeNull();
+  });
+
+  it('rejects visibleCharacters ids missing from the film registry', () => {
+    expect(
+      validateShotPrompt(
+        film,
+        { visuals: 'v', action: 'a', visibleCharacters: ['bob'] },
+        { hasFirstFrame: true },
+        'prompt',
+      ),
+    ).toMatch(/unknown character "bob"/);
+  });
+
+  it('rejects non-string optional fields instead of serializing them into the prompt', () => {
+    expect(
+      validateShotPrompt(
+        film,
+        { visuals: 'v', action: 'a', effects: { kind: 'rain' } as never },
+        { hasFirstFrame: true },
+        'prompt',
+      ),
+    ).toMatch(/\.effects must be a string/);
+    expect(
+      validateShotPrompt(
+        film,
+        { visuals: 'v', action: 'a', audio: 42 as never },
+        { hasFirstFrame: true },
+        'prompt',
+      ),
+    ).toMatch(/\.audio must be a string/);
+    expect(
+      validateShotPrompt(
+        film,
+        { visuals: 'v', action: 'a', scene: ['x'] as never },
+        { hasFirstFrame: true },
+        'prompt',
+      ),
+    ).toMatch(/\.scene must be a string/);
+  });
+
+  it('rejects a malformed visibleCharacters array', () => {
+    expect(
+      validateShotPrompt(
+        film,
+        { visuals: 'v', action: 'a', visibleCharacters: 'alice' as never },
+        { hasFirstFrame: true },
+        'prompt',
+      ),
+    ).toMatch(/visibleCharacters must be an array/);
+    expect(
+      validateShotPrompt(
+        film,
+        { visuals: 'v', action: 'a', visibleCharacters: [42] as never },
+        { hasFirstFrame: true },
+        'prompt',
+      ),
+    ).toMatch(/visibleCharacters must be an array/);
+  });
+});
+
+describe('validateFilmPrompt', () => {
+  it('accepts an absent registry', () => {
+    expect(validateFilmPrompt({}, 'render-input.json')).toBeNull();
+  });
+
+  it('rejects malformed entries and duplicate ids', () => {
+    expect(validateFilmPrompt({ characters: 'nope' as never }, 'render-input.json')).toMatch(
+      /must be an array/,
+    );
+    expect(
+      validateFilmPrompt({ characters: [{ id: '', description: 'd' }] }, 'render-input.json'),
+    ).toMatch(/non-empty "id"/);
+    expect(
+      validateFilmPrompt({ characters: [{ id: 'a', description: ' ' }] }, 'render-input.json'),
+    ).toMatch(/non-empty "description"/);
+    expect(
+      validateFilmPrompt(
+        {
+          characters: [
+            { id: 'a', description: 'd1' },
+            { id: 'a', description: 'd2' },
+          ],
+        },
+        'render-input.json',
+      ),
+    ).toMatch(/duplicates character id "a"/);
+  });
+
+  it('rejects non-string film-level scalar fields', () => {
+    expect(validateFilmPrompt({ style: 8 as never }, 'render-input.json')).toMatch(
+      /\.style must be a string/,
+    );
+    expect(validateFilmPrompt({ consistency: {} as never }, 'render-input.json')).toMatch(
+      /\.consistency must be a string/,
+    );
+    expect(validateFilmPrompt({ negative: ['x'] as never }, 'render-input.json')).toMatch(
+      /\.negative must be a string/,
+    );
+  });
+});

--- a/packages/pi-video-gen/src/__tests__/render.test.ts
+++ b/packages/pi-video-gen/src/__tests__/render.test.ts
@@ -126,7 +126,14 @@ describe('runRender', () => {
     const frame = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
       jobId: 'job-x',
-      shots: [{ id: 's1', videoPrompt: 'motion', firstFramePath: frame, durationSec }],
+      shots: [
+        {
+          id: 's1',
+          prompt: { visuals: 'v', action: 'motion' },
+          firstFramePath: frame,
+          durationSec,
+        },
+      ],
     } as unknown as RenderInput);
 
     await expect(
@@ -138,14 +145,178 @@ describe('runRender', () => {
     expect(calls.submit).toBe(0);
   });
 
+  it('rejects a shot prompt missing required fields before any paid submit', async () => {
+    const frame = makeFrame(cwd, 'a.png');
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { action: 'm1' }, firstFramePath: frame }],
+    } as unknown as RenderInput);
+
+    await expect(
+      runRender({
+        renderSpecPath: join(jobDir, 'render-input.json'),
+        ...baseOpts(cwd, mockAdapter(calls), concatCalls),
+      }),
+    ).rejects.toThrow(/\.prompt\.visuals is required/);
+    expect(calls.submit).toBe(0);
+  });
+
+  it('rejects a non-string shot id instead of coercing it', async () => {
+    const frame = makeFrame(cwd, 'a.png');
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 42, prompt: { visuals: 'v', action: 'm1' }, firstFramePath: frame }],
+    } as unknown as RenderInput);
+    await expect(
+      runRender({
+        renderSpecPath: join(jobDir, 'render-input.json'),
+        ...baseOpts(cwd, mockAdapter(calls), concatCalls),
+      }),
+    ).rejects.toThrow(/id must be a non-empty string/);
+    expect(calls.submit).toBe(0);
+  });
+
+  it('rejects a non-string aspectRatio instead of letting it reach the fingerprint', async () => {
+    const frame = makeFrame(cwd, 'a.png');
+    const jobDir = makeJob(cwd, {
+      aspectRatio: 0,
+      shots: [{ id: 's1', prompt: { visuals: 'v', action: 'm1' }, firstFramePath: frame }],
+    } as unknown as RenderInput);
+    await expect(
+      runRender({
+        renderSpecPath: join(jobDir, 'render-input.json'),
+        ...baseOpts(cwd, mockAdapter(calls), concatCalls),
+      }),
+    ).rejects.toThrow(/aspectRatio must be a non-empty string/);
+    expect(calls.submit).toBe(0);
+  });
+
+  it('rejects a non-string lastFramePath before path operations', async () => {
+    const frame = makeFrame(cwd, 'a.png');
+    const jobDir = makeJob(cwd, {
+      shots: [
+        {
+          id: 's1',
+          prompt: { visuals: 'v', action: 'm1' },
+          firstFramePath: frame,
+          lastFramePath: 42,
+        },
+      ],
+    } as unknown as RenderInput);
+    await expect(
+      runRender({
+        renderSpecPath: join(jobDir, 'render-input.json'),
+        ...baseOpts(cwd, mockAdapter(calls), concatCalls),
+      }),
+    ).rejects.toThrow(/lastFramePath must be a path string/);
+    expect(calls.submit).toBe(0);
+  });
+
+  it('rejects a visibleCharacters reference missing from the film registry', async () => {
+    const frame = makeFrame(cwd, 'a.png');
+    const jobDir = makeJob(cwd, {
+      characters: [{ id: 'alice', description: 'red scarf' }],
+      shots: [
+        {
+          id: 's1',
+          prompt: { visuals: 'v', action: 'm1', visibleCharacters: ['bob'] },
+          firstFramePath: frame,
+        },
+      ],
+    });
+
+    await expect(
+      runRender({
+        renderSpecPath: join(jobDir, 'render-input.json'),
+        ...baseOpts(cwd, mockAdapter(calls), concatCalls),
+      }),
+    ).rejects.toThrow(/unknown character "bob"/);
+    expect(calls.submit).toBe(0);
+  });
+
+  it('rejects duplicate film-level character ids', async () => {
+    const frame = makeFrame(cwd, 'a.png');
+    const jobDir = makeJob(cwd, {
+      characters: [
+        { id: 'alice', description: 'd1' },
+        { id: 'alice', description: 'd2' },
+      ],
+      shots: [{ id: 's1', prompt: { visuals: 'v', action: 'm1' }, firstFramePath: frame }],
+    });
+
+    await expect(
+      runRender({
+        renderSpecPath: join(jobDir, 'render-input.json'),
+        ...baseOpts(cwd, mockAdapter(calls), concatCalls),
+      }),
+    ).rejects.toThrow(/duplicates character id "alice"/);
+    expect(calls.submit).toBe(0);
+  });
+
+  it('submits the assembled labeled prompt carrying film-level directives', async () => {
+    const frame = makeFrame(cwd, 'a.png');
+    const jobDir = makeJob(cwd, {
+      style: 'cinematic, 8K',
+      characters: [
+        { id: 'alice', description: 'long blonde hair, red scarf' },
+        { id: 'bob', description: 'tall, black coat' },
+      ],
+      consistency: 'Faces stay identical, no morphing.',
+      negative: 'no text or watermarks',
+      shots: [
+        {
+          id: 's1',
+          prompt: {
+            scene: 'rainy alley',
+            visuals: 'slow push-in',
+            action: 'Alice walks in',
+            effects: 'rain intensifies',
+            audio: '[Sound Effect] rain',
+            visibleCharacters: ['alice'],
+          },
+          firstFramePath: frame,
+          durationSec: 5,
+        },
+      ],
+    });
+
+    await runRender({
+      renderSpecPath: join(jobDir, 'render-input.json'),
+      ...baseOpts(cwd, mockAdapter(calls), concatCalls),
+    });
+
+    expect(calls.submit).toBe(1);
+    expect(calls.params[0]!.prompt).toBe(
+      [
+        '[Style] cinematic, 8K',
+        '[Character] alice: long blonde hair, red scarf',
+        '[Scene] rainy alley',
+        '[Visuals] slow push-in',
+        '[Action] Alice walks in',
+        '[Effects] rain intensifies',
+        '[Audio] [Sound Effect] rain',
+        'Faces stay identical, no morphing.',
+        'Negative: no text or watermarks',
+      ].join('\n'),
+    );
+  });
+
   it('runs a fresh job end-to-end: snapshot → submit → download → concat', async () => {
     const f1 = makeFrame(cwd, 'a.png');
     const f2 = makeFrame(cwd, 'b.png');
     const jobDir = makeJob(cwd, {
       title: 't',
       shots: [
-        { id: 's1', videoPrompt: 'motion one', firstFramePath: f1, durationSec: 5 },
-        { id: 's2', videoPrompt: 'motion two', firstFramePath: f2, durationSec: 5 },
+        {
+          id: 's1',
+          prompt: { visuals: 'v1', action: 'motion one' },
+          firstFramePath: f1,
+          durationSec: 5,
+        },
+        {
+          id: 's2',
+          prompt: { visuals: 'v2', action: 'motion two' },
+          firstFramePath: f2,
+          durationSec: 5,
+        },
       ],
     });
 
@@ -181,8 +352,8 @@ describe('runRender', () => {
     const f2 = makeFrame(cwd, 'b.png');
     const jobDir = makeJob(cwd, {
       shots: [
-        { id: 's1', videoPrompt: 'm1', firstFramePath: f1 },
-        { id: 's2', videoPrompt: 'm2', firstFramePath: f2 },
+        { id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 },
+        { id: 's2', prompt: { visuals: 'v2', action: 'm2' }, firstFramePath: f2 },
       ],
     });
     const specPath = join(jobDir, 'render-input.json');
@@ -216,7 +387,7 @@ describe('runRender', () => {
   it('refuses resume when normalized model defaults changed', async () => {
     const frame = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }],
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
     });
     const specPath = join(jobDir, 'render-input.json');
     const resolved = baseResolved();
@@ -241,7 +412,9 @@ describe('runRender', () => {
 
   it('merges assets.json instead of wiping image-stage entries', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     // image stage pre-registered a portrait
     writeFileSync(
       join(jobDir, 'assets.json'),
@@ -258,7 +431,9 @@ describe('runRender', () => {
 
   it('refuses a manifest missing a spec shot instead of re-submitting it', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const specPath = join(jobDir, 'render-input.json');
     await runRender({
       renderSpecPath: specPath,
@@ -285,7 +460,14 @@ describe('runRender', () => {
     const first = makeFrame(cwd, 'first.png');
     const last = makeFrame(cwd, 'last.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: first, lastFramePath: last }],
+      shots: [
+        {
+          id: 's1',
+          prompt: { visuals: 'v1', action: 'm1' },
+          firstFramePath: first,
+          lastFramePath: last,
+        },
+      ],
     });
     const specPath = join(jobDir, 'render-input.json');
     await runRender({
@@ -310,7 +492,9 @@ describe('runRender', () => {
 
   it('refuses a corrupted manifest instead of re-billing everything', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     writeFileSync(join(jobDir, 'manifest.json'), '{not json');
     await expect(
       runRender({
@@ -327,7 +511,9 @@ describe('runRender', () => {
     mkdirSync(outside, { recursive: true });
     writeFileSync(
       join(outside, 'render-input.json'),
-      JSON.stringify({ shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] }),
+      JSON.stringify({
+        shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+      }),
     );
     const linkDir = join(cwd, '.video-gen', 'linked-job');
     mkdirSync(join(cwd, '.video-gen'), { recursive: true });
@@ -344,7 +530,9 @@ describe('runRender', () => {
 
   it('refuses a pre-placed destination symlink for a frame snapshot', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const outside = join(cwd, 'victim.txt');
     writeFileSync(outside, 'precious');
     const shotDir = join(jobDir, 'shots', 's1');
@@ -364,7 +552,9 @@ describe('runRender', () => {
 
   it('manifest frame hashes match the SNAPSHOT bytes', async () => {
     const f1 = makeFrame(cwd, 'a.png', 'frame-v1');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     await runRender({
       renderSpecPath: join(jobDir, 'render-input.json'),
       ...baseOpts(cwd, mockAdapter(calls), concatCalls),
@@ -378,7 +568,9 @@ describe('runRender', () => {
 
   it('concat cancel ⇒ polling_stopped; concat error ⇒ failed', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const opts = baseOpts(cwd, mockAdapter(calls), concatCalls);
     opts.concatImpl = (async () => {
       const { CancelledError } = await import('../providers/task.js');
@@ -394,7 +586,9 @@ describe('runRender', () => {
     mkdirSync(jobDir2, { recursive: true });
     writeFileSync(
       join(jobDir2, 'render-input.json'),
-      JSON.stringify({ shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] }),
+      JSON.stringify({
+        shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+      }),
     );
     const opts2 = baseOpts(cwd, mockAdapter(calls), concatCalls);
     opts2.concatImpl = (async () => {
@@ -414,7 +608,9 @@ describe('runRender', () => {
     mkdirSync(jobDir, { recursive: true });
     writeFileSync(
       join(jobDir, 'render-input.json'),
-      JSON.stringify({ shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] }),
+      JSON.stringify({
+        shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+      }),
     );
     const aliasOut = join(cwd, 'alias-out');
     const { symlinkSync, realpathSync } = await import('node:fs');
@@ -432,7 +628,9 @@ describe('runRender', () => {
 
   it('refuses resume when a shot dir was swapped for an external symlink', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const specPath = join(jobDir, 'render-input.json');
     await runRender({
       renderSpecPath: specPath,
@@ -455,7 +653,9 @@ describe('runRender', () => {
 
   it('corrupted assets.json refuses rather than truncating the image-stage index', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     writeFileSync(join(jobDir, 'assets.json'), '{corrupted');
     await expect(
       runRender({
@@ -469,7 +669,9 @@ describe('runRender', () => {
 
   it('ambiguous submit parks the shot and blocks automatic resubmit', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const specPath = join(jobDir, 'render-input.json');
 
     const ambiguousAdapter: VideoProviderAdapter = {
@@ -515,7 +717,7 @@ describe('runRender', () => {
   it('persists ambiguous before entering the paid submit call', async () => {
     const frame = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }],
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
     });
     let stateAtSubmit = '';
     const adapter: VideoProviderAdapter = {
@@ -543,7 +745,7 @@ describe('runRender', () => {
   it('retries a definitively failed provider task in the same job', async () => {
     const frame = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }],
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
     });
     let submits = 0;
     const requestIds: Array<string | undefined> = [];
@@ -582,7 +784,7 @@ describe('runRender', () => {
   it('resumes a legacy submitted shot without persisting attempt zero', async () => {
     const frame = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }],
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
     });
     let cancelled = false;
     const adapter: VideoProviderAdapter = {
@@ -621,7 +823,7 @@ describe('runRender', () => {
   it('calls provider cancellation with a fresh signal before parking remaining work', async () => {
     const frame = makeFrame(cwd, 'cancel.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'stop', firstFramePath: frame }],
+      shots: [{ id: 's1', prompt: { visuals: 'v', action: 'stop' }, firstFramePath: frame }],
     });
     let cancelSignal: AbortSignal | undefined;
     const adapter: VideoProviderAdapter = {
@@ -661,7 +863,7 @@ describe('runRender', () => {
   it('parks a provider-missing task for explicit recover instead of looping forever', async () => {
     const frame = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }],
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
     });
     let submits = 0;
     const adapter: VideoProviderAdapter = {
@@ -698,7 +900,7 @@ describe('runRender', () => {
   it('validates the shots parent before creating a shot directory', async () => {
     const frame = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }],
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
     });
     const outside = join(cwd, 'outside-shots');
     mkdirSync(outside, { recursive: true });
@@ -719,7 +921,7 @@ describe('runRender', () => {
       const caseCwd = join(cwd, `assets-${i}`);
       const f1 = makeFrame(caseCwd, 'a.png');
       const jobDir = makeJob(caseCwd, {
-        shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }],
+        shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
       });
       const raw = JSON.stringify(invalid);
       writeFileSync(join(jobDir, 'assets.json'), raw);
@@ -736,7 +938,9 @@ describe('runRender', () => {
 
   it('refuses resume when the spec changed (revision ⇒ new job)', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const specPath = join(jobDir, 'render-input.json');
     await runRender({
       renderSpecPath: specPath,
@@ -745,7 +949,9 @@ describe('runRender', () => {
 
     writeFileSync(
       specPath,
-      JSON.stringify({ shots: [{ id: 's1', videoPrompt: 'CHANGED', firstFramePath: f1 }] }),
+      JSON.stringify({
+        shots: [{ id: 's1', prompt: { visuals: 'v', action: 'CHANGED' }, firstFramePath: f1 }],
+      }),
     );
     await expect(
       runRender({ renderSpecPath: specPath, ...baseOpts(cwd, mockAdapter(calls), concatCalls) }),
@@ -754,7 +960,9 @@ describe('runRender', () => {
 
   it('refuses resume when a frame snapshot was tampered with', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const specPath = join(jobDir, 'render-input.json');
     await runRender({
       renderSpecPath: specPath,
@@ -771,7 +979,14 @@ describe('runRender', () => {
     const f1 = makeFrame(cwd, 'a.png');
     const f2 = makeFrame(cwd, 'b.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1, lastFramePath: f2 }],
+      shots: [
+        {
+          id: 's1',
+          prompt: { visuals: 'v1', action: 'm1' },
+          firstFramePath: f1,
+          lastFramePath: f2,
+        },
+      ],
     });
     const specPath = join(jobDir, 'render-input.json');
 
@@ -796,8 +1011,8 @@ describe('runRender', () => {
     // duplicate ids
     const dupDir = makeJob(cwd, {
       shots: [
-        { id: 's1', videoPrompt: 'a', firstFramePath: f1 },
-        { id: 's1', videoPrompt: 'b', firstFramePath: f1 },
+        { id: 's1', prompt: { visuals: 'v', action: 'a' }, firstFramePath: f1 },
+        { id: 's1', prompt: { visuals: 'v', action: 'b' }, firstFramePath: f1 },
       ],
     });
     await expect(
@@ -812,7 +1027,9 @@ describe('runRender', () => {
     mkdirSync(outside, { recursive: true });
     writeFileSync(
       join(outside, 'render-input.json'),
-      JSON.stringify({ shots: [{ id: 's1', videoPrompt: 'a', firstFramePath: f1 }] }),
+      JSON.stringify({
+        shots: [{ id: 's1', prompt: { visuals: 'v', action: 'a' }, firstFramePath: f1 }],
+      }),
     );
     await expect(
       runRender({
@@ -822,7 +1039,9 @@ describe('runRender', () => {
     ).rejects.toThrow(/must live under/);
 
     // wrong spec filename
-    const bad = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'a', firstFramePath: f1 }] });
+    const bad = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v', action: 'a' }, firstFramePath: f1 }],
+    });
     const { renameSync } = await import('node:fs');
     renameSync(join(bad, 'render-input.json'), join(bad, 'spec.json'));
     await expect(
@@ -838,7 +1057,9 @@ describe('runRender', () => {
   it('rejects non-integer shot durations before anything paid', async () => {
     const f1 = makeFrame(cwd, 'a.png');
     const jobDir = makeJob(cwd, {
-      shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1, durationSec: 4.5 }],
+      shots: [
+        { id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1, durationSec: 4.5 },
+      ],
     });
     await expect(
       runRender({
@@ -851,7 +1072,9 @@ describe('runRender', () => {
 
   it('rejects concurrent runs of the same job dir', async () => {
     const f1 = makeFrame(cwd, 'a.png');
-    const jobDir = makeJob(cwd, { shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: f1 }] });
+    const jobDir = makeJob(cwd, {
+      shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: f1 }],
+    });
     const opts = baseOpts(cwd, mockAdapter(calls), concatCalls);
     // Hold the job dir's active slot on its REAL path (the lock's key) —
     // /tmp on macOS is itself a symlink, so lexical ≠ real here.

--- a/packages/pi-video-gen/src/__tests__/snapshot-hash.test.ts
+++ b/packages/pi-video-gen/src/__tests__/snapshot-hash.test.ts
@@ -56,7 +56,9 @@ describe('snapshot hash is of the SNAPSHOT bytes (not a pre-copy source read)', 
     );
     writeFileSync(
       join(jobDir, 'render-input.json'),
-      JSON.stringify({ shots: [{ id: 's1', videoPrompt: 'm1', firstFramePath: frame }] }),
+      JSON.stringify({
+        shots: [{ id: 's1', prompt: { visuals: 'v1', action: 'm1' }, firstFramePath: frame }],
+      }),
     );
 
     const adapter: VideoProviderAdapter = {

--- a/packages/pi-video-gen/src/index.ts
+++ b/packages/pi-video-gen/src/index.ts
@@ -45,6 +45,7 @@ import {
   singleJobDir,
   writeJsonAtomic,
 } from './jobs/store.js';
+import { assemblePrompt, validateFilmPrompt, validateShotPrompt } from './prompt.js';
 import { arkAdapter } from './providers/ark.js';
 import { dashscopeAdapter } from './providers/dashscope.js';
 import { klingAdapter } from './providers/kling.js';
@@ -57,9 +58,11 @@ import { runRender } from './render.js';
 import { hasCjkFont } from './text-layer.js';
 import { runTimeline } from './timeline-render.js';
 import type {
+  FilmPrompt,
   GenerateVideoParams,
   RemoteTaskHandle,
   ResolvedProvider,
+  ShotPrompt,
   VideoApiStyle,
   VideoGenSettings,
   VideoModelCapabilities,
@@ -118,13 +121,100 @@ function boundDetails(details: Record<string, unknown>): Record<string, unknown>
   }
 }
 
+/**
+ * Parse `--key value` / `--key "quoted value"` flags for `/video-gen generate`.
+ * Quoted values may escape their delimiter quote (and backslash) with `\`.
+ */
+function parseGenerateFlags(text: string): { flags: Record<string, string> } | { error: string } {
+  const flags: Record<string, string> = {};
+  const re = /--([a-z][a-z-]*)\s+("((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/g;
+  let covered = 0;
+  for (let m = re.exec(text); m !== null; m = re.exec(text)) {
+    const gap = text.slice(covered, m.index).trim();
+    if (gap !== '') {
+      return { error: `Unrecognized text "${gap}" — use --key "value" flags.` };
+    }
+    const quoted = m[3] ?? m[4];
+    flags[m[1]!] = quoted !== undefined ? quoted.replace(/\\(["'\\])/g, '$1') : (m[5] ?? '');
+    covered = m.index + m[0].length;
+  }
+  const tail = text.slice(covered).trim();
+  if (tail !== '') {
+    return { error: `Unrecognized text "${tail}" — use --key "value" flags.` };
+  }
+  return { flags };
+}
+
 /** Capability-driven schema for video_generate (mirrors pi-image-gen's approach). */
 function buildGenerateParams(caps: VideoModelCapabilities | null) {
   return Type.Object({
-    prompt: Type.String({
-      description:
-        'Text prompt for the clip. Describe subject, motion, and camera. When the active model has nativeAudio, append audio cues (e.g. "[Sound Effect] rain; [Speaker] Alice (soft): line").',
-    }),
+    prompt: Type.Optional(
+      Type.Object(
+        {
+          scene: Type.Optional(
+            Type.String({
+              description:
+                'Setting of the clip. REQUIRED when no firstFrame is passed (text-to-video).',
+            }),
+          ),
+          visuals: Type.String({
+            description:
+              'Camera, framing, composition (e.g. "Slow push-in from medium shot to close-up, shallow depth of field").',
+          }),
+          action: Type.String({ description: 'In-frame action/movement.' }),
+          effects: Type.Optional(
+            Type.String({
+              description:
+                'Time-varying visuals a static frame cannot carry: transformations, lighting shifts, particles, atmosphere.',
+            }),
+          ),
+          audio: Type.Optional(
+            Type.String({
+              description:
+                'Audio cues when the active model has nativeAudio (e.g. "[Sound Effect] rain; [Speaker] Alice (soft): line").',
+            }),
+          ),
+          visibleCharacters: Type.Optional(
+            Type.Array(Type.String(), {
+              description: 'Ids of characters (from the characters param) appearing in this clip.',
+            }),
+          ),
+        },
+        {
+          description:
+            'Structured per-shot prompt. Fields are assembled into labeled sections ([Scene]/[Visuals]/[Action]/[Effects]/[Audio]) — write content, not a pre-joined string. Required for a fresh generation; omit when resuming an interrupted job via jobId.',
+        },
+      ),
+    ),
+    style: Type.Optional(
+      Type.String({
+        description:
+          'Film-level look: genre, quality, render texture (e.g. "cinematic, 8K, shallow DoF, film grain"). REQUIRED when no firstFrame is passed.',
+      }),
+    ),
+    characters: Type.Optional(
+      Type.Array(
+        Type.Object({
+          id: Type.String(),
+          description: Type.String({ description: 'Appearance + outfit.' }),
+        }),
+        {
+          description:
+            'Reusable character registry; shots inline a character via prompt.visibleCharacters.',
+        },
+      ),
+    ),
+    consistency: Type.Optional(
+      Type.String({
+        description:
+          'Consistency directive appended to the prompt (e.g. "Face, hair and outfit stay identical throughout, no morphing or drift").',
+      }),
+    ),
+    negative: Type.Optional(
+      Type.String({
+        description: 'Negative directive (e.g. "no text, watermarks, or subtitles").',
+      }),
+    ),
     firstFrame: Type.Optional(
       Type.String({
         description:
@@ -216,8 +306,9 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
   };
 
   /** Tool-facing params (LLM names) — mapped explicitly to the internal shape. */
-  type GenerateToolParams = {
-    prompt: string;
+  type GenerateToolParams = FilmPrompt & {
+    /** Required for a fresh generation; unused on resume (jobId). */
+    prompt?: ShotPrompt | undefined;
     firstFrame?: string | undefined;
     lastFrame?: string | undefined;
     referenceImages?: string[] | undefined;
@@ -255,21 +346,26 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
         ).message,
       );
     }
-    // Map tool params → internal params, applying model defaults. (A raw cast
-    // here silently DROPPED firstFrame/lastFrame and defaulted resolution,
-    // duration, ratio and audio — turning paid requests into silent t2v.)
-    const params: GenerateVideoParams = {
-      prompt: toolParams.prompt,
-      firstFramePath: toolParams.firstFrame ? resolve(ctx.cwd, toolParams.firstFrame) : undefined,
-      lastFramePath: toolParams.lastFrame ? resolve(ctx.cwd, toolParams.lastFrame) : undefined,
-      referenceImagePaths: toolParams.referenceImages?.map((p) => resolve(ctx.cwd, p)),
-      durationSec: toolParams.durationSec ?? resolved.entry.defaultDurationSec,
-      aspectRatio: toolParams.aspectRatio ?? resolved.entry.defaultAspectRatio,
-      resolution: resolved.entry.defaultResolution,
-      generateAudio: caps.nativeAudio,
-    };
-
-    if (toolParams.lastFrame && !caps.supportsFirstLastFrame) {
+    // Trim-normalized once — validation, capability checks and the submit
+    // mapping must all agree on whether a frame is present.
+    const firstFrame = toolParams.firstFrame?.trim();
+    const lastFrame = toolParams.lastFrame?.trim();
+    // Structured prompt validation happens only on fresh submits — the resume
+    // path (jobId) re-polls a frozen request and never re-reads the prompt.
+    if (!toolParams.jobId) {
+      const promptError =
+        validateFilmPrompt(toolParams, 'video_generate') ??
+        validateShotPrompt(
+          toolParams,
+          toolParams.prompt,
+          { hasFirstFrame: !!firstFrame },
+          'prompt',
+        );
+      if (promptError) {
+        return errResult(promptError);
+      }
+    }
+    if (lastFrame && !caps.supportsFirstLastFrame) {
       return errResult(
         `The active model (${resolved.entry.id}) does not support last-frame interpolation. Remove lastFrame, or switch models (/video-gen models).`,
       );
@@ -295,9 +391,7 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
       );
     }
     const totalRefs =
-      (toolParams.firstFrame ? 1 : 0) +
-      (toolParams.lastFrame ? 1 : 0) +
-      (toolParams.referenceImages?.length ?? 0);
+      (firstFrame ? 1 : 0) + (lastFrame ? 1 : 0) + (toolParams.referenceImages?.length ?? 0);
     if (totalRefs > caps.maxReferenceImages) {
       return errResult(
         `Too many reference images (${totalRefs}) — ${resolved.entry.id} accepts at most ${caps.maxReferenceImages} total (frames + references).`,
@@ -410,6 +504,21 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
 
     const jobId = newJobId('gen');
     const jobDir = ensureSingleJobDir(outputDir, jobId);
+    // Map tool params → internal params, applying model defaults. (A raw cast
+    // here silently DROPPED firstFrame/lastFrame and defaulted resolution,
+    // duration, ratio and audio — turning paid requests into silent t2v.)
+    const params: GenerateVideoParams = {
+      // prompt is present here: fresh submits were validated above, and the
+      // resume branch (jobId) has already returned.
+      prompt: assemblePrompt(toolParams, toolParams.prompt!),
+      firstFramePath: firstFrame ? resolve(ctx.cwd, firstFrame) : undefined,
+      lastFramePath: lastFrame ? resolve(ctx.cwd, lastFrame) : undefined,
+      referenceImagePaths: toolParams.referenceImages?.map((p) => resolve(ctx.cwd, p)),
+      durationSec: toolParams.durationSec ?? resolved.entry.defaultDurationSec,
+      aspectRatio: toolParams.aspectRatio ?? resolved.entry.defaultAspectRatio,
+      resolution: resolved.entry.defaultResolution,
+      generateAudio: caps.nativeAudio,
+    };
     params.requestId = jobId;
     const release = activeJobs.acquire(jobDir);
     try {
@@ -756,24 +865,21 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
       name: 'video_generate',
       label: 'Generate Video Clip',
       description:
-        'Generate a single short video clip (one shot) from a text prompt, optionally anchored by first/last frame images. Paid, slow (minutes per clip). For multi-shot videos, use the video-gen skill workflow instead of calling this repeatedly.',
+        'Generate a single short video clip (one shot) from a structured prompt (style/scene/visuals/action/effects/audio), optionally anchored by first/last frame images. Paid, slow (minutes per clip). For multi-shot videos, use the video-gen skill workflow instead of calling this repeatedly.',
       parameters: buildGenerateParams(caps),
-      promptSnippet: 'Generate one short video clip (paid, minutes) via the active video model',
+      promptSnippet:
+        'Generate one short video clip (paid, minutes) from a structured prompt via the active video model',
       promptGuidelines: [
         "Before composing prompts for a video task, call video_capabilities to learn the active model's duration range, aspect ratios, audio support, and first/last-frame support — do not assume.",
+        'Fill the structured prompt fields; never a pre-joined string. visuals + action are always required; style + scene are required when no firstFrame anchors the clip; use effects for transformations or lighting shifts a static frame cannot carry.',
         'Video generation is paid and slow. State the expected clip count and duration to the user and get explicit confirmation before the first call.',
         'Only pass lastFrame when the user needs first+last-frame interpolation and the active model supports it.',
-        'If a call is interrupted, resume with the returned jobId instead of submitting a new task (avoids double billing).',
+        'If a call is interrupted, resume with the returned jobId instead of submitting a new task (avoids double billing); prompt is not needed on resume.',
         'If submit is reported as ambiguous, do not start another generation until the provider console confirms that no paid task exists.',
       ],
       async execute(_toolCallId, params, signal, onUpdate, ctx) {
         try {
-          return await runGenerate(
-            params as GenerateVideoParams & { jobId?: string },
-            ctx,
-            signal,
-            onUpdate,
-          );
+          return await runGenerate(params as GenerateToolParams, ctx, signal, onUpdate);
         } catch (error) {
           console.error(`[pi-video-gen] video_generate failed: ${toLogSummary(error)}`);
           return errResult(errorMessageForUser(error));
@@ -830,6 +936,7 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
       promptGuidelines: [
         'Call ONLY after the user explicitly confirmed rendering: frames ready, shot count and cost magnitude stated.',
         'Generate all frames first via image_generate (pi-image-gen) and record their returned absolute paths in the render spec.',
+        'render-input.json carries structured prompts: film-level style/characters/consistency/negative, per-shot prompt.{scene,visuals,action,effects,audio,visibleCharacters} — the plugin assembles the labeled prompt text; never pre-join a prompt string.',
         'The spec is immutable per job directory: rerunning the same path resumes identical input; revisions go in a NEW job directory.',
         'Interrupting stops locally only — remote tasks may keep billing; rerun the same spec path to resume after they finish.',
       ],
@@ -863,18 +970,68 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
 
   pi.registerCommand('video-gen', {
     description:
-      'pi-video-gen: /video-gen [generate <prompt>|render <spec>|compose <spec>|recover <jobId>|models|reload|doctor]',
+      'pi-video-gen: /video-gen [generate --visuals ".." --action ".." [--style .. --scene ..]|render <spec>|compose <spec>|recover <jobId>|models|reload|doctor]',
     handler: async (args: string | undefined, ctx: ExtensionContext) => {
       const tokens = (args ?? '').trim().split(/\s+/).filter(Boolean);
       const sub = tokens[0];
 
       if (sub === 'generate') {
-        const prompt = tokens.slice(1).join(' ').trim();
-        if (!prompt) {
-          ctx.ui.notify('Usage: /video-gen generate <prompt>', 'error');
+        const parsed = parseGenerateFlags((args ?? '').trim().slice('generate'.length));
+        if ('error' in parsed || Object.keys(parsed.flags).length === 0) {
+          ctx.ui.notify(
+            `${'error' in parsed ? `${parsed.error} ` : ''}Usage: /video-gen generate --visuals "..." --action "..." [--style "..."] [--scene "..."] [--effects "..."] [--audio "..."] [--consistency "..."] [--negative "..."] [--first-frame <path>] [--last-frame <path>] [--duration <sec>] [--ratio <ratio>]`,
+            'error',
+          );
           return;
         }
-        const result = await runGenerate({ prompt }, ctx, ctx.signal);
+        const f = parsed.flags;
+        const known = new Set([
+          'style',
+          'scene',
+          'visuals',
+          'action',
+          'effects',
+          'audio',
+          'consistency',
+          'negative',
+          'first-frame',
+          'last-frame',
+          'duration',
+          'ratio',
+        ]);
+        const unknown = Object.keys(f).filter((k) => !known.has(k));
+        if (unknown.length > 0) {
+          ctx.ui.notify(`Unknown flag(s): ${unknown.map((k) => `--${k}`).join(', ')}.`, 'error');
+          return;
+        }
+        const durationSec = f.duration !== undefined ? Number(f.duration) : undefined;
+        if (durationSec !== undefined && !Number.isInteger(durationSec)) {
+          ctx.ui.notify(
+            `--duration must be an integer number of seconds (got "${f.duration}").`,
+            'error',
+          );
+          return;
+        }
+        const result = await runGenerate(
+          {
+            style: f.style,
+            consistency: f.consistency,
+            negative: f.negative,
+            prompt: {
+              scene: f.scene,
+              visuals: f.visuals ?? '',
+              action: f.action ?? '',
+              effects: f.effects,
+              audio: f.audio,
+            },
+            firstFrame: f['first-frame'],
+            lastFrame: f['last-frame'],
+            durationSec,
+            aspectRatio: f.ratio,
+          },
+          ctx,
+          ctx.signal,
+        );
         ctx.ui.notify(result.content[0]!.text, result.isError ? 'error' : 'info');
         return;
       }
@@ -1072,7 +1229,7 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
       }
 
       ctx.ui.notify(
-        'pi-video-gen commands:\n  /video-gen generate <prompt>  Generate a single clip\n  /video-gen render <spec>      Render a multi-shot video\n  /video-gen compose <spec>     Concat clips or render an image/TTS timeline\n  /video-gen recover <jobId>    Resolve ambiguous shots (reset/adopt)\n  /video-gen models             List registered models\n  /video-gen reload             Reload settings\n  /video-gen doctor             Check environment (ffmpeg, CJK fonts, keys, image_generate, output dir)',
+        'pi-video-gen commands:\n  /video-gen generate --visuals ".." --action ".." [--style ".." --scene ".."]  Generate a single clip\n  /video-gen render <spec>      Render a multi-shot video\n  /video-gen compose <spec>     Concat clips or render an image/TTS timeline\n  /video-gen recover <jobId>    Resolve ambiguous shots (reset/adopt)\n  /video-gen models             List registered models\n  /video-gen reload             Reload settings\n  /video-gen doctor             Check environment (ffmpeg, CJK fonts, keys, image_generate, output dir)',
         'info',
       );
     },

--- a/packages/pi-video-gen/src/index.ts
+++ b/packages/pi-video-gen/src/index.ts
@@ -135,7 +135,16 @@ function parseGenerateFlags(text: string): { flags: Record<string, string> } | {
       return { error: `Unrecognized text "${gap}" — use --key "value" flags.` };
     }
     const quoted = m[3] ?? m[4];
-    flags[m[1]!] = quoted !== undefined ? quoted.replace(/\\(["'\\])/g, '$1') : (m[5] ?? '');
+    const bare = m[5];
+    // A bare value starting with a quote char means an unterminated quote — the
+    // quoted alternative needed a closer, so `--visuals "wide` must not slide
+    // through as the literal value `"wide` into a paid request.
+    if (bare !== undefined && (bare.startsWith('"') || bare.startsWith("'"))) {
+      return {
+        error: `Unterminated quoted value for --${m[1]} (${bare}…). Close the quote, or escape it as \\${bare[0]}.`,
+      };
+    }
+    flags[m[1]!] = quoted !== undefined ? quoted.replace(/\\(["'\\])/g, '$1') : (bare ?? '');
     covered = m.index + m[0].length;
   }
   const tail = text.slice(covered).trim();
@@ -384,6 +393,11 @@ export default function piVideoGenExtension(pi: ExtensionAPI): void {
       return errResult(
         `durationSec must be ${caps.durations[0]}-${caps.durations[1]}s for ${resolved.entry.id} (got ${toolParams.durationSec}).`,
       );
+    }
+    // Reject empty-string ratio before the truthy capability check — "" would
+    // skip the check yet survive `??` into the fingerprint and paid request.
+    if (toolParams.aspectRatio !== undefined && toolParams.aspectRatio.trim() === '') {
+      return errResult('aspectRatio must be a non-empty string when passed (e.g. "16:9").');
     }
     if (toolParams.aspectRatio && !caps.aspectRatios.includes(toolParams.aspectRatio)) {
       return errResult(

--- a/packages/pi-video-gen/src/prompt.ts
+++ b/packages/pi-video-gen/src/prompt.ts
@@ -1,0 +1,114 @@
+import type { FilmPrompt, ShotPrompt } from './types.js';
+
+/**
+ * Structured prompt assembly.
+ *
+ * The creative content is authored by the caller (the video-gen skill guides
+ * the LLM); this module is the mechanical half — it guarantees that every
+ * shot sent to the provider carries the film-level directives (style,
+ * consistency, negative) and the shot-level sections in a fixed, labeled
+ * order, so prompt structure does not depend on LLM compliance at call time.
+ */
+
+/** Serialize film + shot fields into the labeled prompt text sent to providers. */
+export function assemblePrompt(film: FilmPrompt, shot: ShotPrompt): string {
+  const sections: string[] = [];
+  if (film.style) sections.push(`[Style] ${film.style}`);
+  for (const id of shot.visibleCharacters ?? []) {
+    const character = film.characters?.find((c) => c.id === id);
+    if (character) sections.push(`[Character] ${character.id}: ${character.description}`);
+  }
+  if (shot.scene) sections.push(`[Scene] ${shot.scene}`);
+  sections.push(`[Visuals] ${shot.visuals}`);
+  sections.push(`[Action] ${shot.action}`);
+  if (shot.effects) sections.push(`[Effects] ${shot.effects}`);
+  if (shot.audio) sections.push(`[Audio] ${shot.audio}`);
+  if (film.consistency) sections.push(film.consistency);
+  if (film.negative) sections.push(`Negative: ${film.negative}`);
+  return sections.join('\n');
+}
+
+/**
+ * Validate structured prompt fields; returns a user-facing message or null.
+ * `where` prefixes the message (e.g. `shots[2] ("s3").prompt`).
+ *
+ * Rules: visuals + action are always required; a shot without a first frame
+ * is text-to-video, so style and scene become required — the frameless path
+ * must not go out with action-only prompts.
+ */
+export function validateShotPrompt(
+  film: FilmPrompt,
+  /** Untrusted at the JSON boundary — may be absent (e.g. a jobId-only resume call). */
+  shot: ShotPrompt | undefined,
+  opts: { hasFirstFrame: boolean },
+  where: string,
+): string | null {
+  if (!shot || typeof shot !== 'object') {
+    return `${where} must be an object with visuals/action (plus scene/effects/audio/visibleCharacters).`;
+  }
+  if (typeof shot.visuals !== 'string' || shot.visuals.trim() === '') {
+    return `${where}.visuals is required (camera, framing, composition).`;
+  }
+  if (typeof shot.action !== 'string' || shot.action.trim() === '') {
+    return `${where}.action is required (in-frame action/movement).`;
+  }
+  // Optional fields are type-checked too — render-input.json is hand/agent-written
+  // JSON with no schema gate, and a non-string would serialize into the paid
+  // prompt as "[object Object]".
+  for (const key of ['scene', 'effects', 'audio'] as const) {
+    const value = shot[key];
+    if (value !== undefined && typeof value !== 'string') {
+      return `${where}.${key} must be a string.`;
+    }
+  }
+  if (!opts.hasFirstFrame) {
+    if (typeof film.style !== 'string' || film.style.trim() === '') {
+      return `${where} has no first frame — film-level "style" is required for text-to-video (genre/quality anchors, e.g. "cinematic, 8K, film grain").`;
+    }
+    if (typeof shot.scene !== 'string' || shot.scene.trim() === '') {
+      return `${where}.scene is required when no first frame anchors the visuals.`;
+    }
+  }
+  if (
+    shot.visibleCharacters !== undefined &&
+    (!Array.isArray(shot.visibleCharacters) ||
+      shot.visibleCharacters.some((id) => typeof id !== 'string'))
+  ) {
+    return `${where}.visibleCharacters must be an array of character ids (strings).`;
+  }
+  for (const id of shot.visibleCharacters ?? []) {
+    if (!film.characters?.some((c) => c.id === id)) {
+      return `${where}.visibleCharacters references unknown character "${id}" — define it in the film-level "characters" array.`;
+    }
+  }
+  return null;
+}
+
+/** Validate film-level fields; returns a user-facing message or null. */
+export function validateFilmPrompt(film: FilmPrompt, where: string): string | null {
+  for (const key of ['style', 'consistency', 'negative'] as const) {
+    const value = film[key];
+    if (value !== undefined && typeof value !== 'string') {
+      return `${where}.${key} must be a string.`;
+    }
+  }
+  if (film.characters === undefined) return null;
+  if (!Array.isArray(film.characters)) {
+    return `${where}.characters must be an array of {id, description}.`;
+  }
+  const seen = new Set<string>();
+  for (const [i, c] of film.characters.entries()) {
+    const at = `${where}.characters[${i}]`;
+    if (!c || typeof c !== 'object' || typeof c.id !== 'string' || c.id.trim() === '') {
+      return `${at} must have a non-empty "id".`;
+    }
+    if (typeof c.description !== 'string' || c.description.trim() === '') {
+      return `${at} ("${c.id}") must have a non-empty "description" (appearance + outfit).`;
+    }
+    if (seen.has(c.id)) {
+      return `${at} duplicates character id "${c.id}".`;
+    }
+    seen.add(c.id);
+  }
+  return null;
+}

--- a/packages/pi-video-gen/src/render.ts
+++ b/packages/pi-video-gen/src/render.ts
@@ -23,12 +23,15 @@ import {
   saveRenderJob,
   writeJsonAtomic,
 } from './jobs/store.js';
+import { assemblePrompt, validateFilmPrompt, validateShotPrompt } from './prompt.js';
 import { requestFingerprint } from './providers/request.js';
 import { CancelledError, pollTask, type RateLimiter } from './providers/task.js';
 import type {
+  FilmPrompt,
   GenerateVideoParams,
   RemoteTaskHandle,
   ResolvedModel,
+  ShotPrompt,
   VideoGenSettings,
   VideoProviderAdapter,
 } from './types.js';
@@ -50,13 +53,14 @@ import type {
 
 export type RenderShotInput = {
   id: string;
-  videoPrompt: string;
+  /** Structured per-shot prompt fields — assembled via assemblePrompt before submit. */
+  prompt: ShotPrompt;
   firstFramePath: string;
   lastFramePath?: string | undefined;
   durationSec?: number | undefined;
 };
 
-export type RenderInput = {
+export type RenderInput = FilmPrompt & {
   title?: string | undefined;
   aspectRatio?: string | undefined;
   shots: RenderShotInput[];
@@ -127,13 +131,31 @@ function parseRenderSpec(raw: string): RenderInput {
       'render: no shots',
     );
   }
+  const charactersError = validateFilmPrompt(spec, 'render-input.json');
+  if (charactersError) {
+    throw new VideoGenError(charactersError, 'render: bad characters');
+  }
+  // Type-check, not truthiness: 0/false/"" would skip the capability check but
+  // still flow through `??` into the fingerprint and paid request.
+  if (
+    spec.aspectRatio !== undefined &&
+    (typeof spec.aspectRatio !== 'string' || spec.aspectRatio.trim() === '')
+  ) {
+    throw new VideoGenError(
+      'render-input.json aspectRatio must be a non-empty string (e.g. "16:9").',
+      'render: bad ratio type',
+    );
+  }
   const seen = new Set<string>();
   spec.shots.forEach((shot, i) => {
     const where = `shots[${i}]${shot?.id ? ` ("${shot.id}")` : ''}`;
     if (!shot || typeof shot !== 'object') {
       throw new VideoGenError(`${where} is not an object.`, 'render: bad shot');
     }
-    assertSafeId(String(shot.id ?? ''), 'shot');
+    if (typeof shot.id !== 'string' || shot.id.trim() === '') {
+      throw new VideoGenError(`${where}.id must be a non-empty string.`, 'render: bad id type');
+    }
+    assertSafeId(shot.id, 'shot');
     if (seen.has(shot.id)) {
       throw new VideoGenError(
         `Duplicate shot id "${shot.id}" — ids must be unique.`,
@@ -141,17 +163,31 @@ function parseRenderSpec(raw: string): RenderInput {
       );
     }
     seen.add(shot.id);
-    if (typeof shot.videoPrompt !== 'string' || shot.videoPrompt.trim() === '') {
-      throw new VideoGenError(
-        `${where}.videoPrompt is required (motion + optional audio cues).`,
-        'render: no prompt',
-      );
-    }
     if (typeof shot.firstFramePath !== 'string' || shot.firstFramePath.trim() === '') {
       throw new VideoGenError(
         `${where}.firstFramePath is required — generate the frame via image_generate first and point at its returned path.`,
         'render: no frame',
       );
+    }
+    if (
+      shot.lastFramePath !== undefined &&
+      (typeof shot.lastFramePath !== 'string' || shot.lastFramePath.trim() === '')
+    ) {
+      throw new VideoGenError(
+        `${where}.lastFramePath must be a path string when present.`,
+        'render: bad last frame type',
+      );
+    }
+    // Derive, don't hardcode: firstFramePath is required above, but if it ever
+    // becomes optional the frameless style/scene rule must stay live.
+    const promptError = validateShotPrompt(
+      spec,
+      shot.prompt,
+      { hasFirstFrame: Boolean(shot.firstFramePath?.trim()) },
+      `${where}.prompt`,
+    );
+    if (promptError) {
+      throw new VideoGenError(promptError, 'render: bad prompt');
     }
     if (
       shot.durationSec !== undefined &&
@@ -463,7 +499,7 @@ export async function runRender(opts: {
         : undefined;
       const attempt = shotState.attempt ?? 1;
       const params: GenerateVideoParams = {
-        prompt: shot.videoPrompt,
+        prompt: assemblePrompt(spec, shot.prompt),
         requestId: `${jobId}:${shot.id}:${attempt}`,
         firstFramePath: firstSnap,
         lastFramePath: lastSnap,

--- a/packages/pi-video-gen/src/types.ts
+++ b/packages/pi-video-gen/src/types.ts
@@ -121,6 +121,43 @@ export type ResolvedModel = {
   provider: ResolvedProvider;
 };
 
+/** A film-level character whose description is inlined into shot prompts on demand. */
+export type PromptCharacter = {
+  id: string;
+  /** Static + dynamic appearance (face, hair, build, outfit). */
+  description: string;
+};
+
+/**
+ * Per-shot prompt fields. Content is authored by the caller (skill/LLM);
+ * assembly into the provider string is mechanical (see prompt.ts).
+ */
+export type ShotPrompt = {
+  /** Setting of the shot. Required when no first frame anchors the visuals. */
+  scene?: string | undefined;
+  /** Camera, framing, composition ("Static camera, medium close-up, …"). */
+  visuals: string;
+  /** In-frame action/movement. */
+  action: string;
+  /** Time-varying visuals a static frame cannot carry: transformations, lighting shifts, particles, mood. */
+  effects?: string | undefined;
+  /** Audio cues, e.g. "[Sound Effect] rain; [Speaker] Alice (soft): line". */
+  audio?: string | undefined;
+  /** Ids of film-level characters appearing in this shot. */
+  visibleCharacters?: string[] | undefined;
+};
+
+/** Film-level prompt fields shared across shots. */
+export type FilmPrompt = {
+  /** Overall look: genre, quality, render texture ("cinematic, 8K, film grain"). */
+  style?: string | undefined;
+  characters?: PromptCharacter[] | undefined;
+  /** Consistency directive ("Face, hair and outfit stay identical, no morphing or drift"). */
+  consistency?: string | undefined;
+  /** Negative directive ("no text, watermarks, or subtitles"). */
+  negative?: string | undefined;
+};
+
 export type GenerateVideoParams = {
   prompt: string;
   /** Stable orchestration identity for provider idempotency/recovery keys. */

--- a/tests/eval/video/run-video.ts
+++ b/tests/eval/video/run-video.ts
@@ -21,7 +21,8 @@
  */
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { BUILT_IN_VIDEO_MODELS } from '../../../packages/pi-video-gen/src/providers/models.js';
+import { loadVideoGenSettings, resolveModel } from '../../../packages/pi-video-gen/src/config.js';
+import type { VideoGenSettings } from '../../../packages/pi-video-gen/src/types.js';
 import { getFlag } from '../src/judge-client.js';
 import {
   type DriveResult,
@@ -51,33 +52,17 @@ function parseVideoArgs(): VideoArgs {
   const durationSecRaw = getFlag(argv, '--duration-sec', '5');
   const durationSec = Number(durationSecRaw);
   // Reject malformed input at t=0 — a NaN/negative would otherwise surface only
-  // after paid frame generation.
+  // after paid frame generation. The model range check runs later in main()
+  // against the actually-resolved active model (mode-dependent).
   if (!Number.isInteger(durationSec) || durationSec <= 0) {
     throw new Error(`--duration-sec must be a positive integer, got "${durationSecRaw}".`);
-  }
-  const videoModel = getFlag(
-    argv,
-    '--video-model',
-    process.env.PI_EVAL_VIDEO_MODEL || 'doubao-seedance-2-0-260128',
-  );
-  // Deterministic range preflight for built-in ids — an out-of-range duration
-  // must die here, not after the paid image stage. Unknown custom ids defer to
-  // the extension's video_render check.
-  const known = BUILT_IN_VIDEO_MODELS.find(
-    (m) => m.id === videoModel || m.aliases.includes(videoModel),
-  );
-  if (known) {
-    const [min, max] = known.capabilities.durations;
-    if (durationSec < min || durationSec > max) {
-      throw new Error(`--duration-sec ${durationSec} is outside ${min}-${max}s for ${known.id}.`);
-    }
   }
   return {
     samples: Number(getFlag(argv, '--samples', '2')),
     tier: getFlag(argv, '--tier', 'medium') as VideoArgs['tier'],
     storyId: getFlag(argv, '--story', ''),
     // CI-proven ids from integration.yml; override for other gateways.
-    videoModel,
+    videoModel: getFlag(argv, '--video-model', process.env.PI_EVAL_VIDEO_MODEL || 'doubao-seedance-2-0-260128'),
     imageModel: getFlag(argv, '--image-model', process.env.PI_EVAL_IMAGE_MODEL || ''),
     // Per-shot clip length. 5 keeps smoke cheap; use 10-15 for scored runs —
     // longer clips expose within-shot motion drift.
@@ -309,6 +294,25 @@ async function main() {
     // useDefaultPi mode writes no settings — the user's own config drives.
     settings: hcfg.useDefaultPi ? {} : buildSettings(args, vargs),
   });
+
+  // Duration preflight against the ACTIVE model's real capabilities — isolated
+  // mode resolves the harness-written settings; --use-default-pi resolves the
+  // user's own config. Fail closed before any paid frame generation.
+  const videoSettings = hcfg.useDefaultPi
+    ? loadVideoGenSettings(process.cwd(), false)
+    : (buildSettings(args, vargs)['pi-video-gen'] as VideoGenSettings);
+  const activeVideo = resolveModel(videoSettings);
+  if (!activeVideo) {
+    throw new Error(
+      'Cannot resolve the active video model for the duration preflight — refusing to start paid generation.',
+    );
+  }
+  const [minD, maxD] = activeVideo.entry.capabilities.durations;
+  if (vargs.durationSec < minD || vargs.durationSec > maxD) {
+    throw new Error(
+      `--duration-sec ${vargs.durationSec} is outside ${minD}-${maxD}s for the active video model (${activeVideo.entry.id}).`,
+    );
+  }
 
   const shotBooksDir = path.join(ARTIFACTS_DIR, 'shotbooks');
   mkdirSync(shotBooksDir, { recursive: true });

--- a/tests/eval/video/run-video.ts
+++ b/tests/eval/video/run-video.ts
@@ -21,6 +21,7 @@
  */
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { BUILT_IN_VIDEO_MODELS } from '../../../packages/pi-video-gen/src/providers/models.js';
 import { getFlag } from '../src/judge-client.js';
 import {
   type DriveResult,
@@ -50,16 +51,33 @@ function parseVideoArgs(): VideoArgs {
   const durationSecRaw = getFlag(argv, '--duration-sec', '5');
   const durationSec = Number(durationSecRaw);
   // Reject malformed input at t=0 — a NaN/negative would otherwise surface only
-  // after paid frame generation. The model's range check stays with the extension.
+  // after paid frame generation.
   if (!Number.isInteger(durationSec) || durationSec <= 0) {
     throw new Error(`--duration-sec must be a positive integer, got "${durationSecRaw}".`);
+  }
+  const videoModel = getFlag(
+    argv,
+    '--video-model',
+    process.env.PI_EVAL_VIDEO_MODEL || 'doubao-seedance-2-0-260128',
+  );
+  // Deterministic range preflight for built-in ids — an out-of-range duration
+  // must die here, not after the paid image stage. Unknown custom ids defer to
+  // the extension's video_render check.
+  const known = BUILT_IN_VIDEO_MODELS.find(
+    (m) => m.id === videoModel || m.aliases.includes(videoModel),
+  );
+  if (known) {
+    const [min, max] = known.capabilities.durations;
+    if (durationSec < min || durationSec > max) {
+      throw new Error(`--duration-sec ${durationSec} is outside ${min}-${max}s for ${known.id}.`);
+    }
   }
   return {
     samples: Number(getFlag(argv, '--samples', '2')),
     tier: getFlag(argv, '--tier', 'medium') as VideoArgs['tier'],
     storyId: getFlag(argv, '--story', ''),
     // CI-proven ids from integration.yml; override for other gateways.
-    videoModel: getFlag(argv, '--video-model', process.env.PI_EVAL_VIDEO_MODEL || 'doubao-seedance-2-0-260128'),
+    videoModel,
     imageModel: getFlag(argv, '--image-model', process.env.PI_EVAL_IMAGE_MODEL || ''),
     // Per-shot clip length. 5 keeps smoke cheap; use 10-15 for scored runs —
     // longer clips expose within-shot motion drift.

--- a/tests/eval/video/run-video.ts
+++ b/tests/eval/video/run-video.ts
@@ -42,10 +42,18 @@ interface VideoArgs {
   storyId: string;
   videoModel: string;
   imageModel: string;
+  durationSec: number;
 }
 
 function parseVideoArgs(): VideoArgs {
   const argv = process.argv.slice(2);
+  const durationSecRaw = getFlag(argv, '--duration-sec', '5');
+  const durationSec = Number(durationSecRaw);
+  // Reject malformed input at t=0 — a NaN/negative would otherwise surface only
+  // after paid frame generation. The model's range check stays with the extension.
+  if (!Number.isInteger(durationSec) || durationSec <= 0) {
+    throw new Error(`--duration-sec must be a positive integer, got "${durationSecRaw}".`);
+  }
   return {
     samples: Number(getFlag(argv, '--samples', '2')),
     tier: getFlag(argv, '--tier', 'medium') as VideoArgs['tier'],
@@ -53,6 +61,9 @@ function parseVideoArgs(): VideoArgs {
     // CI-proven ids from integration.yml; override for other gateways.
     videoModel: getFlag(argv, '--video-model', process.env.PI_EVAL_VIDEO_MODEL || 'doubao-seedance-2-0-260128'),
     imageModel: getFlag(argv, '--image-model', process.env.PI_EVAL_IMAGE_MODEL || ''),
+    // Per-shot clip length. 5 keeps smoke cheap; use 10-15 for scored runs —
+    // longer clips expose within-shot motion drift.
+    durationSec,
   };
 }
 
@@ -122,7 +133,7 @@ function buildSettings(args: ReturnType<typeof parseCommonArgs>, vargs: VideoArg
 }
 
 /** ViMax story → VideoProject shot book (skill §B schema), deterministically. */
-function toShotBook(story: VimaxStory) {
+function toShotBook(story: VimaxStory, durationSec: number) {
   return {
     title: story.theme,
     characters: [],
@@ -130,8 +141,8 @@ function toShotBook(story: VimaxStory) {
       id: s.shotId,
       intent: s.videoPrompt,
       firstFrame: s.firstFrame,
-      motion: s.videoPrompt,
-      durationSec: 5,
+      action: s.videoPrompt,
+      durationSec,
       continuityGroup: `scene-${s.sceneNum}`,
     })),
   };
@@ -143,9 +154,9 @@ function buildPrompt(story: VimaxStory, shotBookPath: string, renderSpecHint: st
 Shot book (VideoProject JSON): ${shotBookPath} — read it first with the read tool.
 
 Execute exactly:
-1. Call video_capabilities and respect the active model's limits.
+1. Call video_capabilities first. If the shot book's durationSec is outside the active model's duration range, STOP and report the mismatch — do not generate any frames (they are paid).
 2. Image stage: for each shot in order, generate its first frame with image_generate (text-to-image, 16:9) using the shot's firstFrame text VERBATIM as the prompt. Record each returned absolute image path immediately.
-3. Write render-input.json (${renderSpecHint}): {"title","aspectRatio":"16:9","shots":[{"id","videoPrompt","firstFramePath","durationSec"}...]} — videoPrompt is the shot's motion text, firstFramePath the generated frame path from step 2.
+3. Write render-input.json (${renderSpecHint}): {"title","aspectRatio":"16:9","shots":[{"id","prompt":{"visuals","action"},"firstFramePath","durationSec"}...]} — prompt.action is the shot book shot's action text VERBATIM, prompt.visuals describes camera/framing ("Static camera" when the action text implies no camera move), firstFramePath the generated frame path from step 2.
 4. Call video_render ONCE with that spec path.
 5. Reply with the final video path.
 
@@ -294,6 +305,7 @@ async function main() {
     return {
       model: `${args.provider}/${args.model}`,
       videoModel: vargs.videoModel,
+      durationSec: vargs.durationSec,
       n: rows.length,
       completed: completed.length,
       completionRate: completed.length / Math.max(1, rows.length),
@@ -312,7 +324,7 @@ async function main() {
     // Sequential: paid generation; a parallel fleet would also trip rate limits.
     for (const story of selected) {
       const shotBookPath = path.join(shotBooksDir, `${story.id}.json`);
-      writeFileSync(shotBookPath, JSON.stringify(toShotBook(story), null, 2));
+      writeFileSync(shotBookPath, JSON.stringify(toShotBook(story, vargs.durationSec), null, 2));
       const renderSpecHint = hcfg.useDefaultPi
         ? `under the video-gen output dir as job '${story.id}', i.e. <outputDir>/${story.id}/render-input.json`
         : path.join(ARTIFACTS_DIR, 'video', story.id, 'render-input.json');


### PR DESCRIPTION
## Summary

- **Structured prompt contract** for the paid tools: film-level fields (`style` / `characters` / `consistency` / `negative`) + per-shot `prompt` object (`scene` / `visuals` / `action` / `effects` / `audio` / `visibleCharacters`) replace the opaque `videoPrompt` string across `video_generate`, `video_render` (`render-input.json`) and `/video-gen generate`. The plugin mechanically assembles the labeled prompt text (`[Style]` / `[Character]` / `[Scene]` / `[Visuals]` / `[Action]` / `[Effects]` / `[Audio]` + consistency + `Negative:`), so film-level directives reliably reach every shot instead of depending on LLM compliance.
- **Pre-submit validation on untrusted input**: `visuals`/`action` required; `style`+`scene` required for text-to-video (no first frame); type checks on every optional field (malformed JSON can no longer serialize as `[object Object]` into a paid prompt); `shot.id`/`lastFramePath`/`aspectRatio` type-checked (no truthiness bypass into the fingerprint).
- **`/video-gen generate` is flag-based** (`--visuals/--action/--style/--scene/--effects/--audio/--consistency/--negative/--first-frame/--last-frame/--duration/--ratio`) with backslash-escaped quotes supported inside quoted values.
- **`video_generate.prompt` is schema-optional** so `{jobId}`-only resume calls pass the schema; fresh submits without `prompt` still fail inside `execute`.
- **tests/eval/video/run-video.ts aligned**: shot book uses `action`, the render-spec instruction is the structured shape, `--duration-sec` rejects NaN/non-positive at parse time, and the agent is told to stop before paid frame generation when the duration is outside the model's range.

**Breaking change (intentional, no compatibility layer):** old `videoPrompt` render specs fail parsing; pre-structured in-flight render jobs cannot resume (recover clips from the provider console — see the README upgrade note). `video_generate`/`video_render` tool params, the `/video-gen generate` command syntax, and the render-input.json schema all changed; tests, README, SKILL.md, `promptSnippet`/`promptGuidelines` updated in lockstep.

## Test plan

- [x] `pnpm pr-check` green at commit (build + typecheck + 1865 tests + biome) via pre-commit hook
- [x] pi-video-gen: 373 tests, incl. new `prompt.test.ts` (assembly order/omissions + all validation rules), render-spec rejection cases, command flag parsing end-to-end (with escaped quotes in `--audio`), `{jobId}`-only resume
- [ ] Live smoke: `/video-gen doctor` + one small paid clip against a real account before heavy use (per README guidance)