### PR TITLE
fix(ci): request fork approval once

### DIFF
--- a/.github/scripts/integration-matrix.test.mjs
+++ b/.github/scripts/integration-matrix.test.mjs
@@ -9,8 +9,11 @@ test('requires environment approval for secret-backed fork integration', async (
   assert.match(workflow, /pull_request_target:\s+branches: \[master, main\]/);
   assert.doesNotMatch(workflow, /\n  pull_request:\n/);
   assert.doesNotMatch(workflow, /github\.event_name != 'pull_request_target' \|\|/);
-  assert.equal(workflow.match(/name: \$\{\{ github\.event_name == 'pull_request_target' && github\.event\.pull_request\.head\.repo\.full_name != github\.repository && 'fork-integration' \|\| 'integration' \}\}/g)?.length, 2);
-  assert.equal(workflow.match(/deployment: false/g)?.length, 2);
+  assert.equal(workflow.match(/name: \$\{\{ github\.event_name == 'pull_request_target' && github\.event\.pull_request\.head\.repo\.full_name != github\.repository && 'fork-integration' \|\| 'integration' \}\}/g)?.length, 1);
+  assert.equal(workflow.match(/deployment: false/g)?.length, 1);
+  assert.match(workflow, /integration-approval:\s+name: Approve secret-backed Integration/);
+  assert.match(workflow, /pi-runtime-smoke:[\s\S]*?needs: integration-approval/);
+  assert.match(workflow, /extension-tool-matrix:[\s\S]*?needs: \[detect-extension-matrix, integration-approval\]/);
   assert.equal(workflow.match(/allow-unsafe-pr-checkout:/g)?.length, 4);
   assert.equal(workflow.match(/persist-credentials: false/g)?.length, 4);
   assert.equal(workflow.match(/ref: \$\{\{ env\.INTEGRATION_CHECKOUT_REF \}\}/g)?.length, 4);

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -97,17 +97,24 @@ jobs:
           fi
 
   # ──────────────────────────────────────────────────────────────────────
-  # Stage B: single-prompt LLM smoke test against the custom deepseek
-  # provider. This job runs in parallel with the Stage C matrix (both
-  # `needs: pi-runtime` and don't depend on each other) so the LLM
-  # round-trip doesn't gate per-extension verification.
-  # ──────────────────────────────────────────────────────────────────────
-  pi-runtime-smoke:
-    name: Pi runtime smoke (Stage B)
+  integration-approval:
+    name: Approve secret-backed Integration
     needs: pi-runtime
     environment:
       name: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-integration' || 'integration' }}
       deployment: false
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Secret-backed Integration approved"
+
+  # Stage B: single-prompt LLM smoke test against the custom deepseek
+  # provider. This job runs in parallel with the Stage C matrix after the
+  # shared approval gate, so the LLM round-trip doesn't gate per-extension
+  # verification.
+  # ──────────────────────────────────────────────────────────────────────
+  pi-runtime-smoke:
+    name: Pi runtime smoke (Stage B)
+    needs: integration-approval
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -234,18 +241,15 @@ jobs:
   #
   # PR runs use pull_request_target so Integration executes exactly once.
   # Same-repository PRs use the unprotected `integration` environment; fork
-  # PRs check out the exact fork SHA and wait for approval on the protected
-  # `fork-integration` environment before either secret-backed job starts.
+  # PRs check out the exact fork SHA and pass one approval gate on the protected
+  # `fork-integration` environment before any secret-backed job starts.
   # ──────────────────────────────────────────────────────────────────────
   extension-tool-matrix:
     name: Extension E2E (${{ matrix.extension }}${{ matrix.provider && format('-{0}', matrix.provider) || '' }}${{ matrix.scenario && format('-{0}', matrix.scenario) || '' }})
-    needs: [detect-extension-matrix, pi-runtime]
+    needs: [detect-extension-matrix, integration-approval]
     if: >
       needs.detect-extension-matrix.outputs.has_extensions == 'true' &&
       vars.PI_INTEGRATION_SKIP_STAGE_C != 'true'
-    environment:
-      name: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'fork-integration' || 'integration' }}
-      deployment: false
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
## Summary

- gate all secret-backed fork Integration jobs behind one approval job
- keep the approval job free of PR checkout and secrets
- start Stage B and the full Stage C matrix after one approval

## Verification

- `PATH=/opt/homebrew/bin:$PATH pnpm vitest run .github/scripts/integration-matrix.test.mjs tests/security-boundaries.test.ts`
- `actionlint v1.7.12 .github/workflows/integration.yml`
- commit hook: lint, typecheck, test, build

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.