### PR TITLE
feat(pi-image-gen): improve prompt guidance

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -410,4 +410,4 @@ Use `/image-gen list` to verify your config — it will tell you when `defaultMo
 
 ## Bundled skill
 
-This package ships an `image-gen` skill (`skills/image-gen/SKILL.md`) that Pi loads on demand. It carries the prompting playbook the one-line tool guidance can't hold: when to use raster generation vs repo-native SVG/CSS, generate-vs-edit intent, `n`-is-variants-not-assets, multi-image role labeling, edit invariants, text-in-image handling, and the labeled prompt schema. The tool works without it; the skill makes the model use the tool well.
+This package ships an `image-gen` skill (`skills/image-gen/SKILL.md`) that Pi loads on demand. Agents are encouraged to read it before using `image_generate`, but the tool remains usable without it. The skill carries the prompting playbook the one-line tool guidance can't hold: when to use raster generation vs repo-native SVG/CSS, generate-vs-edit intent, `n`-is-variants-not-assets, multi-image role labeling, edit invariants, text-in-image handling, and the labeled prompt schema.

--- a/packages/pi-image-gen/skills/image-gen/SKILL.md
+++ b/packages/pi-image-gen/skills/image-gen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-gen
-description: "Generate or edit raster images with the image_generate tool: photos, illustrations, textures, sprites, product/UI mockups, concept art, or image-to-image edits. Use when the deliverable is a bitmap asset. Do NOT use for icons, logos, diagrams, or UI graphics that should be repo-native SVG/vector/CSS/canvas — edit or write those directly."
+description: "Prompting workflow for image_generate when generating or editing raster images such as photos, illustrations, textures, sprites, mockups, concept art, or image-to-image edits. Use when the deliverable is a bitmap asset; keep repo-native SVG/vector/CSS/canvas work in source form."
 ---
 
 # Image generation
@@ -21,7 +21,7 @@ This skill guides use of the `image_generate` tool from `@amaster.ai/pi-image-ge
 - A small project-local asset edit when the source already exists in an editable native format.
 - Any task where the user clearly wants deterministic code-native output, not a generated bitmap.
 
-## Two questions before every call
+## Before every call
 
 1. **Intent — generate or edit?**
    - No `image`, or `image` entries used only as style/composition/mood references → **generate**.
@@ -30,6 +30,7 @@ This skill guides use of the `image_generate` tool from `@amaster.ai/pi-image-ge
 2. **Strategy — one asset or many?**
    - `n` produces **variants of ONE prompt**, not distinct assets.
    - For several *different* assets, make **one `image_generate` call per asset**, each with its own prompt. Do not raise `n` to cover distinct subjects.
+3. **Inputs — what must the prompt preserve?** Collect exact text, constraints/avoid items, and every input image's role. Ask only when a missing detail blocks a usable result; otherwise proceed.
 
 ## Prompt structure
 
@@ -46,9 +47,12 @@ Style/medium: <photo / illustration / 3D / etc.>
 Composition/framing: <wide / close / top-down; placement; negative space if needed>
 Lighting/mood: <lighting + mood>
 Color palette: <palette notes>
+Materials/textures: <surface details>
 Text (verbatim): "<exact text>"
 Constraints: <must keep / must avoid>
 ```
+
+The labels are scaffolding, not a required form. Keep only the lines that materially improve the request.
 
 ## Specificity policy
 
@@ -73,7 +77,7 @@ Allowed augmentation: composition/framing cues, polish-level or intended-use hin
 
 ## Iterate deliberately
 
-Start from a clean base prompt, then make **one targeted change at a time** and re-check subject, style, composition, text accuracy, and invariants. Prefer a single focused follow-up over rewriting the whole prompt.
+Start from a clean base prompt, then make **one targeted change at a time**. After each output, inspect the subject, style, composition, text accuracy, and edit invariants before reporting success or iterating. Prefer a single focused follow-up over rewriting the whole prompt.
 
 ## Parameters
 

--- a/packages/pi-image-gen/skills/image-gen/evals.json
+++ b/packages/pi-image-gen/skills/image-gen/evals.json
@@ -57,6 +57,29 @@
           "includes_any": ["do not use image_generate", "should not use image_generate", "not use raster", "avoid raster"]
         }
       ]
+    },
+    {
+      "id": "shape-generic-request-into-prompt",
+      "prompt": "Generate a polished landing-page hero showing a ceramic teapot. Write the exact prompt you would send to image_generate, but do not call any tools. Do not invent a brand, slogan, people, or extra props.",
+      "expected_output": "Turn the request into a concise labeled prompt covering intended use, subject, composition, lighting, materials, and explicit avoid constraints without inventing new creative requirements.",
+      "expectations": [
+        {
+          "text": "Identifies the intended asset use",
+          "includes_any": ["Asset type", "landing-page hero", "landing page hero"]
+        },
+        {
+          "text": "Adds useful visual direction",
+          "includes_any": ["Composition", "framing", "Lighting"]
+        },
+        {
+          "text": "Describes the requested material",
+          "includes_any": ["Materials", "texture", "ceramic"]
+        },
+        {
+          "text": "Carries forward the explicit avoid constraints",
+          "includes": ["brand", "slogan", "people", "props"]
+        }
+      ]
     }
   ]
 }

--- a/packages/pi-image-gen/skills/image-gen/evals.json
+++ b/packages/pi-image-gen/skills/image-gen/evals.json
@@ -57,29 +57,6 @@
           "includes_any": ["do not use image_generate", "should not use image_generate", "not use raster", "avoid raster"]
         }
       ]
-    },
-    {
-      "id": "shape-generic-request-into-prompt",
-      "prompt": "Generate a polished landing-page hero showing a ceramic teapot. Write the exact prompt you would send to image_generate, but do not call any tools. Do not invent a brand, slogan, people, or extra props.",
-      "expected_output": "Turn the request into a concise labeled prompt covering intended use, subject, composition, lighting, materials, and explicit avoid constraints without inventing new creative requirements.",
-      "expectations": [
-        {
-          "text": "Identifies the intended asset use",
-          "includes_any": ["Asset type", "landing-page hero", "landing page hero"]
-        },
-        {
-          "text": "Adds useful visual direction",
-          "includes_any": ["Composition", "framing", "Lighting"]
-        },
-        {
-          "text": "Describes the requested material",
-          "includes_any": ["Materials", "texture", "ceramic"]
-        },
-        {
-          "text": "Carries forward the explicit avoid constraints",
-          "includes": ["brand", "slogan", "people", "props"]
-        }
-      ]
     }
   ]
 }

--- a/packages/pi-image-gen/src/__tests__/extension.test.ts
+++ b/packages/pi-image-gen/src/__tests__/extension.test.ts
@@ -108,8 +108,10 @@ describe('piImageGenExtension', () => {
     expect(tool?.promptSnippet).toBeTruthy();
     expect(Array.isArray(tool?.promptGuidelines)).toBe(true);
     expect(tool?.promptGuidelines?.length).toBeGreaterThan(0);
-    // The guidance must steer away from icons/logos and clarify `n` semantics.
+    // The guidance should point to the skill, steer away from icons/logos, and
+    // clarify `n` semantics.
     const guidelines = (tool?.promptGuidelines ?? []).join('\n');
+    expect(guidelines).toMatch(/read the `image-gen` skill/i);
     expect(guidelines).toMatch(/icon|logo|svg/i);
     expect(guidelines).toMatch(/\bn\b/);
     // Invariant params are always present regardless of provider.
@@ -464,6 +466,23 @@ describe('image_generate execute error surfaces are sanitized', () => {
     isolatedHome = '';
     for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
     tmpDirs.length = 0;
+  });
+
+  it('allows image_generate when the image-gen skill was not read', async () => {
+    const cwd = makeProject({ defaultModel: 'gpt-image-2' });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [{ b64_json: PNG_B64 }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+    const result = await runExecute(cwd);
+
+    expect(result.isError).not.toBe(true);
+    expect(result.content.map((item) => item.text).join('\n')).toMatch(/Generated 1 image/i);
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it('leaks neither the signed download URL nor a raw error to stderr or the tool result', async () => {

--- a/packages/pi-image-gen/src/__tests__/extension.test.ts
+++ b/packages/pi-image-gen/src/__tests__/extension.test.ts
@@ -422,6 +422,11 @@ describe('image_generate execute error surfaces are sanitized', () => {
     '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d49444154789c63000100000005000115c46f250000000049454e44ae426082',
     'hex',
   ).toString('base64');
+  const pngResponse = () =>
+    new Response(JSON.stringify({ data: [{ b64_json: PNG_B64 }] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
   const tmpDirs: string[] = [];
   let realFetch: typeof fetch;
   let isolatedHome = '';
@@ -470,13 +475,7 @@ describe('image_generate execute error surfaces are sanitized', () => {
 
   it('allows image_generate when the image-gen skill was not read', async () => {
     const cwd = makeProject({ defaultModel: 'gpt-image-2' });
-    const fetchMock = vi.fn(
-      async () =>
-        new Response(JSON.stringify({ data: [{ b64_json: PNG_B64 }] }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        }),
-    );
+    const fetchMock = vi.fn(async () => pngResponse());
     globalThis.fetch = fetchMock as typeof fetch;
     const result = await runExecute(cwd);
 
@@ -594,11 +593,7 @@ describe('image_generate execute error surfaces are sanitized', () => {
     writeFileSync(filePath, 'x');
     const badOutputDir = join(filePath, 'child'); // parent is a file → ENOTDIR
 
-    globalThis.fetch = (async () =>
-      new Response(JSON.stringify({ data: [{ b64_json: PNG_B64 }] }), {
-        status: 200,
-        headers: { 'content-type': 'application/json' },
-      })) as typeof fetch;
+    globalThis.fetch = (async () => pngResponse()) as typeof fetch;
 
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {

--- a/packages/pi-image-gen/src/index.ts
+++ b/packages/pi-image-gen/src/index.ts
@@ -368,7 +368,7 @@ export function buildImageToolParameters(caps: ImageToolCapabilities) {
 export function buildImageGuidelines(caps: ImageToolCapabilities): string[] {
   const showN = !caps.model || caps.model.nMax > 1;
   const guidelines = [
-    'For best results, read the `image-gen` skill listed in `<available_skills>` before using image_generate; it contains the prompt-shaping workflow.',
+    'For best results, read the `image-gen` skill bundled with this package before using image_generate; it contains the prompt-shaping workflow.',
     'Use image_generate for bitmap assets: photos, illustrations, textures, sprites, product/UI mockups, concept art. Do NOT use it for icons, logos, or diagrams that should match existing repo-native SVG/vector/CSS/canvas assets — edit or write those directly instead.',
     'Generate vs edit: with no `image`, or when `image` entries are only style/composition/mood references, this is a fresh generation. To modify an existing image while preserving most of it, pass that image and describe the change as an edit.',
     ...(showN

--- a/packages/pi-image-gen/src/index.ts
+++ b/packages/pi-image-gen/src/index.ts
@@ -368,6 +368,7 @@ export function buildImageToolParameters(caps: ImageToolCapabilities) {
 export function buildImageGuidelines(caps: ImageToolCapabilities): string[] {
   const showN = !caps.model || caps.model.nMax > 1;
   const guidelines = [
+    'For best results, read the `image-gen` skill listed in `<available_skills>` before using image_generate; it contains the prompt-shaping workflow.',
     'Use image_generate for bitmap assets: photos, illustrations, textures, sprites, product/UI mockups, concept art. Do NOT use it for icons, logos, or diagrams that should match existing repo-native SVG/vector/CSS/canvas assets — edit or write those directly instead.',
     'Generate vs edit: with no `image`, or when `image` entries are only style/composition/mood references, this is a fresh generation. To modify an existing image while preserving most of it, pass that image and describe the change as an edit.',
     ...(showN


### PR DESCRIPTION
## Summary

- expand the bundled image-generation skill with clearer prompt shaping and output checks
- encourage agents to read the skill before `image_generate` while keeping the tool usable without it
- add regression coverage proving `image_generate` remains usable when the skill was not read

## Verification

- `pnpm --filter @amaster.ai/pi-image-gen test` (200 tests passed)
- `pnpm --filter @amaster.ai/pi-image-gen typecheck`
- `pnpm exec biome check packages/pi-image-gen/src/index.ts packages/pi-image-gen/src/__tests__/extension.test.ts`
- skill validation, JSON validation, and `git diff --check`
- full pre-commit test suite is blocked locally because Node 22 cannot load the existing `better-sqlite3` binary compiled for a different Node ABI; 1 unrelated `pi-memory-mem0` test failed

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.