### PR TITLE
fix(pi-telemetry): harden terminal export durability

### DIFF
--- a/packages/pi-telemetry/src/__tests__/extension.test.ts
+++ b/packages/pi-telemetry/src/__tests__/extension.test.ts
@@ -682,6 +682,72 @@ describe('telemetryExtension', () => {
     });
   });
 
+  it('closes a generation at turn_end when message_end did not durably arrive', async () => {
+    telemetryExtension(mockPi as any);
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+    await fireEvent(
+      'before_provider_request',
+      { type: 'before_provider_request', payload: { messages: ['hello'] } },
+      { model: { id: 'deepseek-v4-flash', provider: 'amaster' } },
+    );
+
+    await fireEvent('turn_end', {
+      type: 'turn_end',
+      turnIndex: 0,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'durable result' }],
+        usage: { input: 100, output: 20, cacheRead: 50, totalTokens: 170 },
+        responseId: 'resp-fallback',
+        stopReason: 'stop',
+      },
+      toolResults: [],
+    });
+
+    const events = getPublishedEvents();
+    const generationEvents = events.filter((event) => 'llmGenerationId' in event);
+    expect(generationEvents).toHaveLength(2);
+    expect(generationEvents[1]).toMatchObject({
+      llmGenerationId: 'gen-1',
+      status: 'completed',
+      output: {
+        content: 'durable result',
+        usage: { input: 100, output: 20, cacheRead: 50, totalTokens: 170 },
+      },
+      responseId: 'resp-fallback',
+      stopReason: 'stop',
+    });
+    expect(events.at(-1)).toMatchObject({ type: 'chat_turn_completed' });
+  });
+
+  it('does not duplicate at turn_end a generation already closed by message_end', async () => {
+    telemetryExtension(mockPi as any);
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+    await fireEvent('before_provider_request', {
+      type: 'before_provider_request',
+      payload: { messages: ['hello'] },
+    });
+    const message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'one terminal' }],
+      usage: { input: 10, output: 2 },
+    };
+    await fireEvent('message_end', { type: 'message_end', message });
+    await fireEvent('turn_end', {
+      type: 'turn_end',
+      turnIndex: 0,
+      message,
+      toolResults: [],
+    });
+
+    const terminalEvents = getPublishedEvents().filter(
+      (event) => 'llmGenerationId' in event && event.status === 'completed',
+    );
+    expect(terminalEvents).toHaveLength(1);
+  });
+
   test('message_end keeps content array when it includes tool_use blocks', async () => {
     telemetryExtension(mockPi as any);
     await fireEvent('session_start', { type: 'session_start', reason: 'startup' });

--- a/packages/pi-telemetry/src/__tests__/extension.test.ts
+++ b/packages/pi-telemetry/src/__tests__/extension.test.ts
@@ -73,6 +73,10 @@ describe('telemetryExtension', () => {
     );
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('registers expected event handlers', () => {
     telemetryExtension(mockPi as any);
 
@@ -437,12 +441,77 @@ describe('telemetryExtension', () => {
       status: 429,
       headers: {},
     });
+    const message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'provider rejected' }],
+      usage: { input: 10, output: 2 },
+    };
+    await fireEvent('message_end', { type: 'message_end', message });
+    await fireEvent('turn_end', {
+      type: 'turn_end',
+      turnIndex: 0,
+      message,
+      toolResults: [],
+    });
 
     const events = getPublishedEvents();
     const llmEvents = events.filter((e) => 'llmGenerationId' in e);
+    expect(llmEvents).toHaveLength(2);
     expect(llmEvents[1]).toMatchObject({
       status: 'failed',
       error: 'HTTP 429',
+    });
+  });
+
+  it('releases a failed provider-terminal reservation so message_end can retry', async () => {
+    const exporter = {
+      publish: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('failed terminal publish failed'))
+        .mockResolvedValue(undefined),
+      flush: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+    };
+    (createLangfuseExporter as ReturnType<typeof vi.fn>).mockReturnValue(exporter);
+    telemetryExtension(mockPi as any);
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+    await fireEvent('before_provider_request', {
+      type: 'before_provider_request',
+      payload: {},
+    });
+
+    await expect(
+      fireEvent('after_provider_response', {
+        type: 'after_provider_response',
+        status: 503,
+        headers: {},
+      }),
+    ).rejects.toThrow('failed terminal publish failed');
+
+    const message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'fallback terminal' }],
+      usage: { input: 10, output: 2 },
+    };
+    await fireEvent('message_end', { type: 'message_end', message });
+    await fireEvent('turn_end', {
+      type: 'turn_end',
+      turnIndex: 0,
+      message,
+      toolResults: [],
+    });
+
+    const terminalAttempts = exporter.publish.mock.calls
+      .map(([event]) => event as RuntimeTelemetryEvent)
+      .filter((event) => 'llmGenerationId' in event && event.status !== 'started');
+    expect(terminalAttempts).toHaveLength(2);
+    expect(terminalAttempts[0]).toMatchObject({ llmGenerationId: 'gen-1', status: 'failed' });
+    expect(terminalAttempts[1]).toMatchObject({ llmGenerationId: 'gen-1', status: 'completed' });
+    expect(exporter.publish.mock.calls.at(-1)?.[0]).toMatchObject({
+      type: 'chat_turn_completed',
     });
   });
 
@@ -792,6 +861,52 @@ describe('telemetryExtension', () => {
     expect(exporter.publish.mock.calls.at(-1)?.[0]).toMatchObject({
       type: 'chat_turn_completed',
     });
+  });
+
+  it('keeps the turn lifecycle when its terminal fallback fails without inflating duration', async () => {
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exporter = {
+      publish: vi.fn(async (event: RuntimeTelemetryEvent) => {
+        if ('llmGenerationId' in event && event.status === 'completed') {
+          now = 2_000;
+          throw new Error('turn terminal publish failed');
+        }
+      }),
+      flush: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+    };
+    (createLangfuseExporter as ReturnType<typeof vi.fn>).mockReturnValue(exporter);
+    telemetryExtension(mockPi as any);
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: 500 });
+    await fireEvent('before_provider_request', {
+      type: 'before_provider_request',
+      payload: {},
+    });
+
+    await expect(
+      fireEvent('turn_end', {
+        type: 'turn_end',
+        turnIndex: 0,
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'terminal fallback' }],
+          usage: { input: 10, output: 2 },
+        },
+        toolResults: [],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(exporter.publish.mock.calls.at(-1)?.[0]).toMatchObject({
+      type: 'chat_turn_completed',
+      createdAt: '1970-01-01T00:00:01.000Z',
+      durationMs: 500,
+    });
+    expect(log).toHaveBeenCalledWith(
+      '[pi-telemetry] failed to publish generation terminal during turn_end: turn terminal publish failed',
+    );
   });
 
   test('message_end keeps content array when it includes tool_use blocks', async () => {

--- a/packages/pi-telemetry/src/__tests__/extension.test.ts
+++ b/packages/pi-telemetry/src/__tests__/extension.test.ts
@@ -748,6 +748,52 @@ describe('telemetryExtension', () => {
     expect(terminalEvents).toHaveLength(1);
   });
 
+  it('releases a failed message_end reservation so turn_end can retry the terminal', async () => {
+    const exporter = {
+      publish: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('terminal publish failed'))
+        .mockResolvedValue(undefined),
+      flush: vi.fn(() => Promise.resolve()),
+      close: vi.fn(() => Promise.resolve()),
+    };
+    (createLangfuseExporter as ReturnType<typeof vi.fn>).mockReturnValue(exporter);
+    telemetryExtension(mockPi as any);
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
+    await fireEvent('before_provider_request', {
+      type: 'before_provider_request',
+      payload: { messages: ['hello'] },
+    });
+    const message = {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'retry terminal' }],
+      usage: { input: 10, output: 2 },
+    };
+
+    await expect(fireEvent('message_end', { type: 'message_end', message })).rejects.toThrow(
+      'terminal publish failed',
+    );
+    await fireEvent('turn_end', {
+      type: 'turn_end',
+      turnIndex: 0,
+      message,
+      toolResults: [],
+    });
+
+    const terminalAttempts = exporter.publish.mock.calls
+      .map(([event]) => event as RuntimeTelemetryEvent)
+      .filter((event) => 'llmGenerationId' in event && event.status === 'completed');
+    expect(terminalAttempts).toHaveLength(2);
+    expect(terminalAttempts[0]).toMatchObject({ llmGenerationId: 'gen-1' });
+    expect(terminalAttempts[1]).toMatchObject({ llmGenerationId: 'gen-1' });
+    expect(exporter.publish.mock.calls.at(-1)?.[0]).toMatchObject({
+      type: 'chat_turn_completed',
+    });
+  });
+
   test('message_end keeps content array when it includes tool_use blocks', async () => {
     telemetryExtension(mockPi as any);
     await fireEvent('session_start', { type: 'session_start', reason: 'startup' });

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -261,8 +261,8 @@ describe('telemetry', () => {
 
   it('retries a failed terminal Langfuse flush within the terminal handler', async () => {
     const client = new FakeLangfuseSdkClient();
-    client.flushFailuresRemaining = 2;
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    client.flushFailuresRemaining = 3;
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const exporter = new LangfuseSdkRuntimeEventExporter(
       {
         enabled: true,
@@ -286,12 +286,45 @@ describe('telemetry', () => {
       details: { output: 'done' },
     });
 
-    expect(client.flushed).toBe(3);
-    expect(warn).toHaveBeenCalledTimes(2);
-    expect(warn).toHaveBeenNthCalledWith(
+    expect(client.flushed).toBe(4);
+    expect(log).toHaveBeenCalledTimes(3);
+    expect(log).toHaveBeenNthCalledWith(
       1,
-      'Langfuse telemetry flush failed (attempt 1/3): transient flush failure',
+      '[pi-telemetry] Langfuse telemetry flush failed (attempt 1/4): transient flush failure',
     );
+  });
+
+  it('rejects when every terminal Langfuse flush attempt is exhausted', async () => {
+    const client = new FakeLangfuseSdkClient();
+    client.flushFailuresRemaining = 4;
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 10,
+        flushIntervalMs: 60_000,
+      },
+      client,
+    );
+
+    await expect(
+      exporter.publish({
+        id: 'turn-end-exhausted',
+        traceId,
+        type: 'chat_turn_completed',
+        sessionId: 'session-1',
+        conversationId: 'conversation-1',
+        createdAt: '2026-05-02T00:00:02.000Z',
+        durationMs: 2000,
+        details: { output: 'done' },
+      }),
+    ).rejects.toThrow('transient flush failure');
+
+    expect(client.flushed).toBe(4);
+    expect(log).toHaveBeenCalledTimes(4);
   });
 
   it('flushes Langfuse SDK telemetry after point-in-time lifecycle events', async () => {

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -259,6 +259,41 @@ describe('telemetry', () => {
     expect(client.flushed).toBe(1);
   });
 
+  it('retries a failed terminal Langfuse flush within the terminal handler', async () => {
+    const client = new FakeLangfuseSdkClient();
+    client.flushFailuresRemaining = 2;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const exporter = new LangfuseSdkRuntimeEventExporter(
+      {
+        enabled: true,
+        publicKey: 'public',
+        secretKey: 'secret',
+        baseUrl: 'https://langfuse.example.com',
+        flushAt: 10,
+        flushIntervalMs: 60_000,
+      },
+      client,
+    );
+
+    await exporter.publish({
+      id: 'turn-end-retry',
+      traceId,
+      type: 'chat_turn_completed',
+      sessionId: 'session-1',
+      conversationId: 'conversation-1',
+      createdAt: '2026-05-02T00:00:02.000Z',
+      durationMs: 2000,
+      details: { output: 'done' },
+    });
+
+    expect(client.flushed).toBe(3);
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenNthCalledWith(
+      1,
+      'Langfuse telemetry flush failed (attempt 1/3): transient flush failure',
+    );
+  });
+
   it('flushes Langfuse SDK telemetry after point-in-time lifecycle events', async () => {
     const client = new FakeLangfuseSdkClient();
     const exporter = new LangfuseSdkRuntimeEventExporter(
@@ -1678,6 +1713,7 @@ function getStringAttribute(
 class FakeLangfuseSdkClient implements LangfuseSdkClient {
   readonly traces: FakeLangfuseSdkTraceClient[] = [];
   flushed = 0;
+  flushFailuresRemaining = 0;
   closed = 0;
 
   trace(body?: Record<string, unknown>): LangfuseSdkTraceClient {
@@ -1688,6 +1724,10 @@ class FakeLangfuseSdkClient implements LangfuseSdkClient {
 
   async flushAsync(): Promise<void> {
     this.flushed += 1;
+    if (this.flushFailuresRemaining > 0) {
+      this.flushFailuresRemaining -= 1;
+      throw new Error('transient flush failure');
+    }
   }
 
   async shutdownAsync(): Promise<void> {

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -231,6 +231,7 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
     }
 
     const generationIndex = llmGenerationCounter;
+    const previousTerminalGenerationCounter = terminalGenerationCounter;
     // Reserve the terminal before awaiting the exporter. message_end and turn_end may
     // be dispatched close together; only one of them may close this generation.
     terminalGenerationCounter = generationIndex;
@@ -241,24 +242,34 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
     if (content !== undefined) output.content = content;
     if (usage !== undefined) output.usage = usage as JsonValue;
 
-    await exporter.publish({
-      id: randomUUID(),
-      traceId: currentTraceId,
-      ...runtimeCorrelation,
-      sessionId: localSessionId,
-      conversationId: localSessionId,
-      ...(isSubagent
-        ? { ...(parentSessionId ? { parentSessionId } : {}), childSessionId: localSessionId }
-        : {}),
-      llmGenerationId: `gen-${generationIndex}`,
-      status: 'completed',
-      createdAt: new Date().toISOString(),
-      model: lastModelConfig,
-      ...(Object.keys(output).length > 0 ? { output } : {}),
-      ...(mapped ? { usage: mapped } : {}),
-      ...(typeof msg.responseId === 'string' ? { responseId: msg.responseId } : {}),
-      ...(typeof msg.stopReason === 'string' ? { stopReason: msg.stopReason } : {}),
-    });
+    try {
+      await exporter.publish({
+        id: randomUUID(),
+        traceId: currentTraceId,
+        ...runtimeCorrelation,
+        sessionId: localSessionId,
+        conversationId: localSessionId,
+        ...(isSubagent
+          ? { ...(parentSessionId ? { parentSessionId } : {}), childSessionId: localSessionId }
+          : {}),
+        llmGenerationId: `gen-${generationIndex}`,
+        status: 'completed',
+        createdAt: new Date().toISOString(),
+        model: lastModelConfig,
+        ...(Object.keys(output).length > 0 ? { output } : {}),
+        ...(mapped ? { usage: mapped } : {}),
+        ...(typeof msg.responseId === 'string' ? { responseId: msg.responseId } : {}),
+        ...(typeof msg.stopReason === 'string' ? { stopReason: msg.stopReason } : {}),
+      });
+    } catch (error) {
+      // Keep the synchronous reservation for duplicate suppression, but release
+      // only our own reservation when delivery itself failed. A later turn_end
+      // can then retry the same terminal from its authoritative assistant message.
+      if (terminalGenerationCounter === generationIndex) {
+        terminalGenerationCounter = previousTerminalGenerationCounter;
+      }
+      throw error;
+    }
     return true;
   };
 

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -214,8 +214,53 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
   let traceStartTime: number | undefined;
   let tracePublished = false;
   let llmGenerationCounter = 0;
+  let terminalGenerationCounter = 0;
   let pendingInput: string | undefined;
   let lastModelConfig: RuntimeModelConfig = { provider: 'unknown', model: 'unknown' };
+
+  const publishCompletedGeneration = async (message: unknown): Promise<boolean> => {
+    if (!currentTraceId || llmGenerationCounter <= terminalGenerationCounter) {
+      return false;
+    }
+    if (!message || typeof message !== 'object') {
+      return false;
+    }
+    const msg = message as Record<string, unknown>;
+    if (msg.role !== 'assistant') {
+      return false;
+    }
+
+    const generationIndex = llmGenerationCounter;
+    // Reserve the terminal before awaiting the exporter. message_end and turn_end may
+    // be dispatched close together; only one of them may close this generation.
+    terminalGenerationCounter = generationIndex;
+    const content = simplifyContent(msg.content) ?? extractOutput(message);
+    const usage = msg.usage as Record<string, unknown> | undefined;
+    const mapped = usage ? mapUsage(usage) : undefined;
+    const output: JsonObject = {};
+    if (content !== undefined) output.content = content;
+    if (usage !== undefined) output.usage = usage as JsonValue;
+
+    await exporter.publish({
+      id: randomUUID(),
+      traceId: currentTraceId,
+      ...runtimeCorrelation,
+      sessionId: localSessionId,
+      conversationId: localSessionId,
+      ...(isSubagent
+        ? { ...(parentSessionId ? { parentSessionId } : {}), childSessionId: localSessionId }
+        : {}),
+      llmGenerationId: `gen-${generationIndex}`,
+      status: 'completed',
+      createdAt: new Date().toISOString(),
+      model: lastModelConfig,
+      ...(Object.keys(output).length > 0 ? { output } : {}),
+      ...(mapped ? { usage: mapped } : {}),
+      ...(typeof msg.responseId === 'string' ? { responseId: msg.responseId } : {}),
+      ...(typeof msg.stopReason === 'string' ? { stopReason: msg.stopReason } : {}),
+    });
+    return true;
+  };
 
   pi.on('session_start', async (_event, ctx) => {
     const config = resolveConfig(
@@ -245,12 +290,14 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
     traceStartTime = undefined;
     tracePublished = false;
     llmGenerationCounter = 0;
+    terminalGenerationCounter = 0;
   });
 
   pi.on('turn_start', async (event) => {
     if (!currentTraceId) {
       currentTraceId = randomUUID().replace(/-/g, '');
       llmGenerationCounter = 0;
+      terminalGenerationCounter = 0;
       tracePublished = false;
     }
     if (!traceStartTime) {
@@ -292,6 +339,10 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
 
   pi.on('turn_end', async (event) => {
     if (!currentTraceId) return;
+    // Some executor shutdown paths can reach turn_end before the message_end
+    // listener has durably exported its terminal. Close from the same assistant
+    // message first so the lifecycle flush cannot leave a span-only trace.
+    await publishCompletedGeneration(event.message);
     const now = Date.now();
     const durationMs = traceStartTime ? now - traceStartTime : undefined;
     const output = extractOutput(event.message);
@@ -396,6 +447,9 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
   pi.on('after_provider_response', async (event, ctx) => {
     if (!currentTraceId) return;
     if (event.status < 400) return;
+    const generationIndex = llmGenerationCounter;
+    if (generationIndex <= terminalGenerationCounter) return;
+    terminalGenerationCounter = generationIndex;
 
     await exporter.publish({
       id: randomUUID(),
@@ -406,7 +460,7 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
       ...(isSubagent
         ? { ...(parentSessionId ? { parentSessionId } : {}), childSessionId: localSessionId }
         : {}),
-      llmGenerationId: `gen-${llmGenerationCounter}`,
+      llmGenerationId: `gen-${generationIndex}`,
       status: 'failed',
       createdAt: new Date().toISOString(),
       model: modelConfigFromCtx(ctx),
@@ -415,36 +469,7 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
   });
 
   pi.on('message_end', async (event) => {
-    if (!currentTraceId) return;
-    const msg = event.message as unknown as Record<string, unknown>;
-    if (msg.role !== 'assistant') return;
-
-    const content = simplifyContent(msg.content) ?? extractOutput(event.message);
-    const usage = msg.usage as Record<string, unknown> | undefined;
-    const mapped = usage ? mapUsage(usage) : undefined;
-
-    const output: JsonObject = {};
-    if (content !== undefined) output.content = content;
-    if (usage !== undefined) output.usage = usage as JsonValue;
-
-    await exporter.publish({
-      id: randomUUID(),
-      traceId: currentTraceId,
-      ...runtimeCorrelation,
-      sessionId: localSessionId,
-      conversationId: localSessionId,
-      ...(isSubagent
-        ? { ...(parentSessionId ? { parentSessionId } : {}), childSessionId: localSessionId }
-        : {}),
-      llmGenerationId: `gen-${llmGenerationCounter}`,
-      status: 'completed',
-      createdAt: new Date().toISOString(),
-      model: lastModelConfig,
-      ...(Object.keys(output).length > 0 ? { output } : {}),
-      ...(mapped ? { usage: mapped } : {}),
-      ...(typeof msg.responseId === 'string' ? { responseId: msg.responseId } : {}),
-      ...(typeof msg.stopReason === 'string' ? { stopReason: msg.stopReason } : {}),
-    });
+    await publishCompletedGeneration(event.message);
   });
 
   pi.on('model_select', async (event) => {

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -218,6 +218,19 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
   let pendingInput: string | undefined;
   let lastModelConfig: RuntimeModelConfig = { provider: 'unknown', model: 'unknown' };
 
+  const tryReserveTerminalGeneration = (generationIndex: number): (() => void) | undefined => {
+    if (generationIndex <= terminalGenerationCounter) {
+      return undefined;
+    }
+    const previousTerminalGenerationCounter = terminalGenerationCounter;
+    terminalGenerationCounter = generationIndex;
+    return () => {
+      if (terminalGenerationCounter === generationIndex) {
+        terminalGenerationCounter = previousTerminalGenerationCounter;
+      }
+    };
+  };
+
   const publishCompletedGeneration = async (message: unknown): Promise<boolean> => {
     if (!currentTraceId || llmGenerationCounter <= terminalGenerationCounter) {
       return false;
@@ -231,16 +244,18 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
     }
 
     const generationIndex = llmGenerationCounter;
-    const previousTerminalGenerationCounter = terminalGenerationCounter;
-    // Reserve the terminal before awaiting the exporter. message_end and turn_end may
-    // be dispatched close together; only one of them may close this generation.
-    terminalGenerationCounter = generationIndex;
     const content = simplifyContent(msg.content) ?? extractOutput(message);
     const usage = msg.usage as Record<string, unknown> | undefined;
     const mapped = usage ? mapUsage(usage) : undefined;
     const output: JsonObject = {};
     if (content !== undefined) output.content = content;
     if (usage !== undefined) output.usage = usage as JsonValue;
+    // Reserve only after synchronous extraction succeeds and immediately before
+    // the first await. message_end and turn_end may otherwise double-close it.
+    const releaseReservation = tryReserveTerminalGeneration(generationIndex);
+    if (!releaseReservation) {
+      return false;
+    }
 
     try {
       await exporter.publish({
@@ -262,12 +277,7 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
         ...(typeof msg.stopReason === 'string' ? { stopReason: msg.stopReason } : {}),
       });
     } catch (error) {
-      // Keep the synchronous reservation for duplicate suppression, but release
-      // only our own reservation when delivery itself failed. A later turn_end
-      // can then retry the same terminal from its authoritative assistant message.
-      if (terminalGenerationCounter === generationIndex) {
-        terminalGenerationCounter = previousTerminalGenerationCounter;
-      }
+      releaseReservation();
       throw error;
     }
     return true;
@@ -350,11 +360,17 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
 
   pi.on('turn_end', async (event) => {
     if (!currentTraceId) return;
+    const now = Date.now();
     // Some executor shutdown paths can reach turn_end before the message_end
     // listener has durably exported its terminal. Close from the same assistant
     // message first so the lifecycle flush cannot leave a span-only trace.
-    await publishCompletedGeneration(event.message);
-    const now = Date.now();
+    try {
+      await publishCompletedGeneration(event.message);
+    } catch (error) {
+      console.error(
+        `[pi-telemetry] failed to publish generation terminal during turn_end: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
     const durationMs = traceStartTime ? now - traceStartTime : undefined;
     const output = extractOutput(event.message);
 
@@ -459,24 +475,29 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
     if (!currentTraceId) return;
     if (event.status < 400) return;
     const generationIndex = llmGenerationCounter;
-    if (generationIndex <= terminalGenerationCounter) return;
-    terminalGenerationCounter = generationIndex;
+    const releaseReservation = tryReserveTerminalGeneration(generationIndex);
+    if (!releaseReservation) return;
 
-    await exporter.publish({
-      id: randomUUID(),
-      traceId: currentTraceId,
-      ...runtimeCorrelation,
-      sessionId: localSessionId,
-      conversationId: localSessionId,
-      ...(isSubagent
-        ? { ...(parentSessionId ? { parentSessionId } : {}), childSessionId: localSessionId }
-        : {}),
-      llmGenerationId: `gen-${generationIndex}`,
-      status: 'failed',
-      createdAt: new Date().toISOString(),
-      model: modelConfigFromCtx(ctx),
-      error: `HTTP ${event.status}`,
-    });
+    try {
+      await exporter.publish({
+        id: randomUUID(),
+        traceId: currentTraceId,
+        ...runtimeCorrelation,
+        sessionId: localSessionId,
+        conversationId: localSessionId,
+        ...(isSubagent
+          ? { ...(parentSessionId ? { parentSessionId } : {}), childSessionId: localSessionId }
+          : {}),
+        llmGenerationId: `gen-${generationIndex}`,
+        status: 'failed',
+        createdAt: new Date().toISOString(),
+        model: modelConfigFromCtx(ctx),
+        error: `HTTP ${event.status}`,
+      });
+    } catch (error) {
+      releaseReservation();
+      throw error;
+    }
   });
 
   pi.on('message_end', async (event) => {

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -84,6 +84,8 @@ const DEFAULT_LANGFUSE_BASE_URL = 'https://cloud.langfuse.com';
 const DEFAULT_FLUSH_AT = 20;
 const DEFAULT_FLUSH_INTERVAL_MS = 5000;
 const MAX_PENDING_GENERATIONS = 128;
+const TERMINAL_FLUSH_ATTEMPTS = 3;
+const TERMINAL_FLUSH_RETRY_BASE_MS = 50;
 
 export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
   private readonly client: LangfuseSdkClient;
@@ -143,12 +145,20 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
     if (!isTerminalTelemetryEvent(event)) {
       return;
     }
-    try {
-      await this.client.flushAsync();
-    } catch (error) {
-      console.warn(
-        `Langfuse telemetry flush failed: ${error instanceof Error ? error.message : String(error)}`,
-      );
+    for (let attempt = 1; attempt <= TERMINAL_FLUSH_ATTEMPTS; attempt += 1) {
+      try {
+        await this.client.flushAsync();
+        return;
+      } catch (error) {
+        console.warn(
+          `Langfuse telemetry flush failed (attempt ${attempt}/${TERMINAL_FLUSH_ATTEMPTS}): ${error instanceof Error ? error.message : String(error)}`,
+        );
+        if (attempt < TERMINAL_FLUSH_ATTEMPTS) {
+          await new Promise((resolve) =>
+            setTimeout(resolve, TERMINAL_FLUSH_RETRY_BASE_MS * attempt),
+          );
+        }
+      }
     }
   }
 

--- a/packages/pi-telemetry/src/langfuse.ts
+++ b/packages/pi-telemetry/src/langfuse.ts
@@ -84,7 +84,7 @@ const DEFAULT_LANGFUSE_BASE_URL = 'https://cloud.langfuse.com';
 const DEFAULT_FLUSH_AT = 20;
 const DEFAULT_FLUSH_INTERVAL_MS = 5000;
 const MAX_PENDING_GENERATIONS = 128;
-const TERMINAL_FLUSH_ATTEMPTS = 3;
+const TERMINAL_FLUSH_RETRIES = 3;
 const TERMINAL_FLUSH_RETRY_BASE_MS = 50;
 
 export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
@@ -145,21 +145,25 @@ export class LangfuseSdkRuntimeEventExporter implements RuntimeEventExporter {
     if (!isTerminalTelemetryEvent(event)) {
       return;
     }
-    for (let attempt = 1; attempt <= TERMINAL_FLUSH_ATTEMPTS; attempt += 1) {
+    const maxAttempts = TERMINAL_FLUSH_RETRIES + 1;
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
         await this.client.flushAsync();
         return;
       } catch (error) {
-        console.warn(
-          `Langfuse telemetry flush failed (attempt ${attempt}/${TERMINAL_FLUSH_ATTEMPTS}): ${error instanceof Error ? error.message : String(error)}`,
+        lastError = error;
+        console.error(
+          `[pi-telemetry] Langfuse telemetry flush failed (attempt ${attempt}/${maxAttempts}): ${error instanceof Error ? error.message : String(error)}`,
         );
-        if (attempt < TERMINAL_FLUSH_ATTEMPTS) {
+        if (attempt < maxAttempts) {
           await new Promise((resolve) =>
             setTimeout(resolve, TERMINAL_FLUSH_RETRY_BASE_MS * attempt),
           );
         }
       }
     }
+    throw lastError;
   }
 
   private publishLifecycleEvent(event: RuntimeLifecycleEvent): void {


### PR DESCRIPTION
> [!IMPORTANT]
> 本 PR 来自 dev 全量真实任务验证；没有对应的 GitHub issue。

## Summary

- 在 `turn_end` 增加 assistant generation 的终态兜底，并用同步终态预留避免与 `message_end` 重复上报。
- provider 失败与正常完成共用同一个 reservation/release helper；任一路径 publish 失败都只释放本次 reservation，允许后续权威事件补报。
- Langfuse 终态 flush 最多重试 3 次（共 4 次尝试）；全部失败时向上抛错，不再把未持久化的终态误判为成功。
- `turn_end` generation 兜底失败时记录带 `[pi-telemetry]` 前缀的 stderr 日志，并继续发布 `chat_turn_completed`；turn 时间戳在 flush 前采集，不计入遥测延迟。
- dev 实证中 R4 只有 5 个 Span 且没有 Generation。Pi/Langfuse 源码证明首个断点是 pending Generation 只依赖 `message_end` 终态，而 `turn_end` lifecycle 会清理未闭合 pending Generation；本 PR 在清理前用同一 assistant message 闭合，并在 publish/flush 失败时释放当前 reservation 供后续路径重试。
- R3 完全缺失 Trace，只能确定在 exporter/ingestion 链：runtime usage 非零、遥测 attestation 与关联字段正常、stderr 为空、44 条服务事件没有 extension/Langfuse error，但保留的 Pi stdout 已截断。bounded flush retry 是可靠性增强，不能在新镜像 live 证据前宣称已经确定关闭 R3。

## Verification

- `pnpm --filter @amaster.ai/pi-telemetry test`：3 个测试文件、72 项全部通过。
- `pnpm --filter @amaster.ai/pi-telemetry typecheck`：通过。
- Biome 检查本 PR 4 个文件：通过。
- 根仓库 typecheck：通过；lint 仅有一个既存的 `pi-video-gen` warning，无 error。
- 根仓库测试：130 个文件中 129 个通过；1938 项中 1937 通过，唯一失败仍为无关的 `packages/pi-dingtalk/src/__tests__/cli.test.ts`：本机存在 `~/.dws/node_modules/.bin/dws` 时期待值写死为 `"dws"`。`packages/pi-dingtalk` 相对 `origin/master` 无差异，因此未修改无关逻辑。
- 新增回归覆盖：`turn_end` 兜底、完成终态不重复、失败终态不再跟随 completed、完成/失败 reservation 的 publish 失败回滚、`turn_end` 失败后 lifecycle 继续、duration 不含 flush 延迟、3 次真实重试以及重试穷尽后 reject。
- 最终 dev 验收仍需发布新 telemetry beta、重新构建 runtime 镜像后创建新的 R3/R4 真实任务。R4 必须出现 Generation；R3 必须出现精确 Trace，否则下一步是保留完整 extension stdout 并增加 exporter publish/flush/ingestion receipt，而不是继续推断。

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.
