### PR TITLE
feat(pi-memory-mem0): include dates in recalled memories

### DIFF
--- a/packages/pi-memory-mem0/src/__tests__/extension.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/extension.test.ts
@@ -558,7 +558,14 @@ describe('session_start — user id compatibility', () => {
 describe('passive recall', () => {
   it('returns recalled memories as a custom message, never the system prompt', async () => {
     const provider = mockActiveProvider({
-      search: vi.fn().mockResolvedValue([{ id: '1', memory: 'likes cats', score: 0.9 }]),
+      search: vi.fn().mockResolvedValue([
+        {
+          id: '1',
+          memory: 'likes cats',
+          score: 0.9,
+          created_at: '2026-08-20T10:00:00Z',
+        },
+      ]),
     });
     const { pi, handlers } = createMockPi();
     mem0Extension(pi as never);
@@ -577,6 +584,7 @@ describe('passive recall', () => {
     expect(result?.systemPrompt).toBeUndefined();
     expect(result?.message?.customType).toBe('mem0-recall');
     expect(result?.message?.content).toContain('## Recalled Memories (Mem0)');
+    expect(result?.message?.content).toContain('- (2026-08-20)');
     expect(result?.message?.content).toContain('[UNTRUSTED MEMORY DATA] "likes cats"');
   });
 

--- a/packages/pi-memory-mem0/src/__tests__/tools.test.ts
+++ b/packages/pi-memory-mem0/src/__tests__/tools.test.ts
@@ -65,7 +65,15 @@ describe('mem0_memory tool', () => {
   describe('search action', () => {
     it('searches with the scoped userId and returns memories as untrusted data', async () => {
       const provider = mockProvider({
-        search: vi.fn().mockResolvedValue([{ id: 'm1', memory: 'likes cats', score: 0.9 }]),
+        search: vi.fn().mockResolvedValue([
+          {
+            id: 'm1',
+            memory: 'likes cats',
+            score: 0.9,
+            created_at: '2026-08-20T10:00:00Z',
+            updated_at: '2026-08-28T10:00:00Z',
+          },
+        ]),
       });
       const tool = createTool(provider);
 
@@ -76,7 +84,7 @@ describe('mem0_memory tool', () => {
         'pets',
         expect.objectContaining({ userId: 'user:project:abc', topK: 5 }),
       );
-      expect(result.content[0]!.text).toContain('m1');
+      expect(result.content[0]!.text).toContain('m1 (2026-08-28):');
       expect(result.content[0]!.text).toContain('[UNTRUSTED MEMORY DATA] "likes cats"');
     });
 

--- a/packages/pi-memory-mem0/src/prefetch.ts
+++ b/packages/pi-memory-mem0/src/prefetch.ts
@@ -57,9 +57,10 @@ export class Prefetch {
 
       const lines = memories
         .filter((m) => m.memory?.trim())
-        .map(
-          (m) => `- ${formatRecalledMemory(truncateLine(m.memory.trim(), MAX_ENTRY_CHARS).text)}`,
-        );
+        .map((m) => {
+          const date = (m.updated_at ?? m.created_at)?.slice(0, 10);
+          return `- ${date ? `(${date}) ` : ''}${formatRecalledMemory(truncateLine(m.memory.trim(), MAX_ENTRY_CHARS).text)}`;
+        });
 
       if (lines.length === 0) return '';
       return truncateHead(`## Recalled Memories (Mem0)\n${lines.join('\n')}`, {

--- a/packages/pi-memory-mem0/src/tools.ts
+++ b/packages/pi-memory-mem0/src/tools.ts
@@ -19,6 +19,7 @@ import { truncateHead, truncateLine } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { formatRecalledMemory, redactMemoryText } from './privacy.js';
 import type { Mem0Provider } from './provider.js';
+import type { MemoryItem } from './types.js';
 
 /** Tool results land in model context — keep the block small. */
 const MAX_ENTRY_CHARS = 1_000;
@@ -60,15 +61,13 @@ function errorResult(text: string): Mem0ToolResult {
   return { isError: true, content: [{ type: 'text' as const, text }], details: undefined };
 }
 
-function formatEntry(entry: { id: string; memory: string }): string {
+function formatEntry(entry: MemoryItem): string {
   const text = truncateLine(entry.memory.trim(), MAX_ENTRY_CHARS).text;
-  return `- ${entry.id}: ${formatRecalledMemory(text)}`;
+  const date = (entry.updated_at ?? entry.created_at)?.slice(0, 10);
+  return `- ${entry.id}${date ? ` (${date})` : ''}: ${formatRecalledMemory(text)}`;
 }
 
-function formatBlock(
-  title: string,
-  entries: Array<{ id: string; memory: string }>,
-): AgentToolResult<unknown> {
+function formatBlock(title: string, entries: MemoryItem[]): AgentToolResult<unknown> {
   const lines = entries.filter((e) => e.memory?.trim()).map(formatEntry);
   if (lines.length === 0) return textResult('No memories found.');
   return textResult(


### PR DESCRIPTION
## Summary

- include date-only `updated_at` with a `created_at` fallback in automatic recall and `mem0_memory` results
- preserve the existing output when a memory has no timestamp

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Related issue

Fixes #180

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.