### PR TITLE
docs: document DSH hosts and standardize Markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -6,13 +6,18 @@ labels: ''
 assignees: ''
 ---
 
+## Self-check
+
+- [ ] I searched open and closed issues for duplicates.
+- [ ] This issue covers one focused problem or request.
+
 ## Package and version
 
-<!-- Example: @amaster.ai/pi-memory@1.2.3 -->
+<!-- Required for bugs when applicable. Example: @amaster.ai/pi-memory@1.2.3. Omit for repository-wide changes. -->
 
-## Problem
+## Problem or motivation
 
-<!-- What is wrong or missing? -->
+<!-- What is wrong or missing, and why does it matter? -->
 
 ## Expected outcome
 
@@ -20,4 +25,4 @@ assignees: ''
 
 ## Reproduction or context
 
-<!-- Minimal steps, examples, or links needed to act. Omit if not applicable. -->
+<!-- For bugs: minimal steps and actual behavior. For proposals: examples, screenshots, or links. Omit if not applicable. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
-## Packages and versions
-
-<!-- Example: @amaster.ai/pi-memory: 1.2.3 -> 1.2.4, or 1.2.3 (unchanged). Write "none" only when not package-scoped. -->
+> [!IMPORTANT]
+> Link the related issue with `Fixes #123` when this PR resolves it, or `Refs #123` when it only provides context.
 
 ## Summary
 
@@ -12,7 +11,7 @@
 
 ## Related issue
 
-<!-- Fixes #123. Omit this section when there is no related issue. -->
+<!-- Fixes #123 or Refs #123. Omit this section when there is no related issue. -->
 
 ## Checklist
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,8 +345,8 @@ Rules:
 
 - Before drafting or opening an issue, read and follow `.github/ISSUE_TEMPLATE/issue.md`; before drafting or opening a pull request, read and follow `.github/pull_request_template.md`.
 - Keep titles specific and bodies brief. Include only the context needed to understand, reproduce, or review the work; link to longer logs or design notes instead of copying them.
-- Issues should identify the affected package and version, then state the problem, expected outcome, and minimal reproduction or context. Omit sections that do not apply.
-- Pull requests should list affected packages and their current and resulting versions, summarize what changed and why, list verification performed, and reference the related issue when one exists. Mark unchanged versions explicitly; write `none` only when the change is not package-scoped. Use the conventional-commit title prefix recognized by `.github/workflows/labeler.yml`.
+- Issues should identify the affected package and version when applicable, then state the problem or motivation, expected outcome, and minimal reproduction or context. Omit sections that do not apply.
+- Pull requests should summarize what changed and why, list verification performed, and reference the related issue when one exists. Use the conventional-commit title prefix recognized by `.github/workflows/labeler.yml`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -333,6 +333,7 @@ Rules:
 ## Implementation Discipline
 
 - Before modifying code, look at the same package's existing patterns first — match style, naming, structure
+- Do not hard-wrap Markdown prose. Keep each paragraph on one source line; use line breaks only for Markdown structure such as lists, tables, blockquotes, and code fences.
 - Do not make cross-package refactors unrelated to the current task
 - New config keys must have corresponding test coverage
 - Modifying a public tool or command's parameters requires updating its tests and README; update `promptSnippet` and `promptGuidelines` when the user-facing behavior or tool selection guidance changes

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@
 
 Shared TypeScript packages for Pi runtime applications.
 
-This repository contains the open-source runtime contracts, adapters, and
-orchestration helpers that are consumed by Pi Agent and related applications.
-The packages are intentionally small and composable: host applications provide
-HTTP routing, authentication, model runtime setup, deployment configuration, and
-product-specific UI.
+This repository contains the open-source runtime contracts, adapters, and orchestration helpers that are consumed by Pi Agent and related applications. The packages are intentionally small and composable: host applications provide HTTP routing, authentication, model runtime setup, deployment configuration, and product-specific UI.
 
 ## Packages
 
@@ -33,9 +29,7 @@ product-specific UI.
 | Extension | `@amaster.ai/pi-wecom` | WeCom workspace integration through wecom-cli, including contacts, messages, meetings, schedules, todos, docs, and smart sheets. |
 | Extension | `@amaster.ai/pi-dingtalk` | DingTalk workspace integration through dws CLI, including calendar, docs, chat, todos, sheets, AI tables, approvals, mail, wiki, and meeting minutes. |
 
-Core packages provide types and persistence used by every host application.
-Extension packages each register Pi runtime extensions via their `./extension`
-subpath entry point and are loaded on demand.
+Core packages provide types and persistence used by every host application. Extension packages each register Pi runtime extensions via their `./extension` subpath entry point and are loaded on demand.
 
 Every package is ESM-only and published under the `@amaster.ai` npm scope.
 
@@ -108,9 +102,7 @@ pnpm test
 pnpm --filter @amaster.ai/pi-storage prisma:generate
 ```
 
-`@amaster.ai/pi-storage` includes a Prisma schema at
-`packages/storage/prisma/schema.prisma`. The root `build` and `typecheck`
-scripts generate the Prisma client before compiling project references.
+`@amaster.ai/pi-storage` includes a Prisma schema at `packages/storage/prisma/schema.prisma`. The root `build` and `typecheck` scripts generate the Prisma client before compiling project references.
 
 ## Consuming Packages
 
@@ -120,8 +112,7 @@ Install only the packages your application needs:
 pnpm add @amaster.ai/pi-shared @amaster.ai/pi-storage
 ```
 
-Most packages expose a root entry point. Some packages also expose focused
-subpath entry points:
+Most packages expose a root entry point. Some packages also expose focused subpath entry points:
 
 ```ts
 import { createRuntimeStorage } from "@amaster.ai/pi-storage";
@@ -132,9 +123,7 @@ import { createOtelExporter } from "@amaster.ai/pi-telemetry/otel";
 import memoryExtension from "@amaster.ai/pi-memory/extension";
 ```
 
-Extension packages register themselves through their `./extension` subpath
-entry point. Host applications import these and pass them to the Pi runtime
-during setup.
+Extension packages register themselves through their `./extension` subpath entry point. Host applications import these and pass them to the Pi runtime during setup.
 
 See each package README for package-specific examples and public API notes.
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ during setup.
 
 See each package README for package-specific examples and public API notes.
 
+## DeepSeek Harness
+
+Compatibility depends on the host, DSH, Pi, and extension versions. Follow the selected host's documentation for installation and current support.
+
+| Host | Loading model |
+| --- | --- |
+| [pi2dsh](https://github.com/weijiafu14/pi2dsh) | Discovers explicitly installed Pi packages in a DSH profile. |
+| [dsh-pi-host](https://github.com/TGYD-helige/dsh-pi) | Loads package names configured in its `extensions` list. |
+
 ## License
 
 Apache-2.0

--- a/packages/pi-browser-use/README.md
+++ b/packages/pi-browser-use/README.md
@@ -41,8 +41,7 @@ bun add @amaster.ai/pi-browser-use
 
 Configure via `.pi/settings.json` (project-level) or `~/.pi/agent/settings.json` (user-level) under the `"pi-browser-use"` key:
 
-Project settings are loaded only after project trust is accepted. `${ENV_VAR}`
-interpolation is supported in user and agent settings, but not in project settings.
+Project settings are loaded only after project trust is accepted. `${ENV_VAR}` interpolation is supported in user and agent settings, but not in project settings.
 
 ```json
 {

--- a/packages/pi-channels/README.md
+++ b/packages/pi-channels/README.md
@@ -4,24 +4,13 @@
 
 Pi extension for native messaging channels.
 
-This package follows the same extension shape as the open-source `@e9n/pi-channels`
-package: it registers a `notify` tool, channel events, route aliases, and an optional
-chat bridge that turns incoming channel messages into pi prompts.
+This package follows the same extension shape as the open-source `@e9n/pi-channels` package: it registers a `notify` tool, channel events, route aliases, and an optional chat bridge that turns incoming channel messages into pi prompts.
 
-It does not depend on `@e9n/pi-channels` at runtime. That package is published as
-a standalone extension source package with the older `@mariozechner/*` peer
-namespace and Slack/Telegram dependencies. This package keeps the same channel
-contract while targeting this repo's `@earendil-works/*` API surface and native
-Feishu/DingTalk/WeCom adapters.
+It does not depend on `@e9n/pi-channels` at runtime. That package is published as a standalone extension source package with the older `@mariozechner/*` peer namespace and Slack/Telegram dependencies. This package keeps the same channel contract while targeting this repo's `@earendil-works/*` API surface and native Feishu/DingTalk/WeCom adapters.
 
 ## Configuration
 
-Put the `pi-channels` section in `~/.pi/agent/settings.json`, the configured
-agent directory's `settings.json`, or a project/ancestor `.pi/settings.json`.
-Project-local files are read only after project trust is accepted. `${ENV_VAR}`
-interpolation is supported only in user and agent settings, not in project-local
-files. The direct credential environment variables documented in the examples
-still override loaded adapter values.
+Put the `pi-channels` section in `~/.pi/agent/settings.json`, the configured agent directory's `settings.json`, or a project/ancestor `.pi/settings.json`. Project-local files are read only after project trust is accepted. `${ENV_VAR}` interpolation is supported only in user and agent settings, not in project-local files. The direct credential environment variables documented in the examples still override loaded adapter values.
 
 ## Channels
 
@@ -39,9 +28,7 @@ still override loaded adapter values.
 
 ## Example
 
-The `${...}` placeholders below assume this section is stored in user or agent
-settings. For trusted project settings, use the corresponding direct credential
-environment variables or literal non-secret values.
+The `${...}` placeholders below assume this section is stored in user or agent settings. For trusted project settings, use the corresponding direct credential environment variables or literal non-secret values.
 
 ```json
 {
@@ -85,8 +72,7 @@ environment variables or literal non-secret values.
 
 ### Feishu modes
 
-WebSocket is the default and recommended mode because it does not require a
-public callback URL:
+WebSocket is the default and recommended mode because it does not require a public callback URL:
 
 ```json
 {
@@ -99,10 +85,7 @@ public callback URL:
 }
 ```
 
-Use HTTP callback mode when the deployment already exposes a Feishu event URL.
-The SDK handles challenge responses, token verification, and encrypted event
-payloads. `encryptKey` is required in HTTP mode because it is used to verify
-ordinary event signatures; `verificationToken` alone is not sufficient:
+Use HTTP callback mode when the deployment already exposes a Feishu event URL. The SDK handles challenge responses, token verification, and encrypted event payloads. `encryptKey` is required in HTTP mode because it is used to verify ordinary event signatures; `verificationToken` alone is not sufficient:
 
 ```json
 {
@@ -124,8 +107,7 @@ Set `"eventMode": "off"` for outgoing-only usage.
 
 ### DingTalk modes
 
-Create a DingTalk internal app, add the bot capability, select Stream mode, and
-publish it. Copy the Client ID and Client Secret into the adapter config:
+Create a DingTalk internal app, add the bot capability, select Stream mode, and publish it. Copy the Client ID and Client Secret into the adapter config:
 
 ```json
 {
@@ -139,16 +121,13 @@ publish it. Copy the Client ID and Client Secret into the adapter config:
 }
 ```
 
-Incoming replies use the per-message `sessionWebhook` when available. Active
-route sends use DingTalk's group message OpenAPI with the route recipient as the
-conversation/openConversationId. `robotCode` defaults to `clientId` when omitted.
+Incoming replies use the per-message `sessionWebhook` when available. Active route sends use DingTalk's group message OpenAPI with the route recipient as the conversation/openConversationId. `robotCode` defaults to `clientId` when omitted.
 
 Set `"eventMode": "off"` when the bot should only send messages.
 
 ### WeCom modes
 
-Create an intelligent bot in the WeCom admin console, choose API mode, and select
-the long connection option. Copy the Bot ID and Secret into the adapter config:
+Create an intelligent bot in the WeCom admin console, choose API mode, and select the long connection option. Copy the Bot ID and Secret into the adapter config:
 
 ```json
 {
@@ -170,8 +149,7 @@ notify(action: "list")
 notify(action: "test", adapter: "ops")
 ```
 
-For Feishu, recipients default to `chat_id`. Prefix the recipient to override the
-receive id type:
+For Feishu, recipients default to `chat_id`. Prefix the recipient to override the receive id type:
 
 ```text
 chat_id:oc_xxx
@@ -180,20 +158,16 @@ user_id:abc123
 email:name@example.com
 ```
 
-For WeCom intelligent bots, recipients are the conversation ids used by the Bot
-API. In a group, send one message to the bot and use route capture to fill the
-group `chatid`; for one-to-one pushes, use the target user's userid:
+For WeCom intelligent bots, recipients are the conversation ids used by the Bot API. In a group, send one message to the bot and use route capture to fill the group `chatid`; for one-to-one pushes, use the target user's userid:
 
 ```text
 wr_xxx
 zhangsan
 ```
 
-The intelligent bot adapter uses the WebSocket Bot API, so long connection mode
-does not require a public callback URL.
+The intelligent bot adapter uses the WebSocket Bot API, so long connection mode does not require a public callback URL.
 
-For DingTalk app bots, send one message to the bot and use route capture to fill
-the group conversation id:
+For DingTalk app bots, send one message to the bot and use route capture to fill the group conversation id:
 
 ```text
 cid_xxx

--- a/packages/pi-computer-use/README.md
+++ b/packages/pi-computer-use/README.md
@@ -2,10 +2,7 @@
 
 ![pi-computer-use preview](https://raw.githubusercontent.com/TGYD-helige/pi/master/packages/pi-computer-use/preview.png)
 
-Cross-platform computer-use tools for Pi desktop automation. The extension
-exposes a native MCP tool surface with a `computer_use_` prefix. The bundled
-runtime comes from the official
-[Cua Driver Rust 0.9.0 release](https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.9.0).
+Cross-platform computer-use tools for Pi desktop automation. The extension exposes a native MCP tool surface with a `computer_use_` prefix. The bundled runtime comes from the official [Cua Driver Rust 0.9.0 release](https://github.com/trycua/cua/releases/tag/cua-driver-rs-v0.9.0).
 
 ## What it provides
 
@@ -20,9 +17,7 @@ runtime comes from the official
 - Bounded text and structured results before they enter Pi's context
 - Optional secondary vision analysis through a configured Pi model
 
-`get_window_state` is the primary perception tool. Cua Driver 0.9 returns the
-accessibility tree, structured elements with `element_token`, and a screenshot in
-one response. The standalone `screenshot` tool no longer exists.
+`get_window_state` is the primary perception tool. Cua Driver 0.9 returns the accessibility tree, structured elements with `element_token`, and a screenshot in one response. The standalone `screenshot` tool no longer exists.
 
 ## Install
 
@@ -30,15 +25,13 @@ one response. The standalone `screenshot` tool no longer exists.
 bun add @amaster.ai/pi-computer-use
 ```
 
-The package bundles signed/precompiled driver assets. No separate Cua Driver
-installation is required.
+The package bundles signed/precompiled driver assets. No separate Cua Driver installation is required.
 
 ## Configuration
 
 Configure `.pi/settings.json` or `~/.pi/agent/settings.json`:
 
-Project settings are loaded only after project trust is accepted. `${ENV_VAR}`
-interpolation is supported in user and agent settings, but not in project settings.
+Project settings are loaded only after project trust is accepted. `${ENV_VAR}` interpolation is supported in user and agent settings, but not in project settings.
 
 ```json
 {
@@ -59,8 +52,7 @@ interpolation is supported in user and agent settings, but not in project settin
 | `confirmDangerousActions` | `boolean` | `true` | Confirm high-risk tools such as `kill_app` and `replay_trajectory`; recording always requires confirmation |
 | `visionModel` | `{ provider, model }` | — | Register `computer_use_analyze_screenshot` |
 
-In non-interactive modes, confirmation-required tools return an error unless the
-corresponding confirmation setting is explicitly disabled.
+In non-interactive modes, confirmation-required tools return an error unless the corresponding confirmation setting is explicitly disabled.
 
 ### Optional vision model
 
@@ -75,29 +67,13 @@ corresponding confirmation setting is explicitly disabled.
 }
 ```
 
-`computer_use_analyze_screenshot` requires both `pid` and `window_id`. It calls
-`get_window_state`, reuses the returned image, and invokes the configured model.
-Use it only when the primary model cannot resolve visual ambiguity.
+`computer_use_analyze_screenshot` requires both `pid` and `window_id`. It calls `get_window_state`, reuses the returned image, and invokes the configured model. Use it only when the primary model cannot resolve visual ambiguity.
 
 ## Runtime and permissions
 
-On macOS, `session_start` registers the generated 0.9.0 manifest without
-starting the driver. The signed app and MCP proxy start lazily on the first
-computer-use tool call, which requests any missing permissions through
-`check_permissions({ prompt: true })`. Existing grants do not raise another
-system dialog. The requested tool still runs and reports its own capability or
-permission error. Linux and Windows keep eager startup: they discover the exact
-live `tools/list` surface and call
-`check_permissions({ prompt: false })`. If discovery fails, the extension
-registers `computer_use_connect` (and `/computer-use-connect`) so a later retry
-can install the exact live platform contract without advertising another OS's
-schemas.
+On macOS, `session_start` registers the generated 0.9.0 manifest without starting the driver. The signed app and MCP proxy start lazily on the first computer-use tool call, which requests any missing permissions through `check_permissions({ prompt: true })`. Existing grants do not raise another system dialog. The requested tool still runs and reports its own capability or permission error. Linux and Windows keep eager startup: they discover the exact live `tools/list` surface and call `check_permissions({ prompt: false })`. If discovery fails, the extension registers `computer_use_connect` (and `/computer-use-connect`) so a later retry can install the exact live platform contract without advertising another OS's schemas.
 
-Driver startup, reconnect, and the first macOS permission probe are session-owned.
-Cancelling a tool stops only that caller's wait or MCP request; session shutdown
-aborts the shared work. macOS and Linux also use a transient pipe-backed lease to
-stop the owned daemon after an abrupt host exit; no persistent service or system
-scheduler is installed.
+Driver startup, reconnect, and the first macOS permission probe are session-owned. Cancelling a tool stops only that caller's wait or MCP request; session shutdown aborts the shared work. macOS and Linux also use a transient pipe-backed lease to stop the owned daemon after an abrupt host exit; no persistent service or system scheduler is installed.
 
 - **Bundled macOS:** launches the signed `CuaDriver.app` through LaunchServices,
   so Accessibility and Screen Recording grants belong to `com.trycua.driver`.
@@ -126,10 +102,8 @@ scheduler is installed.
 5. Re-run `computer_use_get_window_state` and verify the change
 6. `computer_use_end_session`
 
-Linux and Windows tool descriptions and schemas come from the exact live driver.
-macOS uses the generated manifest for the bundled driver release.
+Linux and Windows tool descriptions and schemas come from the exact live driver. macOS uses the generated manifest for the bundled driver release.
 
 ## License
 
-Apache-2.0 for this package. Bundled Cua Driver assets retain their upstream
-license and release metadata.
+Apache-2.0 for this package. Bundled Cua Driver assets retain their upstream license and release metadata.

--- a/packages/pi-dingtalk/README.md
+++ b/packages/pi-dingtalk/README.md
@@ -14,9 +14,7 @@ Pi extension for [DingTalk](https://www.dingtalk.com/) workspace — calendar, d
 
 Add to `~/.pi/agent/settings.json` or a trusted project's `.pi/settings.json`:
 
-Project settings are loaded only after project trust is accepted. For
-environment-backed credentials, use user or agent settings because project
-settings do not expand `${ENV_VAR}`.
+Project settings are loaded only after project trust is accepted. For environment-backed credentials, use user or agent settings because project settings do not expand `${ENV_VAR}`.
 
 ```json
 {

--- a/packages/pi-goal/README.md
+++ b/packages/pi-goal/README.md
@@ -20,8 +20,7 @@ Goal state is session-scoped and held in memory (no cross-session persistence), 
 
 ## Pi lifecycle (how the engine hooks in)
 
-The goal engine is driven by Pi's lifecycle events. For one `pi -p '<prompt>'`
-run (non-interactive), events fire in this order:
+The goal engine is driven by Pi's lifecycle events. For one `pi -p '<prompt>'` run (non-interactive), events fire in this order:
 
 ```
 session_start                                 ← session-level, once
@@ -62,13 +61,9 @@ Events pi-goal uses:
 | `agent_end` | If a goal is active, run the engine on `event.messages`: evaluate → mark achieved/impossible or `sendUserMessage` to continue | Engine core. `event.messages` is the full conversation, so no separate buffering is needed |
 | `session_shutdown` | Clear the goal | Cleanup |
 
-The interactive `/goal` command (no argument) derives from the session's own
-history, read via `ctx.sessionManager` — not a buffer this extension maintains.
+The interactive `/goal` command (no argument) derives from the session's own history, read via `ctx.sessionManager` — not a buffer this extension maintains.
 
-Note on derivation timing: a condition can only be derived once there is
-conversation to derive from. `session_start` is too early (no transcript
-yet); `before_agent_start` is the first point that carries the user's prompt
-for the turn, so auto-derivation keys off it rather than firing at startup.
+Note on derivation timing: a condition can only be derived once there is conversation to derive from. `session_start` is too early (no transcript yet); `before_agent_start` is the first point that carries the user's prompt for the turn, so auto-derivation keys off it rather than firing at startup.
 
 ## Usage
 
@@ -79,8 +74,7 @@ for the turn, so auto-derivation keys off it rather than firing at startup.
 /goal clear         Clear the active goal (also: stop, off, reset, none, cancel).
 ```
 
-The slash command is for interactive (TUI) use; print mode can't dispatch it.
-For the CLI / non-interactive runs, use the `--goal` flag instead:
+The slash command is for interactive (TUI) use; print mode can't dispatch it. For the CLI / non-interactive runs, use the `--goal` flag instead:
 
 ```
 pi --goal '<condition>' -p '<prompt>'   Set an explicit goal, then run the prompt.
@@ -89,9 +83,7 @@ pi --goal '' -p '<prompt>'              Derive the goal from the prompt (at befo
 
 ## Configuration
 
-Settings key: `pi-goal` (in `~/.pi/agent/settings.json`, agent dir, or project `.pi/settings.json`).
-Project settings are loaded only after project trust is accepted. Environment-variable
-interpolation is available in user and agent settings, but not in project settings.
+Settings key: `pi-goal` (in `~/.pi/agent/settings.json`, agent dir, or project `.pi/settings.json`). Project settings are loaded only after project trust is accepted. Environment-variable interpolation is available in user and agent settings, but not in project settings.
 
 ```json
 {

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -109,6 +109,15 @@ In global and agent settings, `apiKey`, `baseUrl`, and `headers` values support
 form (for example, `${FOO:-default}`); `$FOO:-default` is not supported.
 Project settings keep all of these placeholders literal.
 
+## DeepSeek Harness
+
+| Host | `pi-image-gen` status |
+| --- | --- |
+| [pi2dsh](https://github.com/weijiafu14/pi2dsh) | `@amaster.ai/pi-image-gen@0.1.8` was exercised against a controlled OpenAI-compatible endpoint ([scope and evidence](https://github.com/TGYD-helige/pi/issues/159)). |
+| [dsh-pi-host](https://github.com/TGYD-helige/dsh-pi) | Loads `@amaster.ai/pi-image-gen` when selected in its `extensions` list. |
+
+Follow the selected host's documentation for installation and current compatibility details.
+
 ## Built-in setup walkthrough
 
 ### 1. OpenAI (`gpt-image-2`)

--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -43,9 +43,7 @@ Settings are read by `pi-shared`'s `loadPiSettings`, which merges three files (l
 2. `$PI_AGENT_HOME/settings.json` (agent dir, if `PI_AGENT_HOME` is set)
 3. `<cwd>/.pi/settings.json` (trusted project)
 
-Project settings are ignored when project trust is declined. `${ENV_VAR}`
-interpolation is supported in global and agent settings only, so keep
-environment-backed credentials out of project settings.
+Project settings are ignored when project trust is declined. `${ENV_VAR}` interpolation is supported in global and agent settings only, so keep environment-backed credentials out of project settings.
 
 All settings live under the `pi-image-gen` key. The minimum viable config sets `defaultModel`:
 
@@ -104,10 +102,7 @@ That's it. From the agent: `image_generate({ prompt: "a cyberpunk cat" })`.
 | `providers`       | Per-built-in-provider override. Set `apiKey`, `baseUrl`, or `headers` to point at a proxy or non-standard env var. |
 | `customProviders` | User-defined providers — see below.                                                      |
 
-In global and agent settings, `apiKey`, `baseUrl`, and `headers` values support
-`$VAR` and `${VAR}` environment interpolation. Fallbacks require the braced
-form (for example, `${FOO:-default}`); `$FOO:-default` is not supported.
-Project settings keep all of these placeholders literal.
+In global and agent settings, `apiKey`, `baseUrl`, and `headers` values support `$VAR` and `${VAR}` environment interpolation. Fallbacks require the braced form (for example, `${FOO:-default}`); `$FOO:-default` is not supported. Project settings keep all of these placeholders literal.
 
 ## DeepSeek Harness
 

--- a/packages/pi-lark/README.md
+++ b/packages/pi-lark/README.md
@@ -14,9 +14,7 @@ Pi extension for [Lark/Feishu](https://www.feishu.cn/) workspace — calendar, d
 
 Add to `~/.pi/agent/settings.json` or a trusted project's `.pi/settings.json`:
 
-Project settings are loaded only after project trust is accepted. For
-environment-backed credentials, use user or agent settings because project
-settings do not expand `${ENV_VAR}`.
+Project settings are loaded only after project trust is accepted. For environment-backed credentials, use user or agent settings because project settings do not expand `${ENV_VAR}`.
 
 ```json
 {

--- a/packages/pi-memory-mem0/README.md
+++ b/packages/pi-memory-mem0/README.md
@@ -60,10 +60,7 @@ User ←→ Agent ←→ Mem0 OSS Memory
 
 ## Quick Start
 
-Store configuration in user/agent settings or in a trusted project's
-`.pi/settings.json`. Project settings are ignored when trust is declined and do
-not expand `${ENV_VAR}`; the environment-backed examples below therefore belong
-in user or agent settings.
+Store configuration in user/agent settings or in a trusted project's `.pi/settings.json`. Project settings are ignored when trust is declined and do not expand `${ENV_VAR}`; the environment-backed examples below therefore belong in user or agent settings.
 
 ### Platform Mode
 
@@ -255,9 +252,7 @@ mem0_memory(action="get_all")                    # List every stored memory
 mem0_memory(action="delete", memory_id="...")    # Remove a memory by id
 ```
 
-Stored content is credential-redacted first; results are returned with the same
-`[UNTRUSTED MEMORY DATA]` wrapping as passive recall, including the memory ids
-needed for `delete`.
+Stored content is credential-redacted first; results are returned with the same `[UNTRUSTED MEMORY DATA]` wrapping as passive recall, including the memory ids needed for `delete`.
 
 ## Commands
 
@@ -276,9 +271,7 @@ needed for `delete`.
 - `pi-memory`: Curated memory — the agent explicitly manages memories via the `memory_add` / `memory_replace` / `memory_remove` / `memory_read` tools, local `.md` files, hard char limits
 - `pi-memory-mem0`: Semantic memory — automatic extraction/storage and semantic recall (passive), plus the `mem0_memory` tool for agent-driven semantic lookup (active); no capacity limits
 
-They do not interfere with each other, and their tool names do not collide. `pi-memory-mem0` injects recalled text as a
-custom user-channel message (never the system prompt); `pi-memory` injects its own
-context separately.
+They do not interfere with each other, and their tool names do not collide. `pi-memory-mem0` injects recalled text as a custom user-channel message (never the system prompt); `pi-memory` injects its own context separately.
 
 ## Dedup API
 

--- a/packages/pi-memory/README.md
+++ b/packages/pi-memory/README.md
@@ -64,9 +64,7 @@ pi.extensions → session_start → initialize store → register tools
 
 Configure via the `pi-memory` settings key:
 
-Project `.pi/settings.json` values are loaded only after project trust is
-accepted and are not environment-interpolated. User and agent settings retain
-environment interpolation.
+Project `.pi/settings.json` values are loaded only after project trust is accepted and are not environment-interpolated. User and agent settings retain environment interpolation.
 
 ```json
 {

--- a/packages/pi-security/README.md
+++ b/packages/pi-security/README.md
@@ -65,8 +65,7 @@ Profiles can be defined in three places. Higher-priority sources override lower-
 3. **User**: `~/.pi/agent/policy/<name>.json`
 4. **Settings**: under `pi-security.security.profiles` in `pi.json`
 
-Each JSON file defines a single profile; the filename (without `.json`) is the profile name.
-Project policies are ignored when project trust is declined or unavailable.
+Each JSON file defines a single profile; the filename (without `.json`) is the profile name. Project policies are ignored when project trust is declined or unavailable.
 
 ### JSON config examples
 

--- a/packages/pi-task-scheduler/README.md
+++ b/packages/pi-task-scheduler/README.md
@@ -4,21 +4,16 @@
 
 Scheduled task domain types, execution scheduler, and pi agent extension.
 
-The package owns schedule parsing, task lifecycle state, process-local timers,
-runner callbacks, scheduler hooks, and LLM-callable tools for autonomous task
-management.
+The package owns schedule parsing, task lifecycle state, process-local timers, runner callbacks, scheduler hooks, and LLM-callable tools for autonomous task management.
 
 ## Storage
 
-The package ships with a built-in file-based storage (default, zero external
-dependencies):
+The package ships with a built-in file-based storage (default, zero external dependencies):
 
 - `JsonScheduledTaskStore` — persists tasks to a JSON file with atomic writes
 - `FileSchedulerLock` — PID-based file lock for single-owner execution
 
-For database-backed storage (multi-tenant, Prisma), use
-`@amaster.ai/pi-storage/scheduler` which implements the same interfaces with
-`DbScheduledTaskStore` and `RedisSchedulerLock`.
+For database-backed storage (multi-tenant, Prisma), use `@amaster.ai/pi-storage/scheduler` which implements the same interfaces with `DbScheduledTaskStore` and `RedisSchedulerLock`.
 
 ### Default (file storage)
 
@@ -42,8 +37,7 @@ await scheduler.start();
 
 ### Custom storage
 
-Implement `ScheduledTaskStore` and `SchedulerLock` interfaces for any backend
-(database, Redis, etc.):
+Implement `ScheduledTaskStore` and `SchedulerLock` interfaces for any backend (database, Redis, etc.):
 
 ```ts
 import { PersistentTaskScheduler } from "@amaster.ai/pi-task-scheduler";
@@ -61,16 +55,11 @@ await scheduler.start();
 
 ## Integration Modes
 
-The package provides two integration paths depending on who controls the
-scheduler lifecycle.
+The package provides two integration paths depending on who controls the scheduler lifecycle.
 
 ### Mode 1: Extension auto-discovery (standalone / CLI)
 
-When installed as an npm dependency with the `pi.extensions` field in
-`package.json`, the runtime auto-discovers and loads the extension. The
-extension creates its own `PersistentTaskScheduler` with file-based storage
-(`JsonScheduledTaskStore` + `FileSchedulerLock`) — fully self-contained, no
-external infrastructure needed.
+When installed as an npm dependency with the `pi.extensions` field in `package.json`, the runtime auto-discovers and loads the extension. The extension creates its own `PersistentTaskScheduler` with file-based storage (`JsonScheduledTaskStore` + `FileSchedulerLock`) — fully self-contained, no external infrastructure needed.
 
 ```
 pi.extensions → session_start → creates file-based scheduler → registers tools + commands
@@ -86,9 +75,7 @@ pi.extensions → session_start → creates file-based scheduler → registers t
 
 Configuration via settings key `pi-scheduler`:
 
-Project `.pi/settings.json` values are loaded only after project trust is
-accepted and are not environment-interpolated. User and agent settings retain
-environment interpolation.
+Project `.pi/settings.json` values are loaded only after project trust is accepted and are not environment-interpolated. User and agent settings retain environment interpolation.
 
 ```json
 {
@@ -100,9 +87,7 @@ environment interpolation.
 
 ### Mode 2: Dependency import (host-controlled)
 
-When the host process owns the scheduler instance (e.g. backed by a database),
-it bypasses the extension and registers tools directly using
-`createSchedulerTools`:
+When the host process owns the scheduler instance (e.g. backed by a database), it bypasses the extension and registers tools directly using `createSchedulerTools`:
 
 ```ts
 import { createSchedulerTools } from "@amaster.ai/pi-task-scheduler/tools";
@@ -119,8 +104,7 @@ await scheduler.start();
 const tools = createSchedulerTools(scheduler);
 ```
 
-In this mode the auto-discovered extension should be filtered out to prevent
-double tool registration. The host manages scheduler start/stop independently.
+In this mode the auto-discovered extension should be filtered out to prevent double tool registration. The host manages scheduler start/stop independently.
 
 ```
 host creates scheduler → createSchedulerTools(scheduler) → tools injected into runtime
@@ -145,10 +129,8 @@ Tasks support three schedule types:
 - `once`: ISO timestamps or relative values such as `+5m`
 - `cron`: 5/6-field cron expressions and a small RRULE subset
 
-The scheduler does not catch up missed runs after process downtime. When it
-starts, it registers future timers for enabled tasks.
+The scheduler does not catch up missed runs after process downtime. When it starts, it registers future timers for enabled tasks.
 
 ## Hooks
 
-Hooks are best-effort observability callbacks. If a hook throws, the scheduler
-swallows the error and keeps task state authoritative.
+Hooks are best-effort observability callbacks. If a hook throws, the scheduler swallows the error and keeps task state authoritative.

--- a/packages/pi-teamwork/README.md
+++ b/packages/pi-teamwork/README.md
@@ -12,18 +12,11 @@ Pi extension for team collaboration and project management. Provides LLM-callabl
 
 ### Auto-Install
 
-Runtime auto-installation is disabled because mutable package-manager taps and
-download scripts cannot provide the pinned artifact verification required in a
-credential-bearing agent process. Install a pinned Multica release separately
-and put the verified binary on `$PATH`, or configure `multica.binary`.
+Runtime auto-installation is disabled because mutable package-manager taps and download scripts cannot provide the pinned artifact verification required in a credential-bearing agent process. Install a pinned Multica release separately and put the verified binary on `$PATH`, or configure `multica.binary`.
 
-The deprecated `autoInstall: true` setting no longer executes an installer. It
-only reports a clear error when the binary is missing.
+The deprecated `autoInstall: true` setting no longer executes an installer. It only reports a clear error when the binary is missing.
 
-Configuration may live in user/agent settings or in a trusted project's
-`.pi/settings.json`. Project settings are ignored when trust is declined and do
-not expand `${ENV_VAR}`; keep environment-backed credentials in user or agent
-settings.
+Configuration may live in user/agent settings or in a trusted project's `.pi/settings.json`. Project settings are ignored when trust is declined and do not expand `${ENV_VAR}`; keep environment-backed credentials in user or agent settings.
 
 ### Mode 1 — Self-hosted server
 

--- a/packages/pi-telemetry/README.md
+++ b/packages/pi-telemetry/README.md
@@ -40,12 +40,7 @@ Langfuse traces include the configured `serviceName` as both a tag and metadata 
 
 ## Configuration
 
-Configuration is read from the `"pi-telemetry"` section of, in increasing
-priority, `~/.pi/agent/settings.json`, the configured agent directory's
-`settings.json` (for example `$PI_CODING_AGENT_DIR/settings.json`), and a trusted
-project's `.pi/settings.json`. Project settings are ignored when project trust
-is declined. Environment variables are expanded only in user and agent-directory
-settings.
+Configuration is read from the `"pi-telemetry"` section of, in increasing priority, `~/.pi/agent/settings.json`, the configured agent directory's `settings.json` (for example `$PI_CODING_AGENT_DIR/settings.json`), and a trusted project's `.pi/settings.json`. Project settings are ignored when project trust is declined. Environment variables are expanded only in user and agent-directory settings.
 
 ```json
 {

--- a/packages/pi-video-gen/README.md
+++ b/packages/pi-video-gen/README.md
@@ -1,12 +1,6 @@
 # pi-video-gen
 
-Pi extension for agentic video generation. Ships the single-clip primitive
-(`video_generate`), the multi-shot render pipeline (`video_render`), local
-lossless clip composing and mixed-media promo timelines with overlays, TTS,
-soft or burned subtitles, source-video audio, and BGM (`video_compose`), the read-only
-`video_capabilities` query, a `/video-gen` command, and the `video-gen` skill
-that orchestrates the full shot-book workflow together with
-[pi-image-gen](../pi-image-gen) (all image work).
+Pi extension for agentic video generation. Ships the single-clip primitive (`video_generate`), the multi-shot render pipeline (`video_render`), local lossless clip composing and mixed-media promo timelines with overlays, TTS, soft or burned subtitles, source-video audio, and BGM (`video_compose`), the read-only `video_capabilities` query, a `/video-gen` command, and the `video-gen` skill that orchestrates the full shot-book workflow together with [pi-image-gen](../pi-image-gen) (all image work).
 
 ## Providers
 
@@ -20,32 +14,11 @@ that orchestrates the full shot-book workflow together with
 | `newapi` | self-hosted NewAPI relay (Kling / Jimeng / Vidu / Gemini channels) | ✅ via `customProviders` — `baseUrl` **required** |
 | custom | your own endpoints | ✅ via `customProviders` |
 
-Registry entries are written against provider documentation (each adapter's
-header notes the source) and are pending live smoke tests against real
-accounts — verify with `/video-gen doctor` + one small paid clip before heavy
-use. Seedance 2.5 stays on the roadmap until its official API ID and parameter
-contract are published.
+Registry entries are written against provider documentation (each adapter's header notes the source) and are pending live smoke tests against real accounts — verify with `/video-gen doctor` + one small paid clip before heavy use. Seedance 2.5 stays on the roadmap until its official API ID and parameter contract are published.
 
-**Seedance trusted portrait assets**: Seedance may reject ordinary image/video
-references containing recognizable real people. For those shots, select a
-preset avatar or an Active authorized-person asset in the same Volcengine Ark
-account/project used for generation, then pass its `asset-...` ID (or
-`asset://asset-...` URI) through `referenceAssets`. The extension supports
-trusted `image`, `video`, and `audio` assets for the built-in Seedance 2.0
-models and maps them to Ark's `asset://` request format. Prompt text refers to
-their order as `Image 1`, `Video 1`, and `Audio 1` — never by Asset ID.
+**Seedance trusted portrait assets**: Seedance may reject ordinary image/video references containing recognizable real people. For those shots, select a preset avatar or an Active authorized-person asset in the same Volcengine Ark account/project used for generation, then pass its `asset-...` ID (or `asset://asset-...` URI) through `referenceAssets`. The extension supports trusted `image`, `video`, and `audio` assets for the built-in Seedance 2.0 models and maps them to Ark's `asset://` request format. Prompt text refers to their order as `Image 1`, `Video 1`, and `Audio 1` — never by Asset ID.
 
-This package ships dated snapshots of the public material cards and preset
-persona library under `skills/video-gen/references/`, including the Asset IDs
-needed by `referenceAssets`. Volcengine does not document those IDs as
-permanent or cross-account, so retry with an ID copied from the active
-account's library if a snapshot ID is rejected. Private or authorized-person
-assets always require the user to provide the current account/project's actual
-ID. Identity verification, authorization H5 flows, activation, uploading, and
-asset-library management remain outside this package. See Volcengine's
-[preset-avatar guide](https://docs.volcengine.com/docs/82379/2608626?lang=zh#preset-avatar),
-[authorized-person asset guide](https://docs.volcengine.com/docs/82379/2223965?lang=zh),
-and [Seedance request format](https://console.volcengine.com/ark/region:cn-beijing/docs/82379/2333589?projectName=default&lang=zh#d9a7d853).
+This package ships dated snapshots of the public material cards and preset persona library under `skills/video-gen/references/`, including the Asset IDs needed by `referenceAssets`. Volcengine does not document those IDs as permanent or cross-account, so retry with an ID copied from the active account's library if a snapshot ID is rejected. Private or authorized-person assets always require the user to provide the current account/project's actual ID. Identity verification, authorization H5 flows, activation, uploading, and asset-library management remain outside this package. See Volcengine's [preset-avatar guide](https://docs.volcengine.com/docs/82379/2608626?lang=zh#preset-avatar), [authorized-person asset guide](https://docs.volcengine.com/docs/82379/2223965?lang=zh), and [Seedance request format](https://console.volcengine.com/ark/region:cn-beijing/docs/82379/2333589?projectName=default&lang=zh#d9a7d853).
 
 ## Setup
 
@@ -64,14 +37,7 @@ Global settings (`~/.pi/agent/settings.json`):
 }
 ```
 
-**Custom providers** (same idea as pi-image-gen's — point any Ark-compatible
-endpoint at your own models; string models get conservative capabilities,
-object models declare them). When a custom model's `id` names a built-in
-model (e.g. `"MiniMax-H3"` behind your relay), the built-in capability table
-and defaults are inherited automatically — undeclared `capabilities`,
-`defaultResolution`/`defaultAspectRatio`/`defaultDurationSec` fall back to
-the registry values instead of the conservative 720p/16:9 profile, and any
-field you do declare overrides the inherited one:
+**Custom providers** (same idea as pi-image-gen's — point any Ark-compatible endpoint at your own models; string models get conservative capabilities, object models declare them). When a custom model's `id` names a built-in model (e.g. `"MiniMax-H3"` behind your relay), the built-in capability table and defaults are inherited automatically — undeclared `capabilities`, `defaultResolution`/`defaultAspectRatio`/`defaultDurationSec` fall back to the registry values instead of the conservative 720p/16:9 profile, and any field you do declare overrides the inherited one:
 
 ```jsonc
 {
@@ -97,17 +63,7 @@ field you do declare overrides the inherited one:
 }
 ```
 
-**NewAPI notes** ([video format docs](https://www.newapi.ai/zh/docs/api/ai-model/videos/createvideogeneration)):
-NewAPI is a self-hosted relay, so the `newapi` wire format has NO default
-endpoint — `baseUrl` is mandatory and resolution fails with the exact
-settings path to fix when it is absent. Both the server root
-(`"https://newapi.example.com"`) and the OpenAI-style `"…/v1"` form are
-accepted. Channel-specific parameters ride in `metadata` following the
-upstream doc examples: `aspect_ratio` + `resolution` (Jimeng/Vidu style),
-`image_tail` for the last frame (Kling style) and `image_urls` for extra
-reference images (Jimeng style); the first frame goes in the top-level
-`image` field. There is no documented audio toggle or idempotency key, so
-ambiguous submits are parked for manual resolution rather than auto-retried:
+**NewAPI notes** ([video format docs](https://www.newapi.ai/zh/docs/api/ai-model/videos/createvideogeneration)): NewAPI is a self-hosted relay, so the `newapi` wire format has NO default endpoint — `baseUrl` is mandatory and resolution fails with the exact settings path to fix when it is absent. Both the server root (`"https://newapi.example.com"`) and the OpenAI-style `"…/v1"` form are accepted. Channel-specific parameters ride in `metadata` following the upstream doc examples: `aspect_ratio` + `resolution` (Jimeng/Vidu style), `image_tail` for the last frame (Kling style) and `image_urls` for extra reference images (Jimeng style); the first frame goes in the top-level `image` field. There is no documented audio toggle or idempotency key, so ambiguous submits are parked for manual resolution rather than auto-retried:
 
 ```jsonc
 {
@@ -125,63 +81,15 @@ ambiguous submits are parked for manual resolution rather than auto-retried:
 }
 ```
 
-**MiniMax notes** (v2 API, [create](https://platform.minimax.io/docs/api-reference/video-generation-v2-create) / [query](https://platform.minimax.io/docs/api-reference/video-generation-v2-query)):
-MiniMax-H3 speaks a multimodal task API — prompt + frames ride in one
-`content` array with `first_frame` / `last_frame` / `reference_image` roles
-(first/last frames and reference images are mutually exclusive; a last frame
-requires a first frame). Resolution is `768P` or `2K`, duration 4–15s, ratio
-`16:9|4:3|1:1|3:4|9:16|21:9` — required and non-adaptive for text-to-video,
-ignored (forced adaptive) once a first frame is present. There is no audio
-toggle, no idempotency key and no documented cancel endpoint, so ambiguous
-submits are parked for manual resolution rather than auto-retried. Auth is a
-plain Bearer key (`providers.minimax.apiKey`, env `MINIMAX_API_KEY`), and keys
-are region-locked: the default endpoint is international
-`api.minimax.io` — mainland-China keys need `providers.minimax.baseUrl` set
-to `https://api.minimaxi.com` (and vice versa a 401 means wrong region).
-Result URLs are time-limited; clips are downloaded immediately, and tasks
-stay queryable for 7 days.
+**MiniMax notes** (v2 API, [create](https://platform.minimax.io/docs/api-reference/video-generation-v2-create) / [query](https://platform.minimax.io/docs/api-reference/video-generation-v2-query)): MiniMax-H3 speaks a multimodal task API — prompt + frames ride in one `content` array with `first_frame` / `last_frame` / `reference_image` roles (first/last frames and reference images are mutually exclusive; a last frame requires a first frame). Resolution is `768P` or `2K`, duration 4–15s, ratio `16:9|4:3|1:1|3:4|9:16|21:9` — required and non-adaptive for text-to-video, ignored (forced adaptive) once a first frame is present. There is no audio toggle, no idempotency key and no documented cancel endpoint, so ambiguous submits are parked for manual resolution rather than auto-retried. Auth is a plain Bearer key (`providers.minimax.apiKey`, env `MINIMAX_API_KEY`), and keys are region-locked: the default endpoint is international `api.minimax.io` — mainland-China keys need `providers.minimax.baseUrl` set to `https://api.minimaxi.com` (and vice versa a 401 means wrong region). Result URLs are time-limited; clips are downloaded immediately, and tasks stay queryable for 7 days.
 
-**Kling notes** (verified against kling.ai/document-api via browser, 2026-07):
-current Kling API 2.0 uses a plain API key (`providers.kling.apiKey`, env
-`KLING_API_KEY`) — the JWT ak/sk scheme is legacy. The model lives in the URL
-path (`kling-3.0-turbo` / `kling-3.0`); default base is
-`api-singapore.klingai.com` (regional endpoints via `baseUrl`). Kling 3.0 Omni
-supports last-frame, native audio and 4k; Turbo is first-frame-only and
-silent. Submits carry `external_task_id` (our request fingerprint), so
-ambiguous failures are looked up first; an inconclusive lookup is parked for
-manual resolution rather than blindly resubmitted.
+**Kling notes** (verified against kling.ai/document-api via browser, 2026-07): current Kling API 2.0 uses a plain API key (`providers.kling.apiKey`, env `KLING_API_KEY`) — the JWT ak/sk scheme is legacy. The model lives in the URL path (`kling-3.0-turbo` / `kling-3.0`); default base is `api-singapore.klingai.com` (regional endpoints via `baseUrl`). Kling 3.0 Omni supports last-frame, native audio and 4k; Turbo is first-frame-only and silent. Submits carry `external_task_id` (our request fingerprint), so ambiguous failures are looked up first; an inconclusive lookup is parked for manual resolution rather than blindly resubmitted.
 
-**HappyHorse notes**: no native audio and no last-frame interpolation
-(`nativeAudio: false`, `supportsFirstLastFrame: false` in the capability table,
-so the tools hide/reject those options). One call takes either a first frame
-(i2v) OR reference images (r2v, prompt them as `[Image 1]`, `[Image 2]`, …),
-not both. The default endpoint is the classic `dashscope.aliyuncs.com` (no
-workspace id needed); if you use a new Bailian workspace, set
-`providers.dashscope.baseUrl` to `https://{workspaceId}.cn-beijing.maas.aliyuncs.com`.
-Video/task URLs expire after 24h — clips are downloaded immediately.
+**HappyHorse notes**: no native audio and no last-frame interpolation (`nativeAudio: false`, `supportsFirstLastFrame: false` in the capability table, so the tools hide/reject those options). One call takes either a first frame (i2v) OR reference images (r2v, prompt them as `[Image 1]`, `[Image 2]`, …), not both. The default endpoint is the classic `dashscope.aliyuncs.com` (no workspace id needed); if you use a new Bailian workspace, set `providers.dashscope.baseUrl` to `https://{workspaceId}.cn-beijing.maas.aliyuncs.com`. Video/task URLs expire after 24h — clips are downloaded immediately.
 
-**Trust boundary**: `providers.*`, `customProviders.*` and `ffmpegPath` are
-honored ONLY from global / agent-dir settings — project-level
-`.pi/settings.json` can set `outputDir`, `defaultModel`, `rateLimit`,
-`concurrency` only (and only when the project is trusted). A malicious repo
-cannot redirect your API key or swap binaries.
+**Trust boundary**: `providers.*`, `customProviders.*` and `ffmpegPath` are honored ONLY from global / agent-dir settings — project-level `.pi/settings.json` can set `outputDir`, `defaultModel`, `rateLimit`, `concurrency` only (and only when the project is trusted). A malicious repo cannot redirect your API key or swap binaries.
 
-**ffmpeg**: required for multi-shot concat and installed automatically with
-the plugin through a platform-specific optional npm package. The main plugin
-stays small, while `pi install npm:@amaster.ai/pi-video-gen` downloads only
-the platform payload matching the current OS and CPU. That payload contains a
-default LGPL build plus separately named GPL `ffmpeg-gpl`/`ffprobe-gpl`
-binaries with libx264 for requested H.264 timeline output. Supported bundled
-targets are macOS 11+ arm64/x64, glibc Linux arm64/x64 (built on Ubuntu 22.04),
-and Windows x64; musl Linux uses a system FFmpeg through PATH. Resolution order:
-`ffmpegPath` setting → `FFMPEG_PATH` env → installed platform package →
-ffmpeg-static (development only) → PATH. An automatic bundled candidate that
-is present but not runnable is skipped so it cannot mask a working PATH
-installation. Check with `/video-gen doctor`.
-Release CI builds every platform package from the pinned official FFmpeg
-source with external-library autodetection disabled; the exact FFmpeg, zlib,
-and x264 source archives, build script, licenses, and provenance ship beside
-the binaries.
+**ffmpeg**: required for multi-shot concat and installed automatically with the plugin through a platform-specific optional npm package. The main plugin stays small, while `pi install npm:@amaster.ai/pi-video-gen` downloads only the platform payload matching the current OS and CPU. That payload contains a default LGPL build plus separately named GPL `ffmpeg-gpl`/`ffprobe-gpl` binaries with libx264 for requested H.264 timeline output. Supported bundled targets are macOS 11+ arm64/x64, glibc Linux arm64/x64 (built on Ubuntu 22.04), and Windows x64; musl Linux uses a system FFmpeg through PATH. Resolution order: `ffmpegPath` setting → `FFMPEG_PATH` env → installed platform package → ffmpeg-static (development only) → PATH. An automatic bundled candidate that is present but not runnable is skipped so it cannot mask a working PATH installation. Check with `/video-gen doctor`. Release CI builds every platform package from the pinned official FFmpeg source with external-library autodetection disabled; the exact FFmpeg, zlib, and x264 source archives, build script, licenses, and provenance ship beside the binaries.
 
 ## Tools
 
@@ -194,10 +102,7 @@ the binaries.
 
 ## Structured prompts
 
-Both paid tools take structured prompt fields, never a pre-joined string. The
-plugin assembles the labeled prompt text (`[Style]` / `[Character]` / `[Scene]`
-/ `[Visuals]` / `[Action]` / `[Effects]` / `[Audio]` + consistency/negative
-directives), so every shot reliably carries the film-level directives:
+Both paid tools take structured prompt fields, never a pre-joined string. The plugin assembles the labeled prompt text (`[Style]` / `[Character]` / `[Scene]` / `[Visuals]` / `[Action]` / `[Effects]` / `[Audio]` + consistency/negative directives), so every shot reliably carries the film-level directives:
 
 - **Film level** — `style` (genre/quality/texture), `characters`
   (`{id, description}` registry), `consistency` (identity/no-drift directive),
@@ -254,22 +159,6 @@ Driven by the `video-gen` skill in conversation:
 └── final_video.mp4
 ```
 
-Crash or cancel mid-render? Rerun the same spec path — the input fingerprint
-(spec + frame hashes + model/provider) is verified, then persisted handles
-resume via `inspect` without re-billing. NOTE: cancelling stops local polling
-only; the remote task may keep running and billable (Ark cancellation support
-is unverified). If submit completion is ambiguous, rerun is blocked until
-`/video-gen recover <jobId>` explicitly resets or adopts the affected shot.
-Single-clip ambiguous submits are also persisted and blocked; check the provider
-console before starting another generation. Single-job resume independently
-recomputes the request fingerprint from its frozen `input.json`; an inspect 404
-keeps the remote handle and parks the job as ambiguous instead of declaring it
-safe to resubmit.
+Crash or cancel mid-render? Rerun the same spec path — the input fingerprint (spec + frame hashes + model/provider) is verified, then persisted handles resume via `inspect` without re-billing. NOTE: cancelling stops local polling only; the remote task may keep running and billable (Ark cancellation support is unverified). If submit completion is ambiguous, rerun is blocked until `/video-gen recover <jobId>` explicitly resets or adopts the affected shot. Single-clip ambiguous submits are also persisted and blocked; check the provider console before starting another generation. Single-job resume independently recomputes the request fingerprint from its frozen `input.json`; an inspect 404 keeps the remote handle and parks the job as ambiguous instead of declaring it safe to resubmit.
 
-**Upgrading from the pre-structured format**: render jobs whose
-`render-input.json` still uses the old `videoPrompt` string can no longer be
-parsed or resumed (the structured `prompt` object replaced it deliberately,
-with no compatibility layer). If an in-flight paid task is stranded by the
-upgrade, download its clip manually from the provider console — task URLs
-expire (Ark: 24h). Single-clip jobs are unaffected: their frozen `input.json`
-is read, not re-parsed.
+**Upgrading from the pre-structured format**: render jobs whose `render-input.json` still uses the old `videoPrompt` string can no longer be parsed or resumed (the structured `prompt` object replaced it deliberately, with no compatibility layer). If an in-flight paid task is stranded by the upgrade, download its clip manually from the provider console — task URLs expire (Ark: 24h). Single-clip jobs are unaffected: their frozen `input.json` is read, not re-parsed.

--- a/packages/pi-web-access/README.md
+++ b/packages/pi-web-access/README.md
@@ -78,9 +78,7 @@ Custom DashScope base URLs must point to an OpenAI-compatible Responses API root
 
 Settings key: `pi-web-access`
 
-Project `.pi/settings.json` values are loaded only after project trust is
-accepted and are not environment-interpolated. User and agent settings retain
-environment interpolation.
+Project `.pi/settings.json` values are loaded only after project trust is accepted and are not environment-interpolated. User and agent settings retain environment interpolation.
 
 ```json
 {

--- a/packages/pi-wecom/README.md
+++ b/packages/pi-wecom/README.md
@@ -14,9 +14,7 @@ Pi extension for [WeCom (企业微信)](https://work.weixin.qq.com/) workspace �
 
 Add to `~/.pi/agent/settings.json` or a trusted project's `.pi/settings.json`:
 
-Project settings are loaded only after project trust is accepted. For
-environment-backed credentials, use user or agent settings because project
-settings do not expand `${ENV_VAR}`.
+Project settings are loaded only after project trust is accepted. For environment-backed credentials, use user or agent settings because project settings do not expand `${ENV_VAR}`.
 
 ```json
 {

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -57,15 +57,7 @@ Platform mode for mem0 (`--mode platform`) reads `MEM0_API_KEY` instead.
 
 ## Browser (pi-browser-use L3 — task-completion rate)
 
-Answers the "does it actually work" question: a **real** tool-calling LLM must
-complete a task using only the `browser_*` tools, driving a **real Chrome**. It
-drives the extension through the **real `pi` CLI** — the same way
-`.github/workflows/integration.yml` does: install the extension with `pi install`
-into an isolated config dir, then `pi --mode json -p '<task>' --tools <allowlist>`
-and parse the event stream. The extension runs exactly as shipped (built dist,
-pi's own dependency resolution), so the success rate reflects the real wrapper
-(snapshot handling, tool descriptions, overlay/stale hints) plus the model — no
-importing package internals, no hand-rolled tool loop.
+Answers the "does it actually work" question: a **real** tool-calling LLM must complete a task using only the `browser_*` tools, driving a **real Chrome**. It drives the extension through the **real `pi` CLI** — the same way `.github/workflows/integration.yml` does: install the extension with `pi install` into an isolated config dir, then `pi --mode json -p '<task>' --tools <allowlist>` and parse the event stream. The extension runs exactly as shipped (built dist, pi's own dependency resolution), so the success rate reflects the real wrapper (snapshot handling, tool descriptions, overlay/stale hints) plus the model — no importing package internals, no hand-rolled tool loop.
 
 Nothing is hardcoded. Provider, model, endpoint, and key are all parameterized:
 
@@ -86,43 +78,13 @@ pnpm --filter @amaster.ai/pi-eval judge:llm -- \
   --input results/browser-tasks.json --llm-model deepseek-v4-pro --models "$MODELS"
 ```
 
-Flags (all optional, with env fallbacks): `--models <path>` (use a ready-made
-models.json verbatim — what CI does; `PI_MODELS_PATH`), or generate one from
-`--provider` (`PI_EVAL_PROVIDER`, default `deepseek-integration`), `--model`
-(`PI_EVAL_MODEL`), `--base-url` (`PI_INTEGRATION_BASE_URL`), `--api`
-(`PI_EVAL_API`, default `openai-completions`), `--api-key-env`
-(`PI_EVAL_API_KEY_ENV`, default `PI_INTEGRATION_API_KEY` — names the env var
-holding the key). Plus `--thinking` (default `high`), `--timeout` (per-task ms),
-`--tasks N`, `--task <id>`. Chrome is found via `CHROME_BIN` or common
-macOS/Linux paths; if none, install one with
-`npx -y @puppeteer/browsers install chrome@stable` and set `CHROME_BIN` (the
-Linux-CI step from integration.yml).
+Flags (all optional, with env fallbacks): `--models <path>` (use a ready-made models.json verbatim — what CI does; `PI_MODELS_PATH`), or generate one from `--provider` (`PI_EVAL_PROVIDER`, default `deepseek-integration`), `--model` (`PI_EVAL_MODEL`), `--base-url` (`PI_INTEGRATION_BASE_URL`), `--api` (`PI_EVAL_API`, default `openai-completions`), `--api-key-env` (`PI_EVAL_API_KEY_ENV`, default `PI_INTEGRATION_API_KEY` — names the env var holding the key). Plus `--thinking` (default `high`), `--timeout` (per-task ms), `--tasks N`, `--task <id>`. Chrome is found via `CHROME_BIN` or common macOS/Linux paths; if none, install one with `npx -y @puppeteer/browsers install chrome@stable` and set `CHROME_BIN` (the Linux-CI step from integration.yml).
 
-**Scoring.** Each task in `browser/tasks.ts` carries a deterministic
-`check(answer, observed)` predicate — success is a string/regex match over the
-model's final answer plus the tool outputs it saw. No LLM in the scoring path, so
-numbers are stable and free. Tasks that genuinely can't be reduced to a match
-omit `check` and defer to `judge-llm.ts` (every task still sets `gold`). The
-summary reports `successRate` (over checked, non-crashed tasks), `avgTurns`
-(model round-trips to reach a passing answer — **fewer is better**; a sharper
-wrapper/prompt lets the model finish in fewer turns), `avgToolCalls`, and a
-`failureMix` bucketing each task as `ok` / `check-failed` / `tool-error` /
-`crash` — a regression in, say, snapshot stripping shows up as a shift in the mix.
+**Scoring.** Each task in `browser/tasks.ts` carries a deterministic `check(answer, observed)` predicate — success is a string/regex match over the model's final answer plus the tool outputs it saw. No LLM in the scoring path, so numbers are stable and free. Tasks that genuinely can't be reduced to a match omit `check` and defer to `judge-llm.ts` (every task still sets `gold`). The summary reports `successRate` (over checked, non-crashed tasks), `avgTurns` (model round-trips to reach a passing answer — **fewer is better**; a sharper wrapper/prompt lets the model finish in fewer turns), `avgToolCalls`, and a `failureMix` bucketing each task as `ok` / `check-failed` / `tool-error` / `crash` — a regression in, say, snapshot stripping shows up as a shift in the mix.
 
-Task coverage aims at the failure modes the wrapper is responsible for, not just
-happy-path reads: single reads (`example-*`, pinned Wikipedia), form fill+submit
-(`login-form-submit` — two fields + submit on the-internet.herokuapp.com), and
-**multi-step navigation** (`multi-step-navigate` — click a link, re-snapshot
-after uids invalidate), which exercises the extension's stale-element handling.
-Seeds are chosen for stability: IANA-reserved `example.com`/`example.org`, pinned
-Wikipedia `oldid`s, and the SeleniumHQ demo site — httpbin.org was dropped after
-it flaked repeatedly (503s / timeouts) in trial runs.
+Task coverage aims at the failure modes the wrapper is responsible for, not just happy-path reads: single reads (`example-*`, pinned Wikipedia), form fill+submit (`login-form-submit` — two fields + submit on the-internet.herokuapp.com), and **multi-step navigation** (`multi-step-navigate` — click a link, re-snapshot after uids invalidate), which exercises the extension's stale-element handling. Seeds are chosen for stability: IANA-reserved `example.com`/`example.org`, pinned Wikipedia `oldid`s, and the SeleniumHQ demo site — httpbin.org was dropped after it flaked repeatedly (503s / timeouts) in trial runs.
 
-**CI.** Runs as the manual **Agentic Eval** workflow
-(`.github/workflows/agentic-eval.yml`, `workflow_dispatch`) — kept separate from
-integration.yml, which is a pass/fail smoke test; this one is effect evaluation.
-The workflow installs a real Chrome and writes models.json from the
-`PI_INTEGRATION_*` secrets, then runs this runner and publishes a scored summary.
+**CI.** Runs as the manual **Agentic Eval** workflow (`.github/workflows/agentic-eval.yml`, `workflow_dispatch`) — kept separate from integration.yml, which is a pass/fail smoke test; this one is effect evaluation. The workflow installs a real Chrome and writes models.json from the `PI_INTEGRATION_*` secrets, then runs this runner and publishes a scored summary.
 
 Known variance:
 - **Site availability.** Seed sites can be down — a seed 503 shows up (correctly)
@@ -135,15 +97,7 @@ Known variance:
 
 ## Computer (pi-computer-use L3 — desktop task-completion rate)
 
-Same shape and same `pi`-CLI harness as the browser eval, one level lower: a real
-tool-calling LLM drives **real macOS desktop apps** via `computer_use_*` tools.
-The extension (with its own `formatToolError` / bundled `cua-driver`) runs as
-shipped. Most seed apps are built-in system apps (Calculator, TextEdit, Notes) so
-results are deterministic and offline. One task (`netease-daily-recommend`)
-drives a real third-party app (NetEase Cloud Music) to its 每日推荐 entry — a
-genuine agentic-interaction case; its `check` only verifies the agent reached the
-recommendation view (content is login-gated and changes daily), and it is skipped
-implicitly if the app isn't installed (the launch tool errors → `tool-error`).
+Same shape and same `pi`-CLI harness as the browser eval, one level lower: a real tool-calling LLM drives **real macOS desktop apps** via `computer_use_*` tools. The extension (with its own `formatToolError` / bundled `cua-driver`) runs as shipped. Most seed apps are built-in system apps (Calculator, TextEdit, Notes) so results are deterministic and offline. One task (`netease-daily-recommend`) drives a real third-party app (NetEase Cloud Music) to its 每日推荐 entry — a genuine agentic-interaction case; its `check` only verifies the agent reached the recommendation view (content is login-gated and changes daily), and it is skipped implicitly if the app isn't installed (the launch tool errors → `tool-error`).
 
 ```bash
 export PI_INTEGRATION_BASE_URL="https://your-gateway/v1"
@@ -156,12 +110,9 @@ pnpm --filter @amaster.ai/pi-eval judge:llm -- \
   --input results/computer-tasks.json --llm-model deepseek-v4-pro --models "$MODELS"
 ```
 
-Flags are identical to the browser runner. Result file:
-`results/computer-tasks.json`, same summary shape.
+Flags are identical to the browser runner. Result file: `results/computer-tasks.json`, same summary shape.
 
-**macOS-only, and skips gracefully elsewhere.** On any non-macOS platform (e.g. a
-Linux CI runner) the runner writes a `{skipped: true}` result and exits 0 — it
-never fails a cross-platform pipeline. On macOS it requires:
+**macOS-only, and skips gracefully elsewhere.** On any non-macOS platform (e.g. a Linux CI runner) the runner writes a `{skipped: true}` result and exits 0 — it never fails a cross-platform pipeline. On macOS it requires:
 - The bundled `cua-driver` binary for your platform
   (`packages/pi-computer-use/bin/<platform>/`).
 - **Accessibility** *and* **Screen Recording** granted to the process running the
@@ -171,25 +122,13 @@ never fails a cross-platform pipeline. On macOS it requires:
 - Apps launch **visibly** and receive synthetic clicks/keystrokes — don't run
   this while doing other work on the same machine.
 
-The **Agentic Eval** workflow includes a `computer-eval` job (run it via the
-`target` input), but there is no hosted macOS runner wired to it yet — on the
-Linux runner it no-ops via the graceful skip above. Point the job's `runs-on` at
-a macOS runner with the TCC grants to get real numbers.
+The **Agentic Eval** workflow includes a `computer-eval` job (run it via the `target` input), but there is no hosted macOS runner wired to it yet — on the Linux runner it no-ops via the graceful skip above. Point the job's `runs-on` at a macOS runner with the TCC grants to get real numbers.
 
 ## Video (pi-video-gen on ViMax-Bench — render quality + cross-shot consistency)
 
-Answers "how good is the video our shot-book pipeline actually produces" — a
-**quality** eval, unlike the L3 task-completion runners above. Input data is
-[HKUDS/ViMax](https://github.com/HKUDS/ViMax)'s `vimax_benchmark/` (MIT): 35
-multi-shot story specs (Type A = character persistence, B = background
-persistence, C = multi-person separability; Medium = 2 scenes/8-10 shots,
-Long = 3-4 scenes/12-16 shots). The runner converts each spec **deterministically**
-into a VideoProject shot book, then drives the real `pi` CLI to execute it
-(`image_generate` per shot frame → one `video_render`) — the LLM only executes
-the plan, so scores reflect render/orchestration quality, not planning variance.
+Answers "how good is the video our shot-book pipeline actually produces" — a **quality** eval, unlike the L3 task-completion runners above. Input data is [HKUDS/ViMax](https://github.com/HKUDS/ViMax)'s `vimax_benchmark/` (MIT): 35 multi-shot story specs (Type A = character persistence, B = background persistence, C = multi-person separability; Medium = 2 scenes/8-10 shots, Long = 3-4 scenes/12-16 shots). The runner converts each spec **deterministically** into a VideoProject shot book, then drives the real `pi` CLI to execute it (`image_generate` per shot frame → one `video_render`) — the LLM only executes the plan, so scores reflect render/orchestration quality, not planning variance.
 
-**COST WARNING: every story is 8-16 paid video clips + ~1 image per shot.**
-Always slice with `--samples`/`--tier`/`--story`.
+**COST WARNING: every story is 8-16 paid video clips + ~1 image per shot.** Always slice with `--samples`/`--tier`/`--story`.
 
 ```bash
 pnpm --filter @amaster.ai/pi-eval fetch:vimax        # one-time, pinned commit
@@ -208,22 +147,9 @@ pnpm --filter @amaster.ai/pi-eval judge:video -- \
   --input results/video-vimax.json --llm-model kimi-k2.6 --models "$MODELS"
 ```
 
-Extra flags: `--tier medium|long|all`, `--story <id>`, `--video-model`
-(default `doubao-seedance-2-0-260128` via a newapi-shaped gateway),
-`--timeout` (default 2h per story — a full shot-book render takes tens of
-minutes). Artifacts (generated images, per-shot clips, `final_video.mp4`,
-judge frames) land in `results/artifacts/`.
+Extra flags: `--tier medium|long|all`, `--story <id>`, `--video-model` (default `doubao-seedance-2-0-260128` via a newapi-shaped gateway), `--timeout` (default 2h per story — a full shot-book render takes tens of minutes). Artifacts (generated images, per-shot clips, `final_video.mp4`, judge frames) land in `results/artifacts/`.
 
-**Scoring.** `run-video.ts` reports pipeline health: `completionRate` (final
-video verified on disk), `specViolations` (runs where the LLM rewrote the shot
-book instead of executing it — the written `render-input.json`'s shot ids/order
-are compared against the spec), `avgTurns`, `failureMix`. `judge-video.ts`
-reports quality: a VLM scores `consistency` (1-5, rubric keyed to the story's
-ViMax type) and per-shot `prompt_following` from probed mid-clip frames,
-aggregated overall and by type. The VLM judge reimplements the *spirit* of the
-paper's ViCLIP consistency metric — **scores are comparable across providers
-and across our own releases, not to the ViMax paper numbers** (that would
-require reimplementing ViCLIP; out of scope, see Status).
+**Scoring.** `run-video.ts` reports pipeline health: `completionRate` (final video verified on disk), `specViolations` (runs where the LLM rewrote the shot book instead of executing it — the written `render-input.json`'s shot ids/order are compared against the spec), `avgTurns`, `failureMix`. `judge-video.ts` reports quality: a VLM scores `consistency` (1-5, rubric keyed to the story's ViMax type) and per-shot `prompt_following` from probed mid-clip frames, aggregated overall and by type. The VLM judge reimplements the *spirit* of the paper's ViCLIP consistency metric — **scores are comparable across providers and across our own releases, not to the ViMax paper numbers** (that would require reimplementing ViCLIP; out of scope, see Status).
 
 ## Datasets
 
@@ -242,23 +168,13 @@ We deliberately do **not** consume [OpenDataBox/MemoryData](https://github.com/O
 | Retrieval           | None — the whole snapshot is the context  | Semantic top-k search                 |
 | What LoCoMo rewards  | —                                        | Storing every retrievable detail      |
 
-Both runners produce a memory `blob` per question and the same LLM-judge asks
-"does this memory contain the answer?" — so the numbers share a scale. But
-**do not read them as a leaderboard.** LoCoMo asks 300+ fine-grained recall
-questions (exact dates, who-did-what, multi-hop). pi-memory's whole design is
-to *discard* most of that under a hard char budget and keep only high-value
-facts (preferences, corrections, stable environment facts). It compresses 19
-sessions of conversation into ~a few hundred chars on purpose. mem0's unbounded
-vector store keeps everything, so it recalls arbitrary details far better.
+Both runners produce a memory `blob` per question and the same LLM-judge asks "does this memory contain the answer?" — so the numbers share a scale. But **do not read them as a leaderboard.** LoCoMo asks 300+ fine-grained recall questions (exact dates, who-did-what, multi-hop). pi-memory's whole design is to *discard* most of that under a hard char budget and keep only high-value facts (preferences, corrections, stable environment facts). It compresses 19 sessions of conversation into ~a few hundred chars on purpose. mem0's unbounded vector store keeps everything, so it recalls arbitrary details far better.
 
-The gap below reflects that mismatch, not that one is "better". A fair
-pi-memory benchmark would measure long-term retention of a small set of
-high-value facts, not exhaustive detail recall.
+The gap below reflects that mismatch, not that one is "better". A fair pi-memory benchmark would measure long-term retention of a small set of high-value facts, not exhaustive detail recall.
 
 ## Results (LoCoMo, 2-sample slice: conv-26 + conv-30, 304 QA)
 
-Extraction/write + answer model: `deepseek-v4-flash`. Judge: `deepseek-v4-pro`.
-Endpoint resolved from a pi `models.json` (`--models`).
+Extraction/write + answer model: `deepseek-v4-flash`. Judge: `deepseek-v4-pro`. Endpoint resolved from a pi `models.json` (`--models`).
 
 | Runner            | literal recall | LLM-judge recall |
 |-------------------|---------------:|-----------------:|


### PR DESCRIPTION
## Summary

- Document `pi2dsh` and `dsh-pi-host` in the root and package READMEs.
- Simplify the PR and issue templates, including removing PR version reporting.
- Normalize README prose wrapping and document the convention in `AGENTS.md`.

## Verification

- Checked all 20 README files; no hard-wrapped prose groups remain.
- Pre-commit hooks: lint, typecheck, 1,893 tests, and build.

## Related issue

Refs #159

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.