### PR TITLE
fix(ci): run fork checks and restore Pi reviews

### DIFF
--- a/.github/scripts/publish-pi-review.mjs
+++ b/.github/scripts/publish-pi-review.mjs
@@ -336,7 +336,7 @@ export async function preparePiReview({ github, context, core, contextPath, work
     '',
     'Use the loaded code-review skill. Its Agent/general-purpose calls must be adapted to the Pi subagent tool:',
     'Make exactly one synchronous subagent workflow call containing exactly two tasks, both using the',
-    'general-purpose agent. Its workflowScript must call runs.all once. Omit async. Task 1 reviews Standards',
+    'general-purpose agent. Its workflowScript must call runs.all once. Set async to false explicitly. Task 1 reviews Standards',
     'and task 2 reviews Spec. Do not call emit, subagent_wait, status, or list, and do not retry.',
     'Reviewer children have no tools and inherit no context. Copy the supplied review data directly into each child task.',
     'Never tell a child to run git, execute the diff command, read files, or fetch context. Do not ask questions,',

--- a/.github/scripts/publish-pi-review.test.mjs
+++ b/.github/scripts/publish-pi-review.test.mjs
@@ -286,6 +286,7 @@ test('prepares the review prompt outside the workflow', async () => {
     assert.match(prompt, /Copy the supplied review data directly into each child task/);
     assert.match(prompt, /Never tell a child to run git, execute the diff command, read files, or fetch context/);
     assert.match(prompt, /Make exactly one synchronous subagent workflow call/);
+    assert.match(prompt, /Set async to false explicitly/);
     assert.match(prompt, /Do not call emit, subagent_wait, status, or list, and do not retry/);
     assert.doesNotMatch(prompt, /file-only/);
   } finally {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -13,9 +16,6 @@ concurrency:
 jobs:
   lint:
     name: Lint
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -24,9 +24,6 @@ jobs:
 
   typecheck:
     name: Typecheck
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -37,9 +34,6 @@ jobs:
 
   test:
     name: Test
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Isolate temporary files
@@ -58,9 +52,6 @@ jobs:
 
   build:
     name: Build
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test]
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,9 +10,6 @@ permissions:
 jobs:
   build-checks:
     name: build checks
-    if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/tests/security-boundaries.test.ts
+++ b/tests/security-boundaries.test.ts
@@ -6,9 +6,14 @@ const read = (path: string) => readFileSync(resolve(path), 'utf8');
 
 describe('security-sensitive workflows', () => {
   it.each(['.github/workflows/ci.yml', '.github/workflows/pr-checks.yml'])(
-    'does not run fork pull requests on self-hosted runners in %s',
+    'runs fork pull requests with read-only permissions on GitHub-hosted runners in %s',
     (path) => {
-      expect(read(path)).toContain(
+      const workflow = read(path);
+
+      expect(workflow).toContain('permissions:\n  contents: read');
+      expect(workflow).toContain('runs-on: ubuntu-latest');
+      expect(workflow).not.toContain('self-hosted');
+      expect(workflow).not.toContain(
         "github.event.pull_request.head.repo.full_name == github.repository",
       );
     },


### PR DESCRIPTION
## Summary

- Run CI and PR Checks for approved fork pull requests instead of skipping every job.
- Keep fork CI on GitHub-hosted runners with read-only repository permissions.
- Keep Pi review dependencies on `latest` and explicitly run workflow-based subagents with `async: false` so structured reviewer results remain available to the combiner.

## Verification

- `pnpm pr-check` (1923 tests)
- `pnpm lint` (passes with one pre-existing warning)
- `pnpm exec vitest run .github/scripts/publish-pi-review.test.mjs`
- `git diff --check`

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.