### PR TITLE
ci: migrate workflows to GitHub-hosted runners

### DIFF
--- a/.github/actions/setup-pi-build/action.yml
+++ b/.github/actions/setup-pi-build/action.yml
@@ -1,9 +1,9 @@
 name: Setup pi build environment
 description: >
-  Shared setup steps for every pi monorepo CI job: clean self-hosted runner
-  state, checkout, pnpm + Node 24, install deps (with optional better-sqlite3
-  prebuilt fetch), and build the workspace. Optionally installs pi-coding-agent
-  globally and exposes a per-job PI_CODING_AGENT_DIR.
+  Shared setup steps for every pi monorepo CI job: per-job pi config dir,
+  pnpm + Node 24, install deps (with optional better-sqlite3 prebuilt fetch),
+  and build the workspace. Optionally installs pi-coding-agent globally and
+  exposes a per-job PI_CODING_AGENT_DIR.
 
 inputs:
   install-pi-cli:
@@ -26,9 +26,9 @@ inputs:
     default: 'false'
   set-pi-agent-dir:
     description: >
-      When 'true', point PI_CODING_AGENT_DIR at $RUNNER_TEMP/pi-agent so
-      concurrent jobs on the same self-hosted host don't trample each
-      other's ~/.pi/agent/settings.json. Sets up the dir clean.
+      When 'true', point PI_CODING_AGENT_DIR at $RUNNER_TEMP/pi-agent so the
+      job's pi state stays isolated under the per-job temp dir. Sets up the
+      dir clean.
     required: false
     default: 'false'
   build:
@@ -43,31 +43,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Bypass proxy for the npm mirror
-      shell: bash
-      run: |
-        # Self-hosted runners route egress through a host-level proxy. npmmirror
-        # redirects package downloads to CDN subdomains (e.g. cdn.npmmirror.com),
-        # which the proxy refuses — breaking pnpm/action-setup and installs with
-        # "fetch failed" / 403. Send the mirror and ALL its subdomains direct.
-        # Append (don't replace) to keep the runner's existing bypasses.
-        {
-          echo "NO_PROXY=${NO_PROXY:+$NO_PROXY,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
-          echo "no_proxy=${no_proxy:+$no_proxy,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
-        } >> "$GITHUB_ENV"
-
     - name: Set up per-job pi config dir
       if: inputs.set-pi-agent-dir == 'true'
       shell: bash
       run: |
-        # Self-hosted runners share $HOME across the matrix workers
-        # (instance-hnpsq9go-1..N), so writes to ~/.pi/agent race between
-        # concurrent jobs. RUNNER_TEMP is per-job. `env:` blocks can't
-        # reference `runner.temp` at job-startup time, so we resolve via
-        # $RUNNER_TEMP at step time and persist via $GITHUB_ENV.
+        # RUNNER_TEMP is per-job. `env:` blocks can't reference `runner.temp`
+        # at job-startup time, so we resolve via $RUNNER_TEMP at step time and
+        # persist via $GITHUB_ENV.
         echo "PI_CODING_AGENT_DIR=$RUNNER_TEMP/pi-agent" >> "$GITHUB_ENV"
 
-    - name: Clean self-hosted runner caches
+    - name: Reset per-job pi config dir
       if: inputs.set-pi-agent-dir == 'true'
       shell: bash
       run: |
@@ -79,34 +64,20 @@ runs:
     # this composite — GitHub needs to find action.yml on disk first.
 
     # Node must come before pnpm: v6's npm-based bootstrap (@pnpm/exe
-    # postinstall uses import.meta.dirname) needs Node >= 20.11, and the
-    # self-hosted runner's system Node is 18.
+    # postinstall uses import.meta.dirname) needs Node >= 20.11.
     - name: Setup Node
       uses: actions/setup-node@v7
       with:
         node-version: 24
 
-    # cache: false — this self-hosted runner persists its host disk across
-    # jobs, so a shared host-level pnpm store (pinned in the next step) gives
-    # the same install speedup without per-job cache upload/download.
+    # cache: false — every job runs on a fresh hosted runner, so there is no
+    # persisted store to reuse and no cache upload/download is configured.
+    # `dest` keeps the pnpm bootstrap inside the per-job temp dir.
     - name: Setup pnpm
       uses: pnpm/action-setup@v6
       with:
         cache: false
-        # Per-job temp dir avoids cwd-deleted races between concurrent matrix
-        # jobs sharing the runner's $HOME/setup-pnpm.
         dest: ${{ runner.temp }}/setup-pnpm
-
-    - name: Use the host-persisted shared pnpm store
-      shell: bash
-      run: |
-        # `dest` above relocates PNPM_HOME into the per-job temp dir, which
-        # can drag the default store along with it. Pin store-dir back to the
-        # host so every job shares one content-addressed store (safe for
-        # concurrent matrix jobs). `pnpm store path` echoes the resolved path
-        # into the log so a misconfigured store is visible at a glance.
-        pnpm config set store-dir "$HOME/.local/share/pnpm/store/v10" --global
-        pnpm store path
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/agentic-eval.yml
+++ b/.github/workflows/agentic-eval.yml
@@ -51,10 +51,7 @@ jobs:
   browser-eval:
     name: Browser eval (task completion)
     if: inputs.target == 'browser' || inputs.target == 'both'
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
@@ -169,10 +166,7 @@ jobs:
     # runs-on at it (the runner needs Accessibility + Screen Recording grants).
     # Until then this job is a placeholder that documents the requirement; the
     # runner itself skips gracefully on non-macOS, so a Linux fallback no-ops.
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
@@ -231,10 +225,7 @@ jobs:
   video-eval:
     name: Video eval (ViMax-Bench render quality)
     if: inputs.target == 'video'
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     # One Medium story ≈ 9 paid clips + frames — tens of minutes per story.
     timeout-minutes: 120
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: biomejs/setup-biome@v2
@@ -30,10 +27,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/setup-pi-build
@@ -46,10 +40,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     steps:
       - name: Isolate temporary files
         run: |
@@ -70,10 +61,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ffmpeg-build.yml
+++ b/.github/workflows/ffmpeg-build.yml
@@ -28,10 +28,7 @@ concurrency:
 jobs:
   decide:
     name: check for unpublished platform versions
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       missing: ${{ steps.check.outputs.missing }}
@@ -72,9 +69,8 @@ jobs:
         include:
           # darwin targets need macOS hosts; linux-* targets keep the pinned
           # ubuntu-22.04 image for the published glibc baseline. win32-x64
-          # produces PE binaries via mingw (host-glibc-agnostic), so it runs
-          # on the accelerated self-hosted runner for reliable source
-          # downloads (ffmpeg.org, zlib.net, code.videolan.org).
+          # produces PE binaries via mingw (host-glibc-agnostic), so it shares
+          # the linux image and cross-compiles inside an ubuntu:22.04 container.
           - target: darwin-arm64
             runner: macos-15
           - target: darwin-x64
@@ -84,7 +80,7 @@ jobs:
           - target: linux-arm64
             runner: ubuntu-22.04
           - target: win32-x64
-            runner: [instance-hnpsq9go, linux, x64]
+            runner: ubuntu-22.04
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
 
@@ -107,9 +103,8 @@ jobs:
               sudo apt-get install -y gcc-aarch64-linux-gnu pkg-config qemu-user
               ;;
             win32-x64)
-              # The self-hosted runner has Docker access but intentionally has
-              # no passwordless sudo. Install the cross toolchain inside an
-              # ephemeral container without mutating the host.
+              # Install the cross toolchain inside an ephemeral container
+              # instead of mutating the hosted runner image.
               win_container="pi-video-gen-win32-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
               docker pull ubuntu:22.04
               docker run --detach --rm --name "$win_container" \
@@ -266,10 +261,7 @@ jobs:
     name: publish FFmpeg platform packages
     needs: [decide, build]
     if: needs.decide.outputs.missing == 'true'
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,10 +20,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
       has_extensions: ${{ steps.select.outputs.has_extensions }}
@@ -48,10 +45,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
@@ -108,10 +102,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}
@@ -212,7 +203,7 @@ jobs:
   # instead so local composition never needs a model call.
   #
   # Skipped on fork PRs (secrets unavailable). Each job duplicates Stage A
-  # setup because self-hosted matrix jobs don't share workspace state.
+  # setup because matrix jobs don't share workspace state.
   # ──────────────────────────────────────────────────────────────────────
   extension-tool-matrix:
     name: Extension E2E (${{ matrix.extension }}${{ matrix.provider && format('-{0}', matrix.provider) || '' }}${{ matrix.scenario && format('-{0}', matrix.scenario) || '' }})
@@ -222,10 +213,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository) &&
       needs.detect-extension-matrix.outputs.has_extensions == 'true' &&
       vars.PI_INTEGRATION_SKIP_STAGE_C != 'true'
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -413,9 +401,9 @@ jobs:
           # 2. settings.json — extension-specific configuration. Every matrix
           #    entry carries any keys it needs; absent extensions ignore them.
           #    pi-memory-mem0's historyDbPath MUST stay on the per-job temp dir:
-          #    its default (~/.pi/agent/memories/) is shared by every matrix job
-          #    on this self-hosted host, and concurrent better-sqlite3 writers
-          #    on one file segfault the pi process (exit 139).
+          #    concurrent better-sqlite3 writers on one shared file segfault
+          #    the pi process (exit 139), so nothing may point at a default
+          #    location like ~/.pi/agent/memories/.
           cat > "$PI_CODING_AGENT_DIR/settings.json" <<EOF
           {
             "pi-teamwork": {
@@ -675,19 +663,13 @@ jobs:
           retention-days: 7
 
       - name: Bootstrap multica CLI (pi-teamwork only)
-        # pi-teamwork's autoInstall path is broken on this self-hosted runner:
-        # multica's upstream install.sh tries `sudo mv ...` to /usr/local/bin
-        # before falling back to ~/.local/bin, but our runner user has sudo
-        # configured to require a password — so the install silently fails.
-        # We bootstrap the binary ourselves with MULTICA_BIN_DIR forcing the
-        # user-bin path, then put it on $GITHUB_PATH so pi-teamwork's
-        # session_start spawn(multica) finds it. Driving login + daemon up
-        # front means the LLM's workspace_list call returns real data
+        # Install + authenticate the multica CLI up front instead of relying
+        # on pi-teamwork's autoInstall at session_start: driving login and the
+        # daemon here means the LLM's workspace_list call returns real data
         # instead of `Exit code 1`, cutting the job from ~12min to ~1min.
         if: matrix.extension == 'pi-teamwork'
         env:
           MULTICA_TOKEN: ${{ secrets.PI_INTEGRATION_MULTICA_TOKEN }}
-          MULTICA_BIN_DIR: /home/work/.local/bin
         run: |
           set -euo pipefail
           mkdir -p "$HOME/.local/bin"
@@ -703,7 +685,7 @@ jobs:
           chmod 0755 "$HOME/.local/bin/multica"
           multica --version
           multica config set server_url https://multica.ai
-          multica daemon start || true   # may already be running on this runner
+          multica daemon start || true   # tolerate an already-running daemon
           multica login --token "$MULTICA_TOKEN"
           # Smoke-test the auth before handing off to pi-teamwork.
           multica workspace list --output json

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -41,10 +41,7 @@ permissions:
 jobs:
   label:
     name: Sync PR labels
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}

--- a/.github/workflows/memory-eval.yml
+++ b/.github/workflows/memory-eval.yml
@@ -1,9 +1,8 @@
 name: Memory Eval
 
 # Manual-only. Benchmarks pi-memory (curated write loop) and pi-memory-mem0
-# (passive extraction) against LoCoMo, then LLM-judges the result. Runs on the
-# self-hosted runner and talks to the custom provider behind
-# PI_INTEGRATION_BASE_URL / PI_INTEGRATION_API_KEY.
+# (passive extraction) against LoCoMo, then LLM-judges the result. Talks to the
+# custom provider behind PI_INTEGRATION_BASE_URL / PI_INTEGRATION_API_KEY.
 on:
   workflow_dispatch:
     inputs:
@@ -39,10 +38,7 @@ permissions:
 jobs:
   memory-eval:
     name: Memory eval (LoCoMo)
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 240
     env:
       PI_INTEGRATION_BASE_URL: ${{ secrets.PI_INTEGRATION_BASE_URL }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,10 +39,7 @@ jobs:
     name: publish packages
     needs: ffmpeg
     if: always() && (needs.ffmpeg.result == 'success' || needs.ffmpeg.result == 'skipped')
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
       publish_filters: ${{ steps.versioning.outputs.publish_filters }}
@@ -414,10 +411,7 @@ jobs:
     name: notify feishu
     needs: publish
     if: needs.publish.result == 'success'
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/pi-review.yml
+++ b/.github/workflows/pi-review.yml
@@ -26,10 +26,7 @@ jobs:
   review:
     name: Pi code review
     if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -46,16 +43,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: 24
-
-      - name: Bypass proxy for the npm mirror
-        run: |
-          # Self-hosted runners route egress through a host-level proxy that
-          # refuses npmmirror's CDN subdomains — every npm/npx install in this
-          # job must reach the mirror directly (same as setup-pi-build).
-          {
-            echo "NO_PROXY=${NO_PROXY:+$NO_PROXY,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
-            echo "no_proxy=${no_proxy:+$no_proxy,}registry.npmmirror.com,npmmirror.com,.npmmirror.com"
-          } >> "$GITHUB_ENV"
 
       - name: Prepare isolated Pi directories
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,10 +13,7 @@ jobs:
     if: >
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -24,10 +24,7 @@ jobs:
   evaluate:
     name: skill eval
     if: github.event.pull_request.draft == false
-    runs-on:
-      - instance-hnpsq9go
-      - linux
-      - x64
+    runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:

--- a/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
+++ b/packages/pi-video-gen/src/__tests__/package-artifacts.test.ts
@@ -82,9 +82,7 @@ describe('pi-video-gen package artifacts', () => {
   it('builds against declared platform baselines and verifies release binaries', () => {
     expect(ffmpegBuildWorkflow).toContain('fail-fast: false');
     expect(ffmpegBuildWorkflow).toContain('runner: ubuntu-22.04');
-    expect(ffmpegBuildWorkflow).toMatch(
-      /- target: win32-x64\n\s+runner: \[instance-hnpsq9go, linux, x64\]/,
-    );
+    expect(ffmpegBuildWorkflow).toMatch(/- target: win32-x64\n\s+runner: ubuntu-22\.04/);
     expect(ffmpegBuildWorkflow).not.toContain('sudo -n');
     expect(ffmpegBuildWorkflow).toContain('docker run --detach');
     expect(ffmpegBuildWorkflow).toContain('ubuntu:22.04 sleep infinity');


### PR DESCRIPTION
Move every CI job from the self-hosted runner pool to GitHub-hosted runners (ubuntu-latest / ubuntu-22.04) and drop the self-hosted-only workarounds.