### PR TITLE
fix(pi-telemetry): 原子闭合 Langfuse Generation

### DIFF
--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   CompositeRuntimeEventExporter,
   NoopRuntimeEventExporter,
@@ -20,6 +20,10 @@ import {
 } from '../otel.js';
 
 const traceId = '11111111111111111111111111111111';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('telemetry', () => {
   it('keeps root exporters resilient when one delegate fails', async () => {
@@ -646,7 +650,7 @@ describe('telemetry', () => {
       id: 'generation-start',
       traceId,
       sessionId: 'session-1',
-      conversationId: 'session-1',
+      conversationId: 'conversation-1',
       llmGenerationId: 'call-1',
       status: 'started',
       createdAt: '2026-05-02T00:00:00.100Z',
@@ -831,6 +835,7 @@ describe('telemetry', () => {
   });
 
   it('drops abandoned starts when their chat turn closes', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const client = new FakeLangfuseSdkClient();
     const exporter = new LangfuseSdkRuntimeEventExporter(
       {
@@ -890,9 +895,103 @@ describe('telemetry', () => {
       output: { error: 'cancelled' },
     });
     expect(generation?.body.input).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[pi-telemetry] dropped 1 pending Langfuse generation start during lifecycle cleanup; late terminal events will be output-only',
+    );
+  });
+
+  it('drops abandoned starts when their subagent lifecycle closes', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const client = new FakeLangfuseSdkClient();
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 20,
+        flushIntervalMs: 5_000,
+        includePayloads: true,
+      },
+      client,
+    );
+
+    await exporter.publish({
+      id: 'turn-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'parent',
+      conversationId: 'parent',
+      createdAt: '2026-05-02T00:00:00.000Z',
+    });
+    await exporter.publish({
+      id: 'subagent-start',
+      traceId,
+      type: 'subagent_started',
+      sessionId: 'parent:subagent:1',
+      conversationId: 'parent:subagent:1',
+      parentSessionId: 'parent',
+      childSessionId: 'parent:subagent:1',
+      runId: 'run-1',
+      createdAt: '2026-05-02T00:00:00.050Z',
+    });
+    await exporter.publish({
+      id: 'generation-start',
+      traceId,
+      sessionId: 'parent:subagent:1',
+      conversationId: 'parent:subagent:1',
+      parentSessionId: 'parent',
+      childSessionId: 'parent:subagent:1',
+      runId: 'run-1',
+      llmGenerationId: 'call-1',
+      status: 'started',
+      createdAt: '2026-05-02T00:00:00.100Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      input: 'abandoned subagent input',
+    });
+    await exporter.publish({
+      id: 'subagent-cancelled',
+      traceId,
+      type: 'subagent_cancelled',
+      sessionId: 'parent:subagent:1',
+      conversationId: 'parent:subagent:1',
+      parentSessionId: 'parent',
+      childSessionId: 'parent:subagent:1',
+      runId: 'run-1',
+      createdAt: '2026-05-02T00:00:00.500Z',
+      error: 'cancelled',
+    });
+    await exporter.publish({
+      id: 'late-generation-terminal',
+      traceId,
+      sessionId: 'parent:subagent:1',
+      conversationId: 'parent:subagent:1',
+      parentSessionId: 'parent',
+      childSessionId: 'parent:subagent:1',
+      runId: 'run-1',
+      llmGenerationId: 'call-1',
+      status: 'failed',
+      createdAt: '2026-05-02T00:00:01.000Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      error: 'cancelled',
+    });
+
+    const rootSpan = client.traces[0]?.spans[0];
+    const subagentSpan = rootSpan?.spans.find((span) => span.body.name === 'subagent');
+    const generation = subagentSpan?.generations[0];
+    expect(generation?.body).toMatchObject({
+      startTime: '2026-05-02T00:00:01.000Z',
+      endTime: '2026-05-02T00:00:01.000Z',
+      output: { error: 'cancelled' },
+    });
+    expect(generation?.body.input).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[pi-telemetry] dropped 1 pending Langfuse generation start during lifecycle cleanup; late terminal events will be output-only',
+    );
   });
 
   it('clears abandoned starts when the exporter closes', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const client = new FakeLangfuseSdkClient();
     const exporter = new LangfuseSdkRuntimeEventExporter(
       {
@@ -936,9 +1035,13 @@ describe('telemetry', () => {
 
     expect(client.closed).toBe(1);
     expect(pendingGenerations).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[pi-telemetry] dropped 1 pending Langfuse generation start during exporter close; late terminal events will be output-only',
+    );
   });
 
   it('bounds abandoned starts and degrades evicted terminals to closed output-only records', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const client = new FakeLangfuseSdkClient();
     const exporter = new LangfuseSdkRuntimeEventExporter(
       {
@@ -993,6 +1096,9 @@ describe('telemetry', () => {
       output: 'completed after eviction',
     });
     expect(generation?.body.input).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[pi-telemetry] dropped 1 pending Langfuse generation start during capacity eviction; late terminal events will be output-only',
+    );
   });
 
   it('nests subagent model and tool observations under the subagent span', async () => {

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -646,11 +646,15 @@ describe('telemetry', () => {
       id: 'generation-start',
       traceId,
       sessionId: 'session-1',
-      conversationId: 'conversation-1',
+      conversationId: 'session-1',
       llmGenerationId: 'call-1',
       status: 'started',
       createdAt: '2026-05-02T00:00:00.100Z',
-      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      model: {
+        provider: 'anthropic-compatible',
+        model: 'kimi-k2.5',
+        thinkingLevel: 'off',
+      },
       input: { messages: [{ role: 'user', content: 'hello' }] },
     });
 
@@ -664,7 +668,7 @@ describe('telemetry', () => {
       llmGenerationId: 'call-1',
       status: 'completed',
       createdAt: '2026-05-02T00:00:01.000Z',
-      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      model: { provider: 'fallback-provider', model: 'fallback-model' },
       output: 'world',
       usage: { input: 10, output: 3, totalTokens: 13 },
     });
@@ -676,7 +680,14 @@ describe('telemetry', () => {
       input: { messages: [{ role: 'user', content: 'hello' }] },
       output: 'world',
       usage: { input: 10, output: 3, total: 13, unit: 'TOKENS' },
-      metadata: { llmGenerationId: 'call-1', status: 'completed' },
+      model: 'kimi-k2.5',
+      modelParameters: { provider: 'anthropic-compatible', thinkingLevel: 'off' },
+      metadata: {
+        llmGenerationId: 'call-1',
+        status: 'completed',
+        model: 'anthropic-compatible/kimi-k2.5',
+        thinkingLevel: 'off',
+      },
     });
     expect(generation?.updates).toHaveLength(0);
   });
@@ -787,7 +798,7 @@ describe('telemetry', () => {
       id: 'generation-start',
       traceId,
       sessionId: 'session-1',
-      conversationId: 'conversation-1',
+      conversationId: 'session-1',
       llmGenerationId: 'call-1',
       status: 'started',
       createdAt: '2026-05-02T00:00:00.100Z',
@@ -817,6 +828,171 @@ describe('telemetry', () => {
       metadata: { llmGenerationId: 'call-1', status: 'failed' },
     });
     expect(generation?.updates).toHaveLength(0);
+  });
+
+  it('drops abandoned starts when their chat turn closes', async () => {
+    const client = new FakeLangfuseSdkClient();
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 20,
+        flushIntervalMs: 5_000,
+        includePayloads: true,
+      },
+      client,
+    );
+
+    await exporter.publish({
+      id: 'turn-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'session-1',
+      createdAt: '2026-05-02T00:00:00.000Z',
+    });
+    await exporter.publish({
+      id: 'generation-start',
+      traceId,
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      llmGenerationId: 'call-1',
+      status: 'started',
+      createdAt: '2026-05-02T00:00:00.100Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      input: 'abandoned input',
+    });
+    await exporter.publish({
+      id: 'turn-failed',
+      traceId,
+      type: 'chat_turn_failed',
+      sessionId: 'session-1',
+      createdAt: '2026-05-02T00:00:00.500Z',
+      error: 'cancelled',
+    });
+    await exporter.publish({
+      id: 'late-generation-terminal',
+      traceId,
+      sessionId: 'session-1',
+      conversationId: 'session-1',
+      llmGenerationId: 'call-1',
+      status: 'failed',
+      createdAt: '2026-05-02T00:00:01.000Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      error: 'cancelled',
+    });
+
+    const generation = client.traces[0]?.spans[0]?.generations[0];
+    expect(generation?.body).toMatchObject({
+      startTime: '2026-05-02T00:00:01.000Z',
+      endTime: '2026-05-02T00:00:01.000Z',
+      output: { error: 'cancelled' },
+    });
+    expect(generation?.body.input).toBeUndefined();
+  });
+
+  it('clears abandoned starts when the exporter closes', async () => {
+    const client = new FakeLangfuseSdkClient();
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 20,
+        flushIntervalMs: 5_000,
+        includePayloads: true,
+      },
+      client,
+    );
+
+    await exporter.publish({
+      id: 'turn-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'session-1',
+      createdAt: '2026-05-02T00:00:00.000Z',
+    });
+    await exporter.publish({
+      id: 'generation-start',
+      traceId,
+      sessionId: 'session-1',
+      conversationId: 'session-1',
+      llmGenerationId: 'call-1',
+      status: 'started',
+      createdAt: '2026-05-02T00:00:00.100Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      input: 'abandoned input',
+    });
+
+    const pendingGenerations = (
+      exporter as unknown as {
+        pendingGenerations: Map<string, unknown>;
+      }
+    ).pendingGenerations;
+    expect(pendingGenerations).toHaveLength(1);
+    await exporter.close();
+
+    expect(client.closed).toBe(1);
+    expect(pendingGenerations).toHaveLength(0);
+  });
+
+  it('bounds abandoned starts and degrades evicted terminals to closed output-only records', async () => {
+    const client = new FakeLangfuseSdkClient();
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 20,
+        flushIntervalMs: 5_000,
+        includePayloads: true,
+      },
+      client,
+    );
+
+    await exporter.publish({
+      id: 'turn-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'session-0',
+      createdAt: '2026-05-02T00:00:00.000Z',
+    });
+    for (let index = 0; index <= 128; index += 1) {
+      await exporter.publish({
+        id: `generation-start-${index}`,
+        traceId,
+        sessionId: `session-${index}`,
+        conversationId: `session-${index}`,
+        llmGenerationId: 'call-1',
+        status: 'started',
+        createdAt: '2026-05-02T00:00:00.100Z',
+        model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+        input: `input-${index}`,
+      });
+    }
+    await exporter.publish({
+      id: 'evicted-generation-terminal',
+      traceId,
+      sessionId: 'session-0',
+      conversationId: 'session-0',
+      llmGenerationId: 'call-1',
+      status: 'completed',
+      createdAt: '2026-05-02T00:00:01.000Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      output: 'completed after eviction',
+      usage: { input: 1, output: 1, totalTokens: 2 },
+    });
+
+    const generation = client.traces[0]?.spans[0]?.generations[0];
+    expect(generation?.body).toMatchObject({
+      startTime: '2026-05-02T00:00:01.000Z',
+      endTime: '2026-05-02T00:00:01.000Z',
+      output: 'completed after eviction',
+    });
+    expect(generation?.body.input).toBeUndefined();
   });
 
   it('nests subagent model and tool observations under the subagent span', async () => {

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -607,17 +607,216 @@ describe('telemetry', () => {
     const generation = client.traces[0]?.spans[0]?.generations[0];
     expect(generation?.body).toMatchObject({
       name: 'llm-generation [main] [hello]',
+      startTime: '2026-05-02T00:00:00.100Z',
+      endTime: '2026-05-02T00:00:01.000Z',
       model: 'kimi-k2.5',
       input: 'hello',
-    });
-    const genUpdates = generation?.updates ?? [];
-    expect(genUpdates[genUpdates.length - 1]).toMatchObject({
       output: 'world',
-      endTime: '2026-05-02T00:00:01.000Z',
       level: 'DEFAULT',
       usage: { input: 10, output: 3, total: 16, unit: 'TOKENS' },
       usageDetails: { input: 10, output: 3, cache_read: 2, cache_write: 1, total: 16 },
     });
+    expect(generation?.updates).toHaveLength(0);
+  });
+
+  it('keeps generation start and terminal data in one SDK create event', async () => {
+    const client = new FakeLangfuseSdkClient();
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 20,
+        flushIntervalMs: 5_000,
+        includePayloads: true,
+      },
+      client,
+    );
+
+    await exporter.publish({
+      id: 'turn-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      createdAt: '2026-05-02T00:00:00.000Z',
+    });
+    await exporter.publish({
+      id: 'generation-start',
+      traceId,
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      llmGenerationId: 'call-1',
+      status: 'started',
+      createdAt: '2026-05-02T00:00:00.100Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      input: { messages: [{ role: 'user', content: 'hello' }] },
+    });
+
+    expect(client.traces[0]?.spans[0]?.generations).toHaveLength(0);
+
+    await exporter.publish({
+      id: 'generation-complete',
+      traceId,
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      llmGenerationId: 'call-1',
+      status: 'completed',
+      createdAt: '2026-05-02T00:00:01.000Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      output: 'world',
+      usage: { input: 10, output: 3, totalTokens: 13 },
+    });
+
+    const generation = client.traces[0]?.spans[0]?.generations[0];
+    expect(generation?.body).toMatchObject({
+      startTime: '2026-05-02T00:00:00.100Z',
+      endTime: '2026-05-02T00:00:01.000Z',
+      input: { messages: [{ role: 'user', content: 'hello' }] },
+      output: 'world',
+      usage: { input: 10, output: 3, total: 13, unit: 'TOKENS' },
+      metadata: { llmGenerationId: 'call-1', status: 'completed' },
+    });
+    expect(generation?.updates).toHaveLength(0);
+  });
+
+  it('keeps interleaved sessions isolated while completing generations', async () => {
+    const client = new FakeLangfuseSdkClient();
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 20,
+        flushIntervalMs: 5_000,
+        includePayloads: true,
+      },
+      client,
+    );
+    const otherTraceId = '22222222222222222222222222222222';
+
+    for (const [sessionId, sessionTraceId, input] of [
+      ['session-a', traceId, 'alpha'],
+      ['session-b', otherTraceId, 'beta'],
+    ] as const) {
+      await exporter.publish({
+        id: `turn-${sessionId}`,
+        traceId: sessionTraceId,
+        type: 'chat_turn_started',
+        sessionId,
+        conversationId: sessionId,
+        createdAt: '2026-05-02T00:00:00.000Z',
+      });
+      await exporter.publish({
+        id: `start-${sessionId}`,
+        traceId: sessionTraceId,
+        sessionId,
+        conversationId: sessionId,
+        llmGenerationId: 'call-1',
+        status: 'started',
+        createdAt: '2026-05-02T00:00:00.100Z',
+        model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+        input,
+      });
+    }
+
+    for (const [sessionId, sessionTraceId, output] of [
+      ['session-b', otherTraceId, 'beta-result'],
+      ['session-a', traceId, 'alpha-result'],
+    ] as const) {
+      await exporter.publish({
+        id: `complete-${sessionId}`,
+        traceId: sessionTraceId,
+        sessionId,
+        conversationId: sessionId,
+        llmGenerationId: 'call-1',
+        status: 'completed',
+        createdAt: '2026-05-02T00:00:01.000Z',
+        model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+        output,
+        usage: { input: 10, output: 2, totalTokens: 12 },
+      });
+    }
+
+    const generationBySession = new Map(
+      client.traces.map((candidate) => [
+        candidate.body.sessionId,
+        candidate.spans[0]?.generations[0],
+      ]),
+    );
+    expect(generationBySession.get('session-a')?.body).toMatchObject({
+      input: 'alpha',
+      output: 'alpha-result',
+      endTime: '2026-05-02T00:00:01.000Z',
+    });
+    expect(generationBySession.get('session-b')?.body).toMatchObject({
+      input: 'beta',
+      output: 'beta-result',
+      endTime: '2026-05-02T00:00:01.000Z',
+    });
+    expect(generationBySession.get('session-a')?.updates).toHaveLength(0);
+    expect(generationBySession.get('session-b')?.updates).toHaveLength(0);
+  });
+
+  it('creates one closed error generation when the provider request fails', async () => {
+    const client = new FakeLangfuseSdkClient();
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 20,
+        flushIntervalMs: 5_000,
+        includePayloads: true,
+      },
+      client,
+    );
+
+    await exporter.publish({
+      id: 'turn-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      createdAt: '2026-05-02T00:00:00.000Z',
+    });
+    await exporter.publish({
+      id: 'generation-start',
+      traceId,
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      llmGenerationId: 'call-1',
+      status: 'started',
+      createdAt: '2026-05-02T00:00:00.100Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      input: 'hello',
+    });
+    await exporter.publish({
+      id: 'generation-failed',
+      traceId,
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      llmGenerationId: 'call-1',
+      status: 'failed',
+      createdAt: '2026-05-02T00:00:01.000Z',
+      model: { provider: 'anthropic-compatible', model: 'kimi-k2.5' },
+      error: 'HTTP 503',
+    });
+
+    const generation = client.traces[0]?.spans[0]?.generations[0];
+    expect(generation?.body).toMatchObject({
+      startTime: '2026-05-02T00:00:00.100Z',
+      endTime: '2026-05-02T00:00:01.000Z',
+      input: 'hello',
+      output: { error: 'HTTP 503' },
+      level: 'ERROR',
+      statusMessage: 'HTTP 503',
+      metadata: { llmGenerationId: 'call-1', status: 'failed' },
+    });
+    expect(generation?.updates).toHaveLength(0);
   });
 
   it('nests subagent model and tool observations under the subagent span', async () => {

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -88,7 +88,10 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
   private readonly client: LangfuseSdkClient;
   private readonly traces = new Map<string, LangfuseSdkTraceClient>();
   private readonly spans = new Map<string, LangfuseSdkSpanClient>();
-  private readonly generations = new Map<string, LangfuseSdkGenerationClient>();
+  // Keep each start local until its terminal event so Langfuse receives one complete
+  // generation-create instead of separate create/update batches that can be merged out of order.
+  // A call that never reaches a terminal event is intentionally absent rather than permanently open.
+  private readonly pendingGenerations = new Map<string, RuntimeLlmGenerationEvent>();
 
   constructor(
     private readonly config: LangfuseExporterConfig,
@@ -321,47 +324,22 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
 
   private publishLlmGenerationEvent(event: RuntimeLlmGenerationEvent): void {
     const traceId = requireTraceId(event.traceId);
-    const trace = this.getOrCreateSdkTrace(event);
-    const rootKey = chatSpanKey(event);
-    const parent = this.getSdkEventParent(trace, rootKey, event);
     const key = llmGenerationKey(event);
-    const id = langfuseSpanId(traceId, key);
 
     if (event.status === 'started') {
-      const body = {
-        id,
-        name: llmGenerationObservationName(event),
-        startTime: event.createdAt,
-        model: event.model.model,
-        modelParameters: {
-          provider: event.model.provider,
-          ...(event.model.thinkingLevel ? { thinkingLevel: event.model.thinkingLevel } : {}),
-        },
-        input: event.input,
-        metadata: llmGenerationMetadata(event),
-      };
-      const generation = this.generations.get(key);
-      if (generation) {
-        generation.update({
-          input: event.input,
-          metadata: llmGenerationMetadata(event),
-        });
-      } else {
-        this.generations.set(key, parent.generation(body));
-      }
+      this.pendingGenerations.set(key, event);
       return;
     }
 
-    const generation =
-      this.generations.get(key) ??
-      parent.generation({
-        id,
-        name: llmGenerationObservationName(event),
-        startTime: event.createdAt,
-        model: event.model.model,
-        metadata: llmGenerationMetadata(event),
-      });
-    generation.update({
+    const started = this.pendingGenerations.get(key);
+    const trace = this.getOrCreateSdkTrace(event);
+    const rootKey = chatSpanKey(event);
+    const parent = this.getSdkEventParent(trace, rootKey, event);
+    parent.generation({
+      id: langfuseSpanId(traceId, key),
+      name: llmGenerationObservationName(started ?? event),
+      startTime: started?.createdAt ?? event.createdAt,
+      input: started?.input,
       output: event.output ?? (event.error ? { error: event.error } : undefined),
       endTime: event.createdAt,
       level: event.error ? 'ERROR' : 'DEFAULT',
@@ -376,7 +354,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
       },
       metadata: llmGenerationMetadata(event),
     });
-    this.generations.delete(key);
+    this.pendingGenerations.delete(key);
   }
 
   private getOrCreateSdkTrace(event: RuntimeTelemetryEvent): LangfuseSdkTraceClient {

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -134,6 +134,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
   }
 
   async close(): Promise<void> {
+    this.reportPendingGenerationDrops('exporter close', this.pendingGenerations.size);
     this.pendingGenerations.clear();
     await this.client.shutdownAsync();
   }
@@ -377,6 +378,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
       const oldestKey = this.pendingGenerations.keys().next().value;
       if (oldestKey !== undefined) {
         this.pendingGenerations.delete(oldestKey);
+        this.reportPendingGenerationDrops('capacity eviction', 1);
       }
     }
     this.pendingGenerations.set(key, event);
@@ -384,11 +386,23 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
 
   private clearPendingGenerationsForLifecycle(event: RuntimeLifecycleEvent): void {
     const generationSessionId = event.childSessionId ?? event.sessionId;
+    let dropped = 0;
     for (const [key, pending] of this.pendingGenerations) {
       if (pending.traceId === event.traceId && pending.sessionId === generationSessionId) {
         this.pendingGenerations.delete(key);
+        dropped += 1;
       }
     }
+    this.reportPendingGenerationDrops('lifecycle cleanup', dropped);
+  }
+
+  private reportPendingGenerationDrops(reason: string, count: number): void {
+    if (count === 0) {
+      return;
+    }
+    console.error(
+      `[pi-telemetry] dropped ${count} pending Langfuse generation start${count === 1 ? '' : 's'} during ${reason}; late terminal events will be output-only`,
+    );
   }
 
   private getOrCreateSdkTrace(event: RuntimeTelemetryEvent): LangfuseSdkTraceClient {

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -83,6 +83,7 @@ type OtelAttributeValue =
 const DEFAULT_LANGFUSE_BASE_URL = 'https://cloud.langfuse.com';
 const DEFAULT_FLUSH_AT = 20;
 const DEFAULT_FLUSH_INTERVAL_MS = 5000;
+const MAX_PENDING_GENERATIONS = 128;
 
 export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
   private readonly client: LangfuseSdkClient;
@@ -133,6 +134,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
   }
 
   async close(): Promise<void> {
+    this.pendingGenerations.clear();
     await this.client.shutdownAsync();
   }
 
@@ -179,6 +181,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
       }
       case 'chat_turn_completed':
       case 'chat_turn_failed': {
+        this.clearPendingGenerationsForLifecycle(event);
         const output = event.details?.output ?? (event.error ? { error: event.error } : undefined);
         this.closeSdkSubagentBatchSpans(traceId, event);
         trace.update({
@@ -248,6 +251,7 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
       case 'subagent_completed':
       case 'subagent_failed':
       case 'subagent_cancelled': {
+        this.clearPendingGenerationsForLifecycle(event);
         const key = subagentSpanKey(event);
         const output = event.details?.output ?? (event.error ? { error: event.error } : undefined);
         this.ensureSdkRootSpan(trace, rootKey, event);
@@ -327,34 +331,64 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
     const key = llmGenerationKey(event);
 
     if (event.status === 'started') {
-      this.pendingGenerations.set(key, event);
+      this.rememberPendingGeneration(key, event);
       return;
     }
 
     const started = this.pendingGenerations.get(key);
+    const source = started ?? event;
+    const model = source.model;
     const trace = this.getOrCreateSdkTrace(event);
     const rootKey = chatSpanKey(event);
     const parent = this.getSdkEventParent(trace, rootKey, event);
-    parent.generation({
-      id: langfuseSpanId(traceId, key),
-      name: llmGenerationObservationName(started ?? event),
-      startTime: started?.createdAt ?? event.createdAt,
-      input: started?.input,
-      output: event.output ?? (event.error ? { error: event.error } : undefined),
-      endTime: event.createdAt,
-      level: event.error ? 'ERROR' : 'DEFAULT',
-      ...(event.error ? { statusMessage: event.error } : {}),
-      ...(event.usage
-        ? { usage: toLangfuseUsage(event.usage), usageDetails: toLangfuseUsageDetails(event.usage) }
-        : {}),
-      model: event.model.model,
-      modelParameters: {
-        provider: event.model.provider,
-        ...(event.model.thinkingLevel ? { thinkingLevel: event.model.thinkingLevel } : {}),
-      },
-      metadata: llmGenerationMetadata(event),
-    });
-    this.pendingGenerations.delete(key);
+    try {
+      parent.generation({
+        id: langfuseSpanId(traceId, key),
+        name: llmGenerationObservationName(source),
+        startTime: source.createdAt,
+        input: source.input,
+        output: event.output ?? (event.error ? { error: event.error } : undefined),
+        endTime: event.createdAt,
+        level: event.error ? 'ERROR' : 'DEFAULT',
+        ...(event.error ? { statusMessage: event.error } : {}),
+        ...(event.usage
+          ? {
+              usage: toLangfuseUsage(event.usage),
+              usageDetails: toLangfuseUsageDetails(event.usage),
+            }
+          : {}),
+        model: model.model,
+        modelParameters: {
+          provider: model.provider,
+          ...(model.thinkingLevel ? { thinkingLevel: model.thinkingLevel } : {}),
+        },
+        metadata: llmGenerationMetadata({ ...event, model }),
+      });
+    } finally {
+      this.pendingGenerations.delete(key);
+    }
+  }
+
+  private rememberPendingGeneration(key: string, event: RuntimeLlmGenerationEvent): void {
+    if (
+      !this.pendingGenerations.has(key) &&
+      this.pendingGenerations.size >= MAX_PENDING_GENERATIONS
+    ) {
+      const oldestKey = this.pendingGenerations.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.pendingGenerations.delete(oldestKey);
+      }
+    }
+    this.pendingGenerations.set(key, event);
+  }
+
+  private clearPendingGenerationsForLifecycle(event: RuntimeLifecycleEvent): void {
+    const generationSessionId = event.childSessionId ?? event.sessionId;
+    for (const [key, pending] of this.pendingGenerations) {
+      if (pending.traceId === event.traceId && pending.sessionId === generationSessionId) {
+        this.pendingGenerations.delete(key);
+      }
+    }
   }
 
   private getOrCreateSdkTrace(event: RuntimeTelemetryEvent): LangfuseSdkTraceClient {


### PR DESCRIPTION
## Summary

- 根因：`pi-telemetry` 在 `started` 时发送 `generation-create`，在 `completed/failed` 时发送 `generation-update`。长于 5 秒的首轮请求会触发 Langfuse SDK 自动 flush，而 terminal flush 不能串行等待先前 ingestion；两个事件进入不同 Server worker 后可乱序合并，较晚写入的 start-only 记录会覆盖已闭合记录，留下 `endTime=null` 和空 usage。
- 原子闭合：先在 exporter 内保存已脱敏的 start 事件，收到 terminal 后用稳定 observation id 一次发送包含 `startTime/endTime/input/output/usage/model/terminal metadata` 的完整 `generation-create`，不再依赖跨批次 update 合并。
- 模型归因：完整记录优先使用实际发起请求时的 model/provider/thinkingLevel，并让 Generation 字段与 metadata 保持一致；terminal-only fallback 继续使用 terminal 模型。
- 内存边界：正常 terminal、chat turn/subagent 终态和 exporter close 都会删除 pending start；另设 128 条硬上限。被清理或驱逐的 start 若随后收到 terminal，仍降级为闭合的 output-only Generation，不形成永久 open 记录。
- 降级诊断：只有 lifecycle cleanup、exporter close 或容量驱逐实际丢弃 pending start 时，才在 stderr 输出带 `[pi-telemetry]` 前缀的 counts-only 诊断；不记录 payload、session 或模型信息。
- 边界：运行中的 Generation 在 terminal 前不会出现在 Langfuse；进程崩溃前未收到 terminal 的调用保持未导出。Pi runtime event 与 OTEL exporter 行为不变。
- 测试：覆盖 completed、failed、两个 session 交错完成、start 模型归因、字段合并、不再调用 generation update、chat/subagent/close 清理、容量上限、诊断和 output-only 降级。

## Verification

- `pnpm --filter @amaster.ai/pi-telemetry test` — 3 files / 65 tests passed
- `pnpm --filter @amaster.ai/pi-telemetry typecheck`
- `pnpm --filter @amaster.ai/pi-telemetry build`
- `pnpm exec biome check packages/pi-telemetry/src/langfuse.ts packages/pi-telemetry/src/__tests__/index.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test` — 126/127 files、1846/1847 tests passed；唯一失败是既有环境相关用例 `pi-dingtalk ... passes credentials as process arguments...`：本机存在 `~/.dws/node_modules/.bin/dws`，实际解析为绝对路径而测试固定期望 `dws`。本 PR 未修改 DingTalk 路径，隔离复跑稳定相同。
- 本机 package-equivalent runtime 以修复后的 `dist` 并发重放 Product/Growth short-kernel 同形任务：
  - B9-38 Growth：单 run 成功、8 Generations、`unfinished=0`、`emptyUsage=0`；Trace `bf28dd1da44cf7577cd9c39bb309e356`
  - B9-39 Product：单 run 成功、9 Generations、`unfinished=0`、`emptyUsage=0`；Trace `9e7956bbbc3b7524d469c970fb227eff`
  - 两 run 启动相差 28ms、重叠约 103.8s；两边均命中精确 Agent selector + source SHA，Delivery Manifest ready，Server 自动终态 `done`。

## Checklist

- [x] I read the applicable `AGENTS.md` files for every changed path.
- [x] This PR contains no unrelated refactors or generated files.
- [x] Behavior and configuration changes include relevant tests, or the reason they do not is explained above.
- [x] Public tool, command, setting, or user-facing behavior changes include the corresponding documentation and prompt guidance.
