### PR TITLE
feat(pi-memory-mem0): add agent scope and safe deduplication

### DIFF
--- a/packages/pi-memory-mem0/README.md
+++ b/packages/pi-memory-mem0/README.md
@@ -265,6 +265,8 @@ Stored content is credential-redacted first; results are returned with the same 
 /mem0 search <query>  # Semantic search
 /mem0 profile         # List all memories
 /mem0 add <text>      # Store a memory manually
+/mem0 dedup           # Preview exact duplicates in the current scope
+/mem0 dedup --apply   # Confirm and remove exact duplicates
 /mem0 delete <id>     # Remove a memory by id
 ```
 
@@ -279,16 +281,18 @@ They do not interfere with each other, and their tool names do not collide. `pi-
 
 ## Dedup API
 
-The package exports a standalone deduplication function used by pi-memory's dreaming job:
+Normal Mem0 writes use inference, so Mem0's own duplicate and conflict handling remains the primary protection. The package also exports a standalone maintenance function for previewing or removing legacy exact duplicates:
 
 ```ts
 import { dedupMemories } from "@amaster.ai/pi-memory-mem0/dedup";
 
 const result = await dedupMemories({
   userId: "my-user",
+  agentId: "my-agent",
   config: { mode: "platform", apiKey: "..." },
+  dryRun: true,
 });
-// result: { total: 42, duplicatesRemoved: 3 }
+// result: { total: 42, duplicatesFound: 3, duplicatesRemoved: 0, deleteFailures: 0 }
 ```
 
-Normalizes entries (case-insensitive, whitespace-collapsed), identifies exact duplicates, and deletes the older ones through the configured provider. In OSS mode those deletes go directly to the vector store.
+Dedup normalizes entries using Unicode NFC, case-insensitive comparison, and collapsed whitespace, then keeps the newest exact match. Platform user and agent entity scopes are processed independently; embedded and self-hosted modes use the exact `userId` + `agentId` scope. Platform and embedded scopes are limited to 10,000 memories; self-hosted dedup requests the server maximum of 1,000 and fails closed when that limit is reached, so it only applies to scopes proven to contain at most 999 memories. Invalid or repeated IDs, empty memory content, missing, invalid, or tied timestamps, incomplete pagination, inconsistent Platform counts, and cancellation all fail closed; individual deletion failures are reported, and no automatic background cleanup is installed.

--- a/packages/pi-memory-mem0/README.md
+++ b/packages/pi-memory-mem0/README.md
@@ -102,6 +102,7 @@ Calls the OSS REST server directly. The server uses `/memories` and `/search`, n
     "baseUrl": "${MEM0_BASE_URL}",
     "apiKey": "${MEM0_API_KEY}",
     "userId": "${PAPERCLIP_COMPANY_ID}",
+    "agentId": "${PAPERCLIP_AGENT_ID}",
     "userIdScope": "exact"
   }
 }
@@ -188,6 +189,7 @@ The configured vector store always owns persistence. To request an intentionally
 | `baseUrl` | string | `https://api.mem0.ai` | Platform override; required for self-hosted mode |
 | `requestTimeoutMs` | number | `30000` | Self-hosted request timeout |
 | `userId` | string | `$USER` or `"default-user"` | Memory scoping identifier |
+| `agentId` | string | — | Optional agent scope. Supports environment interpolation |
 | `userIdScope` | `"project"` \| `"exact"` | `"project"` | Append the cwd hash or use `userId` verbatim |
 | `topK` | number | `5` | Max recalled memories per turn |
 | `useRegistryKeys` | boolean | `true` | Whether OSS mode resolves keys from pi registry |
@@ -197,6 +199,8 @@ The configured vector store always owns persistence. To request an intentionally
 | `oss.historyStore` | object | SQLite at `<home>/memories/mem0-history.db` | Custom mem0 history store config |
 | `oss.historyDbPath` | string | `<home>/memories/mem0-history.db` | Shortcut for SQLite history DB path |
 | `oss.disableHistory` | boolean | `false` | Disable mem0 operation history |
+
+Embedded and self-hosted modes read and write the exact `userId` + `agentId` scope; Platform mode reads the user and agent entity scopes with OR because Mem0 Platform stores them as separate records. Existing memories with a null `agent_id` are not backfilled automatically.
 
 ## Data Storage
 

--- a/packages/pi-memory-mem0/src/__tests__/dedup.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/dedup.test.ts
@@ -25,12 +25,69 @@ function mockProviderWith(items: MemoryItem[]) {
     add: vi.fn(),
     search: vi.fn(),
     getAll: vi.fn().mockResolvedValue(items),
+    getDedupGroups: vi.fn().mockResolvedValue([items]),
     delete: deleteMock,
   });
   return { deleteMock };
 }
 
 describe('dedupMemories', () => {
+  it('refuses providers that cannot separate entity scopes safely', async () => {
+    mockCreateProvider.mockResolvedValue({
+      add: vi.fn(),
+      search: vi.fn(),
+      getAll: vi.fn().mockResolvedValue([]),
+      delete: vi.fn(),
+    });
+
+    await expect(
+      dedupMemories({
+        userId: 'company-1',
+        agentId: 'agent-1',
+        config: { mode: 'platform', apiKey: 'test' },
+        dryRun: true,
+      }),
+    ).rejects.toThrow('does not support safe deduplication');
+  });
+
+  it('previews duplicates in the current agent scope without deleting', async () => {
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    const getDedupGroups = vi
+      .fn()
+      .mockResolvedValue([
+        [
+          makeItem('old', 'User prefers tabs', '2026-06-01T10:00:00Z'),
+          makeItem('new', 'user prefers tabs', '2026-06-10T10:00:00Z'),
+        ],
+      ]);
+    mockCreateProvider.mockResolvedValue({
+      add: vi.fn(),
+      search: vi.fn(),
+      getAll: vi.fn(),
+      delete: deleteMock,
+      getDedupGroups,
+    });
+
+    const result = await dedupMemories({
+      userId: 'company-1',
+      agentId: 'agent-1',
+      config: { mode: 'platform', apiKey: 'test' },
+      dryRun: true,
+    });
+
+    expect(getDedupGroups).toHaveBeenCalledWith({
+      userId: 'company-1',
+      agentId: 'agent-1',
+    });
+    expect(result).toEqual({
+      total: 2,
+      duplicatesFound: 1,
+      duplicatesRemoved: 0,
+      deleteFailures: 0,
+    });
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
   it('returns zero duplicates for empty store', async () => {
     mockProviderWith([]);
 
@@ -39,7 +96,12 @@ describe('dedupMemories', () => {
       config: { mode: 'platform', apiKey: 'test' },
     });
 
-    expect(result).toEqual({ total: 0, duplicatesRemoved: 0 });
+    expect(result).toEqual({
+      total: 0,
+      duplicatesFound: 0,
+      duplicatesRemoved: 0,
+      deleteFailures: 0,
+    });
   });
 
   it('returns zero duplicates when all entries are unique', async () => {
@@ -54,7 +116,12 @@ describe('dedupMemories', () => {
       config: { mode: 'platform', apiKey: 'test' },
     });
 
-    expect(result).toEqual({ total: 3, duplicatesRemoved: 0 });
+    expect(result).toEqual({
+      total: 3,
+      duplicatesFound: 0,
+      duplicatesRemoved: 0,
+      deleteFailures: 0,
+    });
     expect(deleteMock).not.toHaveBeenCalled();
   });
 
@@ -70,9 +137,53 @@ describe('dedupMemories', () => {
       config: { mode: 'platform', apiKey: 'test' },
     });
 
-    expect(result).toEqual({ total: 3, duplicatesRemoved: 1 });
+    expect(result).toEqual({
+      total: 3,
+      duplicatesFound: 1,
+      duplicatesRemoved: 1,
+      deleteFailures: 0,
+    });
     expect(deleteMock).toHaveBeenCalledTimes(1);
     expect(deleteMock).toHaveBeenCalledWith('1');
+  });
+
+  it('normalizes Unicode and collapsed whitespace before comparison', async () => {
+    const { deleteMock } = mockProviderWith([
+      makeItem('old', 'Café\tprefers   tabs', '2026-01-01T00:00:00Z'),
+      makeItem('new', 'CAFE\u0301 prefers tabs', '2026-02-01T00:00:00Z'),
+    ]);
+
+    await dedupMemories({
+      userId: 'test-user',
+      config: { mode: 'platform', apiKey: 'test' },
+    });
+
+    expect(deleteMock).toHaveBeenCalledWith('old');
+  });
+
+  it('does not deduplicate identical text across independent entity groups', async () => {
+    const deleteMock = vi.fn();
+    mockCreateProvider.mockResolvedValue({
+      add: vi.fn(),
+      search: vi.fn(),
+      getAll: vi.fn(),
+      getDedupGroups: vi
+        .fn()
+        .mockResolvedValue([
+          [makeItem('user-memory', 'same text', '2026-01-01T00:00:00Z')],
+          [makeItem('agent-memory', 'same text', '2026-02-01T00:00:00Z')],
+        ]),
+      delete: deleteMock,
+    });
+
+    const result = await dedupMemories({
+      userId: 'company-1',
+      agentId: 'agent-1',
+      config: { mode: 'platform', apiKey: 'test' },
+    });
+
+    expect(result.duplicatesFound).toBe(0);
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it('keeps the most recently updated entry among multiple duplicates', async () => {
@@ -87,10 +198,119 @@ describe('dedupMemories', () => {
       config: { mode: 'platform', apiKey: 'test' },
     });
 
-    expect(result).toEqual({ total: 3, duplicatesRemoved: 2 });
+    expect(result).toEqual({
+      total: 3,
+      duplicatesFound: 2,
+      duplicatesRemoved: 2,
+      deleteFailures: 0,
+    });
     expect(deleteMock).toHaveBeenCalledTimes(2);
     expect(deleteMock).toHaveBeenCalledWith('old');
     expect(deleteMock).toHaveBeenCalledWith('oldest');
+  });
+
+  it('falls back to creation time when duplicate memories were never updated', async () => {
+    const { deleteMock } = mockProviderWith([
+      { id: 'old', memory: 'same text', created_at: '2026-01-01T00:00:00Z' },
+      { id: 'new', memory: 'same text', created_at: '2026-02-01T00:00:00Z' },
+    ]);
+
+    await dedupMemories({
+      userId: 'test-user',
+      config: { mode: 'embedded' },
+    });
+
+    expect(deleteMock).toHaveBeenCalledWith('old');
+    expect(deleteMock).not.toHaveBeenCalledWith('new');
+  });
+
+  it('fails closed when duplicate memories have the same effective timestamp', async () => {
+    const { deleteMock } = mockProviderWith([
+      makeItem('first', 'same text', '2026-01-01T00:00:00Z'),
+      makeItem('second', 'same text', '2026-01-01T00:00:00Z'),
+    ]);
+
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'embedded' },
+      }),
+    ).rejects.toThrow('Mem0 dedup cannot determine the newest duplicate.');
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when older duplicate memories have tied timestamps', async () => {
+    const { deleteMock } = mockProviderWith([
+      makeItem('newest', 'same text', '2026-06-01T00:00:00Z'),
+      makeItem('older-a', 'same text', '2026-01-01T00:00:00Z'),
+      makeItem('older-b', 'same text', '2026-01-01T00:00:00Z'),
+    ]);
+
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'embedded' },
+      }),
+    ).rejects.toThrow('Mem0 dedup cannot determine the newest duplicate.');
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when duplicate recency cannot be determined', async () => {
+    const { deleteMock } = mockProviderWith([
+      makeItem('first', 'same text'),
+      makeItem('second', 'same text'),
+    ]);
+
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'embedded' },
+      }),
+    ).rejects.toThrow('Mem0 dedup cannot determine the newest duplicate.');
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['empty', [{ id: '', memory: 'unique', created_at: '2026-01-01T00:00:00Z' }]],
+    [
+      'internal whitespace',
+      [{ id: 'bad id', memory: 'unique', created_at: '2026-01-01T00:00:00Z' }],
+    ],
+    [
+      'duplicate',
+      [
+        { id: 'same-id', memory: 'same text', created_at: '2026-01-01T00:00:00Z' },
+        { id: 'same-id', memory: 'same text', created_at: '2026-01-01T00:00:00Z' },
+      ],
+    ],
+  ])('fails closed for %s memory ids', async (_kind, items) => {
+    const { deleteMock } = mockProviderWith(items);
+
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'embedded' },
+      }),
+    ).rejects.toThrow('Mem0 dedup received an invalid or duplicate memory ID.');
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['empty', ''],
+    ['whitespace-only', ' \t\n '],
+  ])('fails closed for %s memory content', async (_kind, memory) => {
+    const { deleteMock } = mockProviderWith([
+      makeItem('first', memory, '2026-01-01T00:00:00Z'),
+      makeItem('second', memory, '2026-06-01T00:00:00Z'),
+    ]);
+
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'embedded' },
+      }),
+    ).rejects.toThrow('Mem0 dedup received empty memory content.');
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it('continues on individual delete failures and counts only successes', async () => {
@@ -108,6 +328,15 @@ describe('dedupMemories', () => {
           makeItem('2', 'hello', '2026-06-01T00:00:00Z'),
           makeItem('3', 'hello', '2026-06-10T00:00:00Z'),
         ]),
+      getDedupGroups: vi
+        .fn()
+        .mockResolvedValue([
+          [
+            makeItem('1', 'hello', '2026-01-01T00:00:00Z'),
+            makeItem('2', 'hello', '2026-06-01T00:00:00Z'),
+            makeItem('3', 'hello', '2026-06-10T00:00:00Z'),
+          ],
+        ]),
       delete: deleteMock,
     });
 
@@ -116,28 +345,86 @@ describe('dedupMemories', () => {
       config: { mode: 'platform', apiKey: 'test' },
     });
 
-    expect(result).toEqual({ total: 3, duplicatesRemoved: 1 });
+    expect(result).toEqual({
+      total: 3,
+      duplicatesFound: 2,
+      duplicatesRemoved: 1,
+      deleteFailures: 1,
+    });
     expect(deleteMock).toHaveBeenCalledTimes(2);
   });
 
   it('respects abort signal', async () => {
     const controller = new AbortController();
-    controller.abort();
+    const reason = new Error('cancelled');
+    controller.abort(reason);
 
     const { deleteMock } = mockProviderWith([
       makeItem('1', 'a', '2026-06-01T10:00:00Z'),
       makeItem('2', 'a', '2026-06-10T10:00:00Z'),
     ]);
 
-    const result = await dedupMemories({
-      userId: 'test-user',
-      config: { mode: 'platform', apiKey: 'test' },
-      signal: controller.signal,
-    });
-
-    expect(result.total).toBe(2);
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'platform', apiKey: 'test' },
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
     expect(deleteMock).not.toHaveBeenCalled();
   });
+
+  it('propagates cancellation between duplicate deletions', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled during deletion');
+    const items = [
+      makeItem('1', 'same', '2026-01-01T00:00:00Z'),
+      makeItem('2', 'same', '2026-02-01T00:00:00Z'),
+      makeItem('3', 'same', '2026-03-01T00:00:00Z'),
+    ];
+    const deleteMock = vi.fn().mockImplementation(async () => {
+      controller.abort(reason);
+    });
+    mockCreateProvider.mockResolvedValue({
+      add: vi.fn(),
+      search: vi.fn(),
+      getAll: vi.fn(),
+      getDedupGroups: vi.fn().mockResolvedValue([items]),
+      delete: deleteMock,
+    });
+
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'platform', apiKey: 'test' },
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates cancellation while waiting for approval', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancelled during approval');
+    const { deleteMock } = mockProviderWith([
+      makeItem('old', 'same', '2026-01-01T00:00:00Z'),
+      makeItem('new', 'same', '2026-02-01T00:00:00Z'),
+    ]);
+
+    await expect(
+      dedupMemories({
+        userId: 'test-user',
+        config: { mode: 'platform', apiKey: 'test' },
+        signal: controller.signal,
+        approve: async () => {
+          controller.abort(reason);
+          return false;
+        },
+      }),
+    ).rejects.toBe(reason);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
   it('uses stable vector-store IDs in OSS mode', async () => {
     const { deleteMock } = mockProviderWith([
       makeItem('1', 'User prefers tabs', '2026-06-01T10:00:00Z'),
@@ -150,7 +437,12 @@ describe('dedupMemories', () => {
       config: { mode: 'embedded' },
     });
 
-    expect(result).toEqual({ total: 3, duplicatesRemoved: 1 });
+    expect(result).toEqual({
+      total: 3,
+      duplicatesFound: 1,
+      duplicatesRemoved: 1,
+      deleteFailures: 0,
+    });
     expect(deleteMock).toHaveBeenCalledWith('1');
     expect(mockCreateProvider).toHaveBeenCalledWith({ config: { mode: 'embedded' } });
   });

--- a/packages/pi-memory-mem0/src/__tests__/extension.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/extension.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const { mockCreateMem0Provider } = vi.hoisted(() => ({
+const { mockCreateMem0Provider, mockDedupProviderMemories } = vi.hoisted(() => ({
   mockCreateMem0Provider: vi.fn(),
+  mockDedupProviderMemories: vi.fn(),
 }));
 
 // Isolate mem0Extension from any settings.json that happens to live on the
@@ -26,6 +27,10 @@ vi.mock('../provider.js', async (importOriginal) => {
   };
 });
 
+vi.mock('../dedup.js', () => ({
+  dedupProviderMemories: mockDedupProviderMemories,
+}));
+
 import { loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import mem0Extension from '../index.js';
 
@@ -33,6 +38,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.mocked(loadPiSettings).mockReturnValue({});
   mockCreateMem0Provider.mockReset();
+  mockDedupProviderMemories.mockReset();
 });
 
 // ---------------------------------------------------------------------------
@@ -583,6 +589,108 @@ describe('/mem0 command — not active', () => {
 });
 
 describe('/mem0 command — active subcommands', () => {
+  it('previews exact duplicates without deleting them', async () => {
+    const provider = mockActiveProvider();
+    mockDedupProviderMemories.mockResolvedValue({
+      total: 3,
+      duplicatesFound: 1,
+      duplicatesRemoved: 0,
+      deleteFailures: 0,
+    });
+    vi.mocked(loadPiSettings).mockReturnValue({
+      mode: 'platform',
+      apiKey: 'm0-test',
+      agentId: 'agent-1',
+    });
+    const { pi, handlers, commands } = createMockPi();
+    mem0Extension(pi as never);
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    await commands.mem0!.handler('dedup', ctx);
+
+    expect(mockDedupProviderMemories).toHaveBeenCalledWith(provider, {
+      userId: expect.any(String),
+      agentId: 'agent-1',
+      dryRun: true,
+    });
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      'Mem0 dedup preview: scanned 3 memories and found 1 exact duplicate. Run /mem0 dedup --apply to remove it.',
+      'info',
+    );
+  });
+
+  it('does not suggest apply when the dedup preview is clean', async () => {
+    mockActiveProvider();
+    mockDedupProviderMemories.mockResolvedValue({
+      total: 3,
+      duplicatesFound: 0,
+      duplicatesRemoved: 0,
+      deleteFailures: 0,
+    });
+    const { pi, handlers, commands } = createMockPi();
+    mem0Extension(pi as never);
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    await commands.mem0!.handler('dedup', ctx);
+
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      'Mem0 dedup preview: scanned 3 memories; no exact duplicates found.',
+      'info',
+    );
+  });
+
+  it('applies exact dedup only after interactive confirmation', async () => {
+    const provider = mockActiveProvider();
+    mockDedupProviderMemories.mockImplementation(
+      async (
+        _provider: unknown,
+        opts: { approve: (preview: Record<string, number>) => Promise<boolean> },
+      ) => {
+        const approved = await opts.approve({
+          total: 3,
+          duplicatesFound: 1,
+          duplicatesRemoved: 0,
+          deleteFailures: 0,
+        });
+        expect(approved).toBe(true);
+        return {
+          total: 3,
+          duplicatesFound: 1,
+          duplicatesRemoved: 1,
+          deleteFailures: 0,
+        };
+      },
+    );
+    const { pi, handlers, commands } = createMockPi();
+    mem0Extension(pi as never);
+    const confirm = vi.fn().mockResolvedValue(true);
+    const ctx = {
+      ...createMockCtx(),
+      hasUI: true,
+      ui: { ...createMockCtx().ui, confirm },
+    };
+    await handlers.session_start![0]!({}, ctx);
+
+    await commands.mem0!.handler('dedup --apply', ctx);
+
+    expect(confirm).toHaveBeenCalledWith(
+      'Remove exact duplicate memories?',
+      '1 duplicate will be permanently deleted.',
+    );
+    expect(mockDedupProviderMemories).toHaveBeenCalledTimes(1);
+    expect(mockDedupProviderMemories).toHaveBeenCalledWith(provider, {
+      userId: expect.any(String),
+      dryRun: false,
+      approve: expect.any(Function),
+    });
+    expect(ctx.ui.notify).toHaveBeenCalledWith(
+      'Mem0 dedup complete: removed 1 duplicate; 0 deletions failed.',
+      'info',
+    );
+  });
+
   it('uses the configured agentId for add, search, and profile', async () => {
     const provider = mockActiveProvider();
     vi.mocked(loadPiSettings).mockReturnValue({

--- a/packages/pi-memory-mem0/src/__tests__/extension.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/extension.test.ts
@@ -242,6 +242,54 @@ describe('memoryMode gating', () => {
     expect(result.content[0]!.text).toContain('disabled');
   });
 
+  it('uses the current session agentId from an earlier tool registration', async () => {
+    const providerA = {
+      add: vi.fn(),
+      search: vi.fn().mockResolvedValue([]),
+      getAll: vi.fn(),
+      delete: vi.fn(),
+    };
+    const providerB = {
+      add: vi.fn(),
+      search: vi.fn().mockResolvedValue([]),
+      getAll: vi.fn(),
+      delete: vi.fn(),
+    };
+    const { pi, handlers, tools } = createMockPi();
+    mem0Extension(pi as never);
+    const ctx = createMockCtx();
+
+    vi.mocked(loadPiSettings).mockReturnValue({
+      mode: 'platform',
+      apiKey: 'm0-test',
+      memoryMode: 'hybrid',
+      agentId: 'agent-a',
+    });
+    mockCreateMem0Provider.mockResolvedValueOnce(providerA);
+    await handlers.session_start![0]!({}, ctx);
+    const earlierTool = tools[0]! as unknown as {
+      execute: (...args: unknown[]) => Promise<unknown>;
+    };
+    await handlers.session_shutdown![0]!({}, ctx);
+
+    vi.mocked(loadPiSettings).mockReturnValue({
+      mode: 'platform',
+      apiKey: 'm0-test',
+      memoryMode: 'hybrid',
+      agentId: 'agent-b',
+    });
+    mockCreateMem0Provider.mockResolvedValueOnce(providerB);
+    await handlers.session_start![0]!({}, ctx);
+
+    await earlierTool.execute('call-1', { action: 'search', query: 'x' }, undefined, undefined, {});
+
+    expect(providerA.search).not.toHaveBeenCalled();
+    expect(providerB.search).toHaveBeenCalledWith(
+      'x',
+      expect.objectContaining({ agentId: 'agent-b' }),
+    );
+  });
+
   it('ignores a superseded session_start that resolves after a newer session', async () => {
     // Session A (hybrid, slow embedded-style init) is still awaiting its
     // provider when session B (passive, fast init) starts and completes.
@@ -431,6 +479,11 @@ describe('passive recall', () => {
 describe('passive capture', () => {
   it('stores the turn with credentials redacted', async () => {
     const provider = mockActiveProvider();
+    vi.mocked(loadPiSettings).mockReturnValue({
+      mode: 'platform',
+      apiKey: 'm0-test',
+      agentId: ' agent-1 ',
+    });
     const { pi, handlers } = createMockPi();
     mem0Extension(pi as never);
     const ctx = createMockCtx();
@@ -451,7 +504,7 @@ describe('passive capture', () => {
     expect(provider.add).toHaveBeenCalledTimes(1);
     const [messages, opts] = provider.add.mock.calls[0] as [
       Array<{ role: string; content: string }>,
-      { userId: string },
+      { userId: string; agentId?: string },
     ];
     expect(messages[0]!.role).toBe('user');
     expect(messages[1]!.role).toBe('assistant');
@@ -459,11 +512,12 @@ describe('passive capture', () => {
     expect(JSON.stringify(messages)).not.toContain('abcdefghijklmnop');
     expect(JSON.stringify(messages)).toContain('[REDACTED]');
     expect(opts.userId).toMatch(/:project:/);
+    expect(opts.agentId).toBe('agent-1');
 
     // The prefetch search query is redacted before it reaches the backend too.
     expect(provider.search).toHaveBeenCalledWith(
       'use api_key=[REDACTED] for the API',
-      expect.objectContaining({ topK: 5 }),
+      expect.objectContaining({ agentId: 'agent-1', topK: 5 }),
     );
   });
 
@@ -529,6 +583,33 @@ describe('/mem0 command — not active', () => {
 });
 
 describe('/mem0 command — active subcommands', () => {
+  it('uses the configured agentId for add, search, and profile', async () => {
+    const provider = mockActiveProvider();
+    vi.mocked(loadPiSettings).mockReturnValue({
+      mode: 'platform',
+      apiKey: 'm0-test',
+      agentId: 'agent-1',
+    });
+    const { pi, handlers, commands } = createMockPi();
+    mem0Extension(pi as never);
+    const ctx = createMockCtx();
+    await handlers.session_start![0]!({}, ctx);
+
+    await commands.mem0!.handler('search preferences', ctx);
+    await commands.mem0!.handler('profile', ctx);
+    await commands.mem0!.handler('add remember this', ctx);
+
+    expect(provider.search).toHaveBeenCalledWith(
+      'preferences',
+      expect.objectContaining({ agentId: 'agent-1' }),
+    );
+    expect(provider.getAll).toHaveBeenCalledWith(expect.objectContaining({ agentId: 'agent-1' }));
+    expect(provider.add).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ agentId: 'agent-1' }),
+    );
+  });
+
   it('add stores text with credentials redacted', async () => {
     const provider = mockActiveProvider();
     const { pi, handlers, commands } = createMockPi();

--- a/packages/pi-memory-mem0/src/__tests__/provider-scope.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/provider-scope.test.ts
@@ -53,6 +53,116 @@ describe('Mem0 provider entity scope', () => {
     expect(mocks.platformGetAll).toHaveBeenCalledWith({ filters });
   });
 
+  it('paginates Platform user and agent memories as separate dedup groups', async () => {
+    mocks.platformGetAll.mockImplementation(async (options: Record<string, unknown>) => {
+      const filters = options.filters as Record<string, string>;
+      if (filters.user_id && options.page === 1) {
+        return {
+          count: 2,
+          results: [{ id: 'user-1', memory: 'same text' }],
+          next: 'page-2',
+        };
+      }
+      if (filters.user_id) {
+        return {
+          count: 2,
+          results: [{ id: 'user-2', memory: 'same text' }],
+          next: null,
+        };
+      }
+      return {
+        count: 1,
+        results: [{ id: 'agent-1', memory: 'same text' }],
+        next: null,
+      };
+    });
+    const provider = await createMem0Provider({
+      config: { mode: 'platform', apiKey: 'm0-test' },
+    });
+
+    const groups = await provider.getDedupGroups!({
+      userId: 'company-1',
+      agentId: 'agent-1',
+    });
+
+    expect(groups).toEqual([
+      [
+        { id: 'user-1', memory: 'same text' },
+        { id: 'user-2', memory: 'same text' },
+      ],
+      [{ id: 'agent-1', memory: 'same text' }],
+    ]);
+    expect(mocks.platformGetAll).toHaveBeenCalledWith({
+      filters: { user_id: 'company-1' },
+      page: 1,
+      pageSize: 200,
+    });
+    expect(mocks.platformGetAll).toHaveBeenCalledWith({
+      filters: { user_id: 'company-1' },
+      page: 2,
+      pageSize: 200,
+    });
+    expect(mocks.platformGetAll).toHaveBeenCalledWith({
+      filters: { agent_id: 'agent-1' },
+      page: 1,
+      pageSize: 200,
+    });
+  });
+
+  it('fails closed when Platform pagination returns no progress', async () => {
+    mocks.platformGetAll.mockResolvedValue({ count: 1, results: [], next: 'same-page' });
+    const provider = await createMem0Provider({
+      config: { mode: 'platform', apiKey: 'm0-test' },
+    });
+
+    await expect(provider.getDedupGroups!({ userId: 'company-1' })).rejects.toThrow(
+      'Mem0 dedup pagination returned an empty page with a next link.',
+    );
+    expect(mocks.platformGetAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when Platform count exceeds the returned memories', async () => {
+    mocks.platformGetAll.mockResolvedValue({
+      count: 2,
+      results: [{ id: 'only-result', memory: 'incomplete page' }],
+      next: null,
+    });
+    const provider = await createMem0Provider({
+      config: { mode: 'platform', apiKey: 'm0-test' },
+    });
+
+    await expect(provider.getDedupGroups!({ userId: 'company-1' })).rejects.toThrow(
+      'Mem0 dedup pagination count does not match the returned memories.',
+    );
+  });
+
+  it('fails closed when Platform pagination omits a valid count', async () => {
+    mocks.platformGetAll.mockResolvedValue({ results: [], next: null });
+    const provider = await createMem0Provider({
+      config: { mode: 'platform', apiKey: 'm0-test' },
+    });
+
+    await expect(provider.getDedupGroups!({ userId: 'company-1' })).rejects.toThrow(
+      'Mem0 dedup pagination returned an invalid count.',
+    );
+  });
+
+  it('bounds Platform dedup pagination requests', async () => {
+    mocks.platformGetAll.mockResolvedValue({
+      count: 10_000,
+      results: [{ id: 'one', memory: 'one result per page' }],
+      next: 'more',
+    });
+    const provider = await createMem0Provider({
+      config: { mode: 'platform', apiKey: 'm0-test' },
+    });
+
+    await expect(provider.getDedupGroups!({ userId: 'company-1' })).rejects.toThrow(
+      'Mem0 dedup pagination exceeds 50 pages.',
+    );
+    expect(mocks.platformGetAll).toHaveBeenCalledTimes(50);
+  });
+
   it('uses top-level agentId for Embedded writes and exact filters for reads', async () => {
     const provider = await createMem0Provider({
       config: { mode: 'embedded', oss: { disableHistory: true } },
@@ -73,5 +183,34 @@ describe('Mem0 provider entity scope', () => {
     const filters = { user_id: 'company-1', agent_id: 'agent-1' };
     expect(mocks.embeddedSearch).toHaveBeenCalledWith('preferences', { filters, topK: 7 });
     expect(mocks.embeddedGetAll).toHaveBeenCalledWith({ filters });
+  });
+
+  it('keeps Embedded user and agent memories in one exact dedup group', async () => {
+    mocks.embeddedGetAll.mockResolvedValue({
+      results: [
+        { id: 'old', memory: 'same text' },
+        { id: 'new', memory: 'same text' },
+      ],
+    });
+    const provider = await createMem0Provider({
+      config: { mode: 'embedded', oss: { disableHistory: true } },
+    });
+    mocks.embeddedGetAll.mockClear();
+
+    const groups = await provider.getDedupGroups!({
+      userId: 'company-1',
+      agentId: 'agent-1',
+    });
+
+    expect(groups).toEqual([
+      [
+        { id: 'old', memory: 'same text' },
+        { id: 'new', memory: 'same text' },
+      ],
+    ]);
+    expect(mocks.embeddedGetAll).toHaveBeenCalledWith({
+      filters: { user_id: 'company-1', agent_id: 'agent-1' },
+      topK: 10_001,
+    });
   });
 });

--- a/packages/pi-memory-mem0/src/__tests__/provider-scope.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/provider-scope.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMem0Provider } from '../provider.js';
+
+const mocks = vi.hoisted(() => ({
+  platformAdd: vi.fn().mockResolvedValue({ results: [] }),
+  platformSearch: vi.fn().mockResolvedValue({ results: [] }),
+  platformGetAll: vi.fn().mockResolvedValue({ results: [] }),
+  embeddedAdd: vi.fn().mockResolvedValue({ results: [] }),
+  embeddedSearch: vi.fn().mockResolvedValue({ results: [] }),
+  embeddedGetAll: vi.fn().mockResolvedValue({ results: [] }),
+}));
+
+vi.mock('mem0ai', () => ({
+  MemoryClient: class {
+    _fetchWithErrorHandling = vi.fn();
+    add = mocks.platformAdd;
+    search = mocks.platformSearch;
+    getAll = mocks.platformGetAll;
+  },
+}));
+
+vi.mock('mem0ai/oss', () => ({
+  Memory: class {
+    add = mocks.embeddedAdd;
+    search = mocks.embeddedSearch;
+    getAll = mocks.embeddedGetAll;
+  },
+}));
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockClear();
+});
+
+describe('Mem0 provider entity scope', () => {
+  it('uses top-level agentId for Platform writes and OR filters for reads', async () => {
+    const provider = await createMem0Provider({
+      config: { mode: 'platform', apiKey: 'm0-test' },
+    });
+
+    await provider.add([{ role: 'user', content: 'dark mode' }], {
+      userId: 'company-1',
+      agentId: 'agent-1',
+    });
+    await provider.search('preferences', { userId: 'company-1', agentId: 'agent-1', topK: 7 });
+    await provider.getAll({ userId: 'company-1', agentId: 'agent-1' });
+
+    expect(mocks.platformAdd).toHaveBeenCalledWith([{ role: 'user', content: 'dark mode' }], {
+      userId: 'company-1',
+      agentId: 'agent-1',
+    });
+    const filters = { OR: [{ user_id: 'company-1' }, { agent_id: 'agent-1' }] };
+    expect(mocks.platformSearch).toHaveBeenCalledWith('preferences', { filters, topK: 7 });
+    expect(mocks.platformGetAll).toHaveBeenCalledWith({ filters });
+  });
+
+  it('uses top-level agentId for Embedded writes and exact filters for reads', async () => {
+    const provider = await createMem0Provider({
+      config: { mode: 'embedded', oss: { disableHistory: true } },
+    });
+    mocks.embeddedGetAll.mockClear();
+
+    await provider.add([{ role: 'user', content: 'dark mode' }], {
+      userId: 'company-1',
+      agentId: 'agent-1',
+    });
+    await provider.search('preferences', { userId: 'company-1', agentId: 'agent-1', topK: 7 });
+    await provider.getAll({ userId: 'company-1', agentId: 'agent-1' });
+
+    expect(mocks.embeddedAdd).toHaveBeenCalledWith([{ role: 'user', content: 'dark mode' }], {
+      userId: 'company-1',
+      agentId: 'agent-1',
+    });
+    const filters = { user_id: 'company-1', agent_id: 'agent-1' };
+    expect(mocks.embeddedSearch).toHaveBeenCalledWith('preferences', { filters, topK: 7 });
+    expect(mocks.embeddedGetAll).toHaveBeenCalledWith({ filters });
+  });
+});

--- a/packages/pi-memory-mem0/src/__tests__/self-hosted.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/self-hosted.test.ts
@@ -6,7 +6,7 @@ describe('self-hosted Mem0 provider', () => {
     vi.unstubAllGlobals();
   });
 
-  it('uses the OSS REST protocol and exact user filter', async () => {
+  it('uses exact user and agent filters for search', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ results: [{ id: '1', memory: 'likes cats', score: 0.9 }] }), {
         status: 200,
@@ -22,9 +22,9 @@ describe('self-hosted Mem0 provider', () => {
       },
     });
 
-    await expect(provider.search('pets', { userId: 'company-1', topK: 7 })).resolves.toEqual([
-      { id: '1', memory: 'likes cats', score: 0.9 },
-    ]);
+    await expect(
+      provider.search('pets', { userId: 'company-1', agentId: 'agent-1', topK: 7 }),
+    ).resolves.toEqual([{ id: '1', memory: 'likes cats', score: 0.9 }]);
     expect(fetchMock).toHaveBeenCalledWith(
       'https://mem0.example.com/search',
       expect.objectContaining({
@@ -35,7 +35,7 @@ describe('self-hosted Mem0 provider', () => {
         },
         body: JSON.stringify({
           query: 'pets',
-          filters: { user_id: 'company-1' },
+          filters: { user_id: 'company-1', agent_id: 'agent-1' },
           top_k: 7,
         }),
       }),
@@ -91,9 +91,10 @@ describe('self-hosted Mem0 provider', () => {
 
     await provider.add([{ role: 'user', content: 'dark mode' }], {
       userId: 'company/1',
+      agentId: 'agent/1',
       infer: false,
     });
-    await expect(provider.getAll({ userId: 'company/1' })).resolves.toEqual([
+    await expect(provider.getAll({ userId: 'company/1', agentId: 'agent/1' })).resolves.toEqual([
       { id: '1', memory: 'dark mode' },
     ]);
     await provider.delete('memory/1');
@@ -101,10 +102,11 @@ describe('self-hosted Mem0 provider', () => {
     expect(JSON.parse(fetchMock.mock.calls[0]![1].body)).toEqual({
       messages: [{ role: 'user', content: 'dark mode' }],
       user_id: 'company/1',
+      agent_id: 'agent/1',
       infer: false,
     });
     expect(fetchMock.mock.calls[1]![0]).toBe(
-      'https://mem0.example.com/memories?user_id=company%2F1',
+      'https://mem0.example.com/memories?user_id=company%2F1&agent_id=agent%2F1',
     );
     expect(fetchMock.mock.calls[2]![0]).toBe('https://mem0.example.com/memories/memory%2F1');
   });

--- a/packages/pi-memory-mem0/src/__tests__/self-hosted.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/self-hosted.test.ts
@@ -6,6 +6,63 @@ describe('self-hosted Mem0 provider', () => {
     vi.unstubAllGlobals();
   });
 
+  it('keeps self-hosted user and agent memories in one exact dedup group', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: [
+            { id: 'old', memory: 'same text' },
+            { id: 'new', memory: 'same text' },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = await createMem0Provider({
+      config: { mode: 'self-hosted', baseUrl: 'https://mem0.example.com' },
+    });
+
+    const groups = await provider.getDedupGroups!({
+      userId: 'company/1',
+      agentId: 'agent/1',
+    });
+
+    expect(groups).toEqual([
+      [
+        { id: 'old', memory: 'same text' },
+        { id: 'new', memory: 'same text' },
+      ],
+    ]);
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      'https://mem0.example.com/memories?user_id=company%2F1&agent_id=agent%2F1&top_k=1000',
+    );
+  });
+
+  it('fails closed when a self-hosted dedup scope reaches the server limit', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            results: Array.from({ length: 1000 }, (_, index) => ({
+              id: String(index),
+              memory: `memory ${index}`,
+            })),
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      ),
+    );
+    const provider = await createMem0Provider({
+      config: { mode: 'self-hosted', baseUrl: 'https://mem0.example.com' },
+    });
+
+    await expect(provider.getDedupGroups!({ userId: 'company-1' })).rejects.toThrow(
+      'Mem0 self-hosted dedup scope may exceed 999 memories.',
+    );
+  });
+
   it('uses exact user and agent filters for search', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ results: [{ id: '1', memory: 'likes cats', score: 0.9 }] }), {

--- a/packages/pi-memory-mem0/src/__tests__/tools.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/tools.test.ts
@@ -16,6 +16,7 @@ function createTool(provider: Mem0Provider | undefined, enabled = true) {
   return createMem0MemoryTool({
     getProvider: () => provider,
     getUserId: () => 'user:project:abc',
+    getAgentId: () => undefined,
     isEnabled: () => enabled,
     topK: 5,
   });

--- a/packages/pi-memory-mem0/src/dedup.ts
+++ b/packages/pi-memory-mem0/src/dedup.ts
@@ -7,76 +7,147 @@
  * All modes use the provider interface. In embedded mode the configured
  * vector store is the source of truth and its IDs remain stable across restarts.
  */
-import { createMem0Provider, type ProviderResolver } from './provider.js';
+import { createMem0Provider, type Mem0Provider, type ProviderResolver } from './provider.js';
 import type { Mem0ExtensionConfig, MemoryItem } from './types.js';
 
 export interface DedupOptions {
   userId: string;
+  agentId?: string;
   config: Mem0ExtensionConfig;
   resolveProvider?: ProviderResolver;
   signal?: AbortSignal;
+  dryRun?: boolean;
+  approve?: (preview: DedupResult) => boolean | Promise<boolean>;
 }
 
 export interface DedupResult {
   total: number;
+  duplicatesFound: number;
   duplicatesRemoved: number;
+  deleteFailures: number;
 }
 
 export async function dedupMemories(opts: DedupOptions): Promise<DedupResult> {
-  const { userId, config, resolveProvider, signal } = opts;
+  const { config, resolveProvider } = opts;
 
   const provider = await createMem0Provider({
     config,
     ...(resolveProvider ? { resolveProvider } : {}),
   });
-  const allMemories = await provider.getAll({ userId, ...(signal ? { signal } : {}) });
+  return dedupProviderMemories(provider, opts);
+}
 
-  if (allMemories.length === 0) {
-    return { total: 0, duplicatesRemoved: 0 };
+export async function dedupProviderMemories(
+  provider: Mem0Provider,
+  opts: Pick<DedupOptions, 'userId' | 'agentId' | 'signal' | 'dryRun' | 'approve'>,
+): Promise<DedupResult> {
+  const { userId, agentId, signal, dryRun = false, approve } = opts;
+  const scope = {
+    userId,
+    ...(agentId ? { agentId } : {}),
+    ...(signal ? { signal } : {}),
+  };
+  if (!provider.getDedupGroups) {
+    throw new Error('The configured Mem0 provider does not support safe deduplication.');
+  }
+  signal?.throwIfAborted();
+  const groups = await provider.getDedupGroups(scope);
+  signal?.throwIfAborted();
+  const memoryIds = new Set<string>();
+  for (const item of groups.flat()) {
+    signal?.throwIfAborted();
+    const { id } = item;
+    if (!id || /\s/.test(id) || memoryIds.has(id)) {
+      throw new Error('Mem0 dedup received an invalid or duplicate memory ID.');
+    }
+    memoryIds.add(id);
+    if (!item.memory.trim()) {
+      throw new Error('Mem0 dedup received empty memory content.');
+    }
+  }
+  const total = groups.reduce((count, group) => count + group.length, 0);
+
+  const duplicateIds = new Set(groups.flatMap((group) => findDuplicateIds(group, signal)));
+  const preview = {
+    total,
+    duplicatesFound: duplicateIds.size,
+    duplicatesRemoved: 0,
+    deleteFailures: 0,
+  };
+  if (dryRun) return preview;
+  if (approve) {
+    const approved = await approve(preview);
+    signal?.throwIfAborted();
+    if (!approved) return preview;
   }
 
-  const duplicateIds = findDuplicateIds(allMemories, signal);
-
   let removed = 0;
+  let failures = 0;
   for (const id of duplicateIds) {
-    if (signal?.aborted) break;
+    signal?.throwIfAborted();
     try {
       await (signal ? provider.delete(id, { signal }) : provider.delete(id));
+      signal?.throwIfAborted();
       removed++;
     } catch {
-      // best-effort
+      signal?.throwIfAborted();
+      failures++;
     }
   }
 
-  return { total: allMemories.length, duplicatesRemoved: removed };
+  return {
+    total,
+    duplicatesFound: duplicateIds.size,
+    duplicatesRemoved: removed,
+    deleteFailures: failures,
+  };
 }
 
 /**
  * Shared: find IDs of duplicate entries to remove (keeps the newest).
  */
 function findDuplicateIds(allMemories: MemoryItem[], signal?: AbortSignal): string[] {
-  const seen = new Map<string, MemoryItem>();
-  const duplicateIds: string[] = [];
+  const groups = new Map<string, MemoryItem[]>();
 
   for (const item of allMemories) {
-    if (signal?.aborted) break;
-
+    signal?.throwIfAborted();
     const normalized = item.memory.normalize('NFC').replace(/\s+/g, ' ').trim().toLowerCase();
-    const existing = seen.get(normalized);
+    const group = groups.get(normalized);
+    if (group) group.push(item);
+    else groups.set(normalized, [item]);
+  }
 
-    if (existing) {
-      const existingTime = existing.updated_at ? new Date(existing.updated_at).getTime() : 0;
-      const currentTime = item.updated_at ? new Date(item.updated_at).getTime() : 0;
-      if (currentTime > existingTime) {
-        duplicateIds.push(existing.id);
-        seen.set(normalized, item);
-      } else {
-        duplicateIds.push(item.id);
+  const duplicateIds: string[] = [];
+  for (const group of groups.values()) {
+    if (group.length < 2) continue;
+    const [first, ...rest] = group;
+    if (!first) continue;
+    let newest = first;
+    let newestTime = memoryTime(first);
+    const times = new Set([newestTime]);
+    for (const item of rest) {
+      signal?.throwIfAborted();
+      const time = memoryTime(item);
+      if (times.has(time)) {
+        throw new Error('Mem0 dedup cannot determine the newest duplicate.');
       }
-    } else {
-      seen.set(normalized, item);
+      times.add(time);
+      if (time > newestTime) {
+        newest = item;
+        newestTime = time;
+      }
     }
+    duplicateIds.push(...group.filter((item) => item !== newest).map((item) => item.id));
   }
 
   return duplicateIds;
+}
+
+function memoryTime(item: MemoryItem): number {
+  const timestamp = item.updated_at ?? item.created_at;
+  const time = timestamp ? new Date(timestamp).getTime() : Number.NaN;
+  if (!Number.isFinite(time)) {
+    throw new Error('Mem0 dedup cannot determine the newest duplicate.');
+  }
+  return time;
 }

--- a/packages/pi-memory-mem0/src/index.ts
+++ b/packages/pi-memory-mem0/src/index.ts
@@ -63,6 +63,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
   let provider: Mem0Provider | undefined;
   let prefetch: Prefetch | undefined;
   let userId = '';
+  let agentId: string | undefined;
   let activeMode = '';
   let activeMemoryMode = '';
   let activeToolEnabled = false;
@@ -78,6 +79,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
     const epoch = ++sessionEpoch;
     provider = undefined;
     prefetch = undefined;
+    agentId = undefined;
     activeToolEnabled = false;
     const config = loadConfig(ctx.cwd, isProjectTrusted(ctx));
     try {
@@ -88,6 +90,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
         return;
       }
       const resolvedUserId = resolveUserId(config.userId, config.userIdScope);
+      const resolvedAgentId = config.agentId?.trim() || undefined;
       const newProvider = await createMem0Provider({
         config,
         resolveProvider: async (providerName: string) => {
@@ -118,10 +121,14 @@ export default function mem0Extension(pi: ExtensionAPI): void {
       if (epoch !== sessionEpoch) return;
       provider = newProvider;
       userId = scopeMemoryUserId(resolvedUserId, ctx.cwd, config.userIdScope);
+      agentId = resolvedAgentId;
       activeMode = mode;
       activeMemoryMode = memoryMode;
       if (memoryMode !== 'active') {
-        prefetch = new Prefetch(provider, userId, { topK: config.topK ?? 5 });
+        prefetch = new Prefetch(provider, userId, {
+          ...(agentId ? { agentId } : {}),
+          topK: config.topK ?? 5,
+        });
       }
       if (memoryMode !== 'passive') {
         activeToolEnabled = true;
@@ -129,6 +136,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
           createMem0MemoryTool({
             getProvider: () => provider,
             getUserId: () => userId,
+            getAgentId: () => agentId,
             isEnabled: () => activeToolEnabled,
             topK: config.topK ?? 5,
           }),
@@ -170,6 +178,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
     lastUserText = '';
     const activeProvider = provider;
     const activeUserId = userId;
+    const activeAgentId = agentId;
     pendingWrite = pendingWrite
       .catch(() => {})
       .then(async () => {
@@ -178,7 +187,10 @@ export default function mem0Extension(pi: ExtensionAPI): void {
             { role: 'user', content: redactMemoryText(userText) },
             { role: 'assistant', content: redactMemoryText(text) },
           ],
-          { userId: activeUserId },
+          {
+            userId: activeUserId,
+            ...(activeAgentId ? { agentId: activeAgentId } : {}),
+          },
         );
         // Extraction legitimately finds nothing in many turns, but a totally
         // silent no-op makes a broken pipeline indistinguishable from a quiet
@@ -214,6 +226,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
     await pendingWrite;
     provider = undefined;
     prefetch = undefined;
+    agentId = undefined;
     activeToolEnabled = false;
     lastUserText = '';
     pendingWrite = Promise.resolve();
@@ -227,6 +240,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
         ctx.ui.notify('Mem0 is not active.', 'warning');
         return;
       }
+      const scope = { userId, ...(agentId ? { agentId } : {}) };
 
       const parts = args.trim().split(/\s+/).filter(Boolean);
       const subcommand = parts[0]?.toLowerCase() ?? 'status';
@@ -243,7 +257,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
             break;
           }
           const results = await provider.search(rest, {
-            userId,
+            ...scope,
             topK: 10,
             ...(ctx.signal ? { signal: ctx.signal } : {}),
           });
@@ -257,7 +271,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
         }
         case 'profile': {
           const all = await provider.getAll({
-            userId,
+            ...scope,
             ...(ctx.signal ? { signal: ctx.signal } : {}),
           });
           if (all.length === 0) {
@@ -274,7 +288,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
             break;
           }
           const result = await provider.add([{ role: 'user', content: redactMemoryText(rest) }], {
-            userId,
+            ...scope,
             ...(ctx.signal ? { signal: ctx.signal } : {}),
           });
           const created = result?.results ?? [];

--- a/packages/pi-memory-mem0/src/index.ts
+++ b/packages/pi-memory-mem0/src/index.ts
@@ -26,6 +26,7 @@
 
 import { isProjectTrusted, loadPiSettings } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { dedupProviderMemories } from './dedup.js';
 import { Prefetch } from './prefetch.js';
 import { formatRecalledMemory, redactMemoryText, scopeMemoryUserId } from './privacy.js';
 import {
@@ -234,7 +235,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
 
   pi.registerCommand('mem0', {
     description:
-      'Mem0 memory commands. Subcommands: status, search <query>, profile, add <text>, delete <id>.',
+      'Mem0 memory commands. Subcommands: status, search <query>, profile, add <text>, dedup [--apply], delete <id>.',
     handler: async (args, ctx) => {
       if (!provider) {
         ctx.ui.notify('Mem0 is not active.', 'warning');
@@ -300,6 +301,68 @@ export default function mem0Extension(pi: ExtensionAPI): void {
           }
           break;
         }
+        case 'dedup': {
+          if (rest && rest !== '--apply') {
+            ctx.ui.notify('Usage: /mem0 dedup [--apply]', 'warning');
+            break;
+          }
+          if (rest !== '--apply') {
+            const preview = await dedupProviderMemories(provider, {
+              ...scope,
+              dryRun: true,
+              ...(ctx.signal ? { signal: ctx.signal } : {}),
+            });
+            if (preview.duplicatesFound === 0) {
+              ctx.ui.notify(
+                `Mem0 dedup preview: scanned ${preview.total} memories; no exact duplicates found.`,
+                'info',
+              );
+              break;
+            }
+            const noun = preview.duplicatesFound === 1 ? 'duplicate' : 'duplicates';
+            const pronoun = preview.duplicatesFound === 1 ? 'it' : 'them';
+            ctx.ui.notify(
+              `Mem0 dedup preview: scanned ${preview.total} memories and found ${preview.duplicatesFound} exact ${noun}. Run /mem0 dedup --apply to remove ${pronoun}.`,
+              'info',
+            );
+            break;
+          }
+          if (!ctx.hasUI) {
+            ctx.ui.notify('Mem0 dedup --apply requires an interactive confirmation.', 'warning');
+            break;
+          }
+          let preview: Awaited<ReturnType<typeof dedupProviderMemories>> | undefined;
+          let approved = false;
+          const result = await dedupProviderMemories(provider, {
+            ...scope,
+            dryRun: false,
+            ...(ctx.signal ? { signal: ctx.signal } : {}),
+            approve: async (candidate) => {
+              preview = candidate;
+              if (candidate.duplicatesFound === 0) return false;
+              const noun = candidate.duplicatesFound === 1 ? 'duplicate' : 'duplicates';
+              approved = await ctx.ui.confirm(
+                'Remove exact duplicate memories?',
+                `${candidate.duplicatesFound} ${noun} will be permanently deleted.`,
+              );
+              return approved;
+            },
+          });
+          if (preview?.duplicatesFound === 0) {
+            ctx.ui.notify('Mem0 dedup complete: no exact duplicates found.', 'info');
+            break;
+          }
+          if (!approved) {
+            ctx.ui.notify('Mem0 dedup cancelled.', 'info');
+            break;
+          }
+          const removedNoun = result.duplicatesRemoved === 1 ? 'duplicate' : 'duplicates';
+          ctx.ui.notify(
+            `Mem0 dedup complete: removed ${result.duplicatesRemoved} ${removedNoun}; ${result.deleteFailures} deletions failed.`,
+            result.deleteFailures ? 'warning' : 'info',
+          );
+          break;
+        }
         case 'delete': {
           if (!rest) {
             ctx.ui.notify('Usage: /mem0 delete <memory-id>', 'warning');
@@ -311,7 +374,7 @@ export default function mem0Extension(pi: ExtensionAPI): void {
         }
         default:
           ctx.ui.notify(
-            'Unknown subcommand. Available: status, search, profile, add, delete.',
+            'Unknown subcommand. Available: status, search, profile, add, dedup, delete.',
             'warning',
           );
       }

--- a/packages/pi-memory-mem0/src/prefetch.ts
+++ b/packages/pi-memory-mem0/src/prefetch.ts
@@ -16,19 +16,25 @@ const MAX_BLOCK_LINES = 50;
 export class Prefetch {
   private readonly provider: Mem0Provider;
   private readonly userId: string;
+  private readonly agentId: string | undefined;
   private readonly topK: number;
   private pending: Promise<MemoryItem[]> | null = null;
 
-  constructor(provider: Mem0Provider, userId: string, opts: { topK: number }) {
+  constructor(provider: Mem0Provider, userId: string, opts: { agentId?: string; topK: number }) {
     this.provider = provider;
     this.userId = userId;
+    this.agentId = opts.agentId;
     this.topK = opts.topK;
   }
 
   /** Phase 1: kick off a background search (called on input with user text). */
   queue(query: string): void {
     if (!query.trim()) return;
-    const search = this.provider.search(query, { userId: this.userId, topK: this.topK });
+    const search = this.provider.search(query, {
+      userId: this.userId,
+      ...(this.agentId ? { agentId: this.agentId } : {}),
+      topK: this.topK,
+    });
     // A replaced or never-consumed search must not surface as an unhandled rejection.
     search.catch(() => {});
     this.pending = search;

--- a/packages/pi-memory-mem0/src/provider.ts
+++ b/packages/pi-memory-mem0/src/provider.ts
@@ -30,6 +30,10 @@ import type {
 type Mem0ScopeOptions = { userId: string; agentId?: string; signal?: AbortSignal };
 type Mem0AddOptions = Mem0ScopeOptions & { infer?: boolean; observedAt?: Date | string };
 type Mem0SearchOptions = Mem0ScopeOptions & { topK?: number };
+const DEDUP_PAGE_SIZE = 200;
+const MAX_DEDUP_ITEMS_PER_SCOPE = 10_000;
+const MAX_DEDUP_PAGES = MAX_DEDUP_ITEMS_PER_SCOPE / DEDUP_PAGE_SIZE;
+const SELF_HOSTED_DEDUP_LIMIT = 1000;
 
 export interface Mem0Provider {
   add(
@@ -40,6 +44,9 @@ export interface Mem0Provider {
   search(query: string, opts: Mem0SearchOptions): Promise<MemoryItem[]>;
 
   getAll(opts: Mem0ScopeOptions): Promise<MemoryItem[]>;
+
+  /** Enumerate maintenance groups that may be deduplicated independently. */
+  getDedupGroups?(opts: Mem0ScopeOptions): Promise<MemoryItem[][]>;
 
   delete(memoryId: string, opts?: { signal?: AbortSignal }): Promise<void>;
 }
@@ -252,6 +259,63 @@ class PlatformProvider implements Mem0Provider {
     return normalizeResults(results);
   }
 
+  async getDedupGroups(opts: Mem0ScopeOptions): Promise<MemoryItem[][]> {
+    const groups = [await this.getAllPages({ user_id: opts.userId }, opts.signal)];
+    if (opts.agentId) {
+      groups.push(await this.getAllPages({ agent_id: opts.agentId }, opts.signal));
+    }
+    return groups;
+  }
+
+  private async getAllPages(
+    filters: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<MemoryItem[]> {
+    await waitWithCancellation(this.ensureClient(), signal);
+    const memories: MemoryItem[] = [];
+    let expectedCount: number | undefined;
+    for (let page = 1; ; page++) {
+      const result = await waitWithCancellation(
+        this.runWithSignal(signal, () =>
+          this.client!.getAll({ filters, page, pageSize: DEDUP_PAGE_SIZE }),
+        ),
+        signal,
+      );
+      const count = result && typeof result === 'object' && 'count' in result ? result.count : null;
+      if (typeof count !== 'number' || !Number.isInteger(count) || count < 0) {
+        throw new Error('Mem0 dedup pagination returned an invalid count.');
+      }
+      if (count > MAX_DEDUP_ITEMS_PER_SCOPE) {
+        throw new Error(`Mem0 dedup scope exceeds ${MAX_DEDUP_ITEMS_PER_SCOPE} memories.`);
+      }
+      if (expectedCount !== undefined && count !== expectedCount) {
+        throw new Error('Mem0 dedup pagination count changed between pages.');
+      }
+      expectedCount = count;
+      const pageMemories = normalizeResults(result);
+      memories.push(...pageMemories);
+      if (memories.length > MAX_DEDUP_ITEMS_PER_SCOPE) {
+        throw new Error(`Mem0 dedup scope exceeds ${MAX_DEDUP_ITEMS_PER_SCOPE} memories.`);
+      }
+      const hasNext = Boolean(
+        result && typeof result === 'object' && 'next' in result && result.next,
+      );
+      if (!hasNext) {
+        if (expectedCount !== undefined && memories.length !== expectedCount) {
+          throw new Error('Mem0 dedup pagination count does not match the returned memories.');
+        }
+        break;
+      }
+      if (pageMemories.length === 0) {
+        throw new Error('Mem0 dedup pagination returned an empty page with a next link.');
+      }
+      if (page >= MAX_DEDUP_PAGES) {
+        throw new Error(`Mem0 dedup pagination exceeds ${MAX_DEDUP_PAGES} pages.`);
+      }
+    }
+    return memories;
+  }
+
   async delete(memoryId: string, opts?: { signal?: AbortSignal }): Promise<void> {
     await waitWithCancellation(this.ensureClient(), opts?.signal);
     await waitWithCancellation(
@@ -356,6 +420,20 @@ class SelfHostedProvider implements Mem0Provider {
     if (opts.agentId) params.set('agent_id', opts.agentId);
     const result = await this.request(`/memories?${params}`, { method: 'GET' }, opts.signal);
     return normalizeResults(result);
+  }
+
+  async getDedupGroups(opts: Mem0ScopeOptions): Promise<MemoryItem[][]> {
+    const params = new URLSearchParams({ user_id: opts.userId });
+    if (opts.agentId) params.set('agent_id', opts.agentId);
+    params.set('top_k', String(SELF_HOSTED_DEDUP_LIMIT));
+    const result = await this.request(`/memories?${params}`, { method: 'GET' }, opts.signal);
+    const memories = normalizeResults(result);
+    if (memories.length >= SELF_HOSTED_DEDUP_LIMIT) {
+      throw new Error(
+        `Mem0 self-hosted dedup scope may exceed ${SELF_HOSTED_DEDUP_LIMIT - 1} memories.`,
+      );
+    }
+    return [memories];
   }
 
   async delete(memoryId: string, opts?: { signal?: AbortSignal }): Promise<void> {
@@ -657,6 +735,26 @@ class OSSProvider implements Mem0Provider {
       opts.signal,
     );
     return normalizeResults(results);
+  }
+
+  async getDedupGroups(opts: Mem0ScopeOptions): Promise<MemoryItem[][]> {
+    await waitWithCancellation(this.ensureMemory(), opts.signal);
+    const results = await waitWithCancellation(
+      // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
+      (this.memory as any).getAll({
+        filters: {
+          user_id: opts.userId,
+          ...(opts.agentId ? { agent_id: opts.agentId } : {}),
+        },
+        topK: MAX_DEDUP_ITEMS_PER_SCOPE + 1,
+      }),
+      opts.signal,
+    );
+    const memories = normalizeResults(results);
+    if (memories.length > MAX_DEDUP_ITEMS_PER_SCOPE) {
+      throw new Error(`Mem0 dedup scope exceeds ${MAX_DEDUP_ITEMS_PER_SCOPE} memories.`);
+    }
+    return [memories];
   }
 
   async delete(memoryId: string, opts?: { signal?: AbortSignal }): Promise<void> {

--- a/packages/pi-memory-mem0/src/provider.ts
+++ b/packages/pi-memory-mem0/src/provider.ts
@@ -27,18 +27,19 @@ import type {
 // Provider Interface
 // ---------------------------------------------------------------------------
 
+type Mem0ScopeOptions = { userId: string; agentId?: string; signal?: AbortSignal };
+type Mem0AddOptions = Mem0ScopeOptions & { infer?: boolean; observedAt?: Date | string };
+type Mem0SearchOptions = Mem0ScopeOptions & { topK?: number };
+
 export interface Mem0Provider {
   add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean; observedAt?: Date | string; signal?: AbortSignal },
+    opts: Mem0AddOptions,
   ): Promise<AddResult | null>;
 
-  search(
-    query: string,
-    opts: { userId: string; topK?: number; signal?: AbortSignal },
-  ): Promise<MemoryItem[]>;
+  search(query: string, opts: Mem0SearchOptions): Promise<MemoryItem[]>;
 
-  getAll(opts: { userId: string; signal?: AbortSignal }): Promise<MemoryItem[]>;
+  getAll(opts: Mem0ScopeOptions): Promise<MemoryItem[]>;
 
   delete(memoryId: string, opts?: { signal?: AbortSignal }): Promise<void>;
 }
@@ -199,10 +200,13 @@ class PlatformProvider implements Mem0Provider {
 
   async add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean; observedAt?: Date | string; signal?: AbortSignal },
+    opts: Mem0AddOptions,
   ): Promise<AddResult | null> {
     await waitWithCancellation(this.ensureClient(), opts.signal);
-    const addOpts: Record<string, unknown> = { userId: opts.userId };
+    const addOpts: Record<string, unknown> = {
+      userId: opts.userId,
+      ...(opts.agentId ? { agentId: opts.agentId } : {}),
+    };
     if (opts.infer === false) addOpts.infer = false;
     // Platform mem0 exposes a `timestamp` field on add(); pass observedAt
     // through as an ISO string. (OSS mode honors observedAt via prompt
@@ -218,14 +222,12 @@ class PlatformProvider implements Mem0Provider {
     return result as AddResult;
   }
 
-  async search(
-    query: string,
-    opts: { userId: string; topK?: number; signal?: AbortSignal },
-  ): Promise<MemoryItem[]> {
+  async search(query: string, opts: Mem0SearchOptions): Promise<MemoryItem[]> {
     await waitWithCancellation(this.ensureClient(), opts.signal);
-    const searchOpts: Record<string, unknown> = {
-      filters: { user_id: opts.userId },
-    };
+    const filters = opts.agentId
+      ? { OR: [{ user_id: opts.userId }, { agent_id: opts.agentId }] }
+      : { user_id: opts.userId };
+    const searchOpts: Record<string, unknown> = { filters };
     if (opts.topK) searchOpts.topK = opts.topK;
     const results = await waitWithCancellation(
       this.runWithSignal(opts.signal, () => this.client!.search(query, searchOpts)),
@@ -234,12 +236,15 @@ class PlatformProvider implements Mem0Provider {
     return normalizeResults(results);
   }
 
-  async getAll(opts: { userId: string; signal?: AbortSignal }): Promise<MemoryItem[]> {
+  async getAll(opts: Mem0ScopeOptions): Promise<MemoryItem[]> {
     await waitWithCancellation(this.ensureClient(), opts.signal);
+    const filters = opts.agentId
+      ? { OR: [{ user_id: opts.userId }, { agent_id: opts.agentId }] }
+      : { user_id: opts.userId };
     const results = await waitWithCancellation(
       this.runWithSignal(opts.signal, () =>
         this.client!.getAll({
-          filters: { user_id: opts.userId },
+          filters,
         }),
       ),
       opts.signal,
@@ -310,7 +315,7 @@ class SelfHostedProvider implements Mem0Provider {
 
   async add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean; observedAt?: Date | string; signal?: AbortSignal },
+    opts: Mem0AddOptions,
   ): Promise<AddResult | null> {
     return (await this.request(
       '/memories',
@@ -319,6 +324,7 @@ class SelfHostedProvider implements Mem0Provider {
         body: JSON.stringify({
           messages,
           user_id: opts.userId,
+          ...(opts.agentId ? { agent_id: opts.agentId } : {}),
           ...(opts.infer === undefined ? {} : { infer: opts.infer }),
         }),
       },
@@ -326,17 +332,17 @@ class SelfHostedProvider implements Mem0Provider {
     )) as AddResult;
   }
 
-  async search(
-    query: string,
-    opts: { userId: string; topK?: number; signal?: AbortSignal },
-  ): Promise<MemoryItem[]> {
+  async search(query: string, opts: Mem0SearchOptions): Promise<MemoryItem[]> {
     const result = await this.request(
       '/search',
       {
         method: 'POST',
         body: JSON.stringify({
           query,
-          filters: { user_id: opts.userId },
+          filters: {
+            user_id: opts.userId,
+            ...(opts.agentId ? { agent_id: opts.agentId } : {}),
+          },
           ...(opts.topK === undefined ? {} : { top_k: opts.topK }),
         }),
       },
@@ -345,12 +351,10 @@ class SelfHostedProvider implements Mem0Provider {
     return normalizeResults(result);
   }
 
-  async getAll(opts: { userId: string; signal?: AbortSignal }): Promise<MemoryItem[]> {
-    const result = await this.request(
-      `/memories?user_id=${encodeURIComponent(opts.userId)}`,
-      { method: 'GET' },
-      opts.signal,
-    );
+  async getAll(opts: Mem0ScopeOptions): Promise<MemoryItem[]> {
+    const params = new URLSearchParams({ user_id: opts.userId });
+    if (opts.agentId) params.set('agent_id', opts.agentId);
+    const result = await this.request(`/memories?${params}`, { method: 'GET' }, opts.signal);
     return normalizeResults(result);
   }
 
@@ -562,10 +566,13 @@ class OSSProvider implements Mem0Provider {
 
   async add(
     messages: Array<{ role: string; content: string }>,
-    opts: { userId: string; infer?: boolean; observedAt?: Date | string; signal?: AbortSignal },
+    opts: Mem0AddOptions,
   ): Promise<AddResult | null> {
     await waitWithCancellation(this.ensureMemory(), opts.signal);
-    const addOpts: Record<string, unknown> = { userId: opts.userId };
+    const addOpts: Record<string, unknown> = {
+      userId: opts.userId,
+      ...(opts.agentId ? { agentId: opts.agentId } : {}),
+    };
     if (opts.infer === false) addOpts.infer = false;
 
     // Serialize add() when observedAt is used. mem0 never exposes the
@@ -620,13 +627,13 @@ class OSSProvider implements Mem0Provider {
     }
   }
 
-  async search(
-    query: string,
-    opts: { userId: string; topK?: number; signal?: AbortSignal },
-  ): Promise<MemoryItem[]> {
+  async search(query: string, opts: Mem0SearchOptions): Promise<MemoryItem[]> {
     await waitWithCancellation(this.ensureMemory(), opts.signal);
     const searchOpts: Record<string, unknown> = {
-      filters: { user_id: opts.userId },
+      filters: {
+        user_id: opts.userId,
+        ...(opts.agentId ? { agent_id: opts.agentId } : {}),
+      },
     };
     if (opts.topK) searchOpts.topK = opts.topK;
     const results = await waitWithCancellation(
@@ -637,12 +644,15 @@ class OSSProvider implements Mem0Provider {
     return normalizeResults(results);
   }
 
-  async getAll(opts: { userId: string; signal?: AbortSignal }): Promise<MemoryItem[]> {
+  async getAll(opts: Mem0ScopeOptions): Promise<MemoryItem[]> {
     await waitWithCancellation(this.ensureMemory(), opts.signal);
     const results = await waitWithCancellation(
       // biome-ignore lint/suspicious/noExplicitAny: mem0ai/oss lacks type definitions
       (this.memory as any).getAll({
-        filters: { user_id: opts.userId },
+        filters: {
+          user_id: opts.userId,
+          ...(opts.agentId ? { agent_id: opts.agentId } : {}),
+        },
       }),
       opts.signal,
     );

--- a/packages/pi-memory-mem0/src/tools.ts
+++ b/packages/pi-memory-mem0/src/tools.ts
@@ -34,6 +34,7 @@ export interface Mem0MemoryToolOptions {
    */
   getProvider: () => Mem0Provider | undefined;
   getUserId: () => string;
+  getAgentId: () => string | undefined;
   /**
    * The runtime keeps tool registrations for the life of the extension — a
    * tool registered in a hybrid/active session is still callable after a
@@ -126,20 +127,22 @@ export function createMem0MemoryTool(opts: Mem0MemoryToolOptions): ToolDefinitio
       const provider = opts.getProvider();
       if (!provider) return errorResult('Mem0 is not active.');
       const userId = opts.getUserId();
+      const agentId = opts.getAgentId();
+      const scope = { userId, ...(agentId ? { agentId } : {}) };
 
       try {
         switch (action) {
           case 'search': {
             const query = redactMemoryText(String(params.query ?? '').trim());
             if (!query) return errorResult('query is required for the search action.');
-            const results = await provider.search(query, { userId, topK, ...signalOpts });
+            const results = await provider.search(query, { ...scope, topK, ...signalOpts });
             return formatBlock(`## Memories matching "${query}"`, results);
           }
           case 'add': {
             const content = redactMemoryText(String(params.content ?? '').trim());
             if (!content) return errorResult('content is required for the add action.');
             const result = await provider.add([{ role: 'user', content }], {
-              userId,
+              ...scope,
               ...signalOpts,
             });
             const created = result?.results ?? [];
@@ -149,7 +152,7 @@ export function createMem0MemoryTool(opts: Mem0MemoryToolOptions): ToolDefinitio
             return formatBlock(`Saved ${created.length} memories:`, created);
           }
           case 'get_all': {
-            const results = await provider.getAll({ userId, ...signalOpts });
+            const results = await provider.getAll({ ...scope, ...signalOpts });
             return formatBlock(`## All memories (${results.length})`, results);
           }
           case 'delete': {

--- a/packages/pi-memory-mem0/src/types.ts
+++ b/packages/pi-memory-mem0/src/types.ts
@@ -40,6 +40,8 @@ export interface Mem0ExtensionConfig {
   // ── Shared ──────────────────────────────────────────────────────────────
   /** User identifier for memory scoping. Supports ${USER}. */
   userId?: string;
+  /** Optional agent identifier for memory scoping. Supports environment interpolation. */
+  agentId?: string;
   /** Append a cwd hash (default) or use userId verbatim. */
   userIdScope?: MemoryUserIdScope;
   /** Max recalled memories per turn. Default: 5 */


### PR DESCRIPTION
## Summary

- Add configurable `agentId` scoping across Platform, embedded, and self-hosted modes.
- Add `/mem0 dedup [--apply]` with preview, interactive confirmation, bounded enumeration, cancellation, and fail-closed validation before deletion.
- Supersede #71 with a complete implementation based on the current `master` branch.

## Affected package

- `@amaster.ai/pi-memory-mem0`: published `0.1.9` → `0.1.9` (unchanged); current beta dist-tag: `0.1.2-beta.60`

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 129 files, 1923 tests passed
- `pnpm build`
- Standards review: no findings
- Spec review: no findings

## Related pull request

Supersedes #71.

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.