### PR TITLE
fix(pi-wecom): support wecom-cli 1.2

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -347,6 +347,19 @@ jobs:
       - name: Run checks
         run: pnpm run pr-check
 
+      - name: Verify pi-wecom package contents
+        run: |
+          set -euo pipefail
+          pack_dir="$RUNNER_TEMP/pi-wecom-pack"
+          mkdir -p "$pack_dir"
+          pnpm --dir packages/pi-wecom pack --pack-destination "$pack_dir" >/dev/null
+          tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
+          skill_count="$(tar -tzf "$tarball" | grep -Ec '^package/skills/wecomcli-[^/]+/SKILL\.md$' || true)"
+          if [ "$skill_count" -ne 14 ]; then
+            echo "Expected 14 pi-wecom skills in $tarball, found $skill_count."
+            exit 1
+          fi
+
       - name: Publish to npm
         if: steps.versioning.outputs.skip_publish != 'true'
         env:

--- a/packages/pi-wecom/README.md
+++ b/packages/pi-wecom/README.md
@@ -30,19 +30,26 @@ Project settings are loaded only after project trust is accepted. For environmen
 | `botId` | Yes | Bot ID from [WeCom Admin Console](https://work.weixin.qq.com/) |
 | `botSecret` | Yes | Bot Secret |
 
-> **Note:** wecom-cli requires QR code scan for initial authentication. After the extension installs the CLI, run `wecom-cli init` to complete the interactive login.
+> **Note:** wecom-cli requires QR code scan for initial authentication. After the extension installs the CLI, run `wecom-cli auth init --noninteractive` to complete login.
 
 ## Skills Provided
 
-7 skills from wecom-cli covering:
+14 skills from wecom-cli covering:
 
-- `wecomcli-msg` — Messages, conversations, media download
+- `wecomcli-shared` — Shared setup and authentication checks
+- `wecomcli-message` — Messages and conversations
 - `wecomcli-contact` — Address book, user search
 - `wecomcli-meeting` — Create, cancel, manage meetings
-- `wecomcli-schedule` — Schedule CRUD, free/busy
+- `wecomcli-calendar` — Schedule CRUD, free/busy
 - `wecomcli-todo` — Task management
-- `wecomcli-doc` — Documents and smart sheets
-- `wecomcli-smartsheet` — Table, field, record CRUD
+- `wecomcli-email` — Email search and reading
+- `wecomcli-disk` — WeDrive files and folders
+- `wecomcli-media` — Media upload and download
+- `wecomcli-doc-manage` — Document search and permissions
+- `wecomcli-doc` — Online documents
+- `wecomcli-sheet` — Online spreadsheets
+- `wecomcli-smartsheet` — Smart Sheet data and structure
+- `wecomcli-smartpage` — Smart documents
 
 ## CLI Reference
 

--- a/packages/pi-wecom/package.json
+++ b/packages/pi-wecom/package.json
@@ -46,6 +46,7 @@
   "scripts": {
     "fetch-skills": "node scripts/fetch-skills.mjs",
     "prebuild": "node scripts/fetch-skills.mjs",
+    "prepack": "node scripts/fetch-skills.mjs",
     "build": "tsc -b",
     "typecheck": "tsc -b --pretty false",
     "test": "vitest run src"

--- a/packages/pi-wecom/scripts/fetch-skills.mjs
+++ b/packages/pi-wecom/scripts/fetch-skills.mjs
@@ -2,7 +2,7 @@
  * Fetches the latest wecom-cli skills from GitHub and writes them to the skills/ directory.
  */
 import { execSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -13,11 +13,6 @@ const REMOTE_PATH = 'skills';
 
 async function fetchSkills() {
   console.log('[pi-wecom] Fetching skills from github.com/%s ...', REPO);
-
-  if (existsSync(SKILLS_DIR)) {
-    rmSync(SKILLS_DIR, { recursive: true, force: true });
-  }
-  mkdirSync(SKILLS_DIR, { recursive: true });
 
   const tmpDir = join(__dirname, '..', '.tmp-skills-fetch');
   if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
@@ -35,7 +30,8 @@ async function fetchSkills() {
       throw new Error(`Skills directory not found at ${srcSkills}`);
     }
 
-    execSync(`cp -r "${srcSkills}/"* "${SKILLS_DIR}/"`, { stdio: 'pipe' });
+    rmSync(SKILLS_DIR, { recursive: true, force: true });
+    cpSync(srcSkills, SKILLS_DIR, { recursive: true });
     console.log('[pi-wecom] Skills fetched successfully.');
   } finally {
     rmSync(tmpDir, { recursive: true, force: true });
@@ -43,6 +39,6 @@ async function fetchSkills() {
 }
 
 fetchSkills().catch((err) => {
-  console.warn('[pi-wecom] Failed to fetch skills (using existing if available):', err.message);
-  process.exit(0);
+  console.error('[pi-wecom] Failed to fetch skills:', err.message);
+  process.exitCode = 1;
 });

--- a/packages/pi-wecom/src/__tests__/cli.test.ts
+++ b/packages/pi-wecom/src/__tests__/cli.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mockExec = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  exec: (...args: unknown[]) => mockExec(...args),
+}));
+
+const { isWeComCliAuthenticated } = await import('../cli.js');
+
+describe('isWeComCliAuthenticated', () => {
+  it('uses the CLI 1.2 status command and accepts authorized', async () => {
+    const signal = new AbortController().signal;
+    mockExec.mockImplementation(
+      (
+        command: string,
+        options: { signal?: AbortSignal },
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        expect(options.signal).toBe(signal);
+        if (command.endsWith('auth show --status')) callback(null, 'authorized\n', '');
+        else callback(new Error('unrecognized subcommand'), '', '');
+      },
+    );
+
+    await expect(isWeComCliAuthenticated(signal)).resolves.toBe(true);
+  });
+
+  it('rejects unauthorized', async () => {
+    mockExec.mockImplementation(
+      (
+        _command: string,
+        _options: { signal?: AbortSignal },
+        callback: (error: Error | null, stdout: string, stderr: string) => void,
+      ) => callback(null, 'unauthorized\n', ''),
+    );
+
+    await expect(isWeComCliAuthenticated()).resolves.toBe(false);
+  });
+});

--- a/packages/pi-wecom/src/cli.ts
+++ b/packages/pi-wecom/src/cli.ts
@@ -10,9 +10,12 @@ const BIN_PATH = join(INSTALL_DIR, 'node_modules', '.bin', 'wecom-cli');
 let installAttempted = false;
 let cliAvailable: boolean | undefined;
 
-function execAsync(command: string): Promise<{ stdout: string; stderr: string }> {
+function execAsync(
+  command: string,
+  signal?: AbortSignal,
+): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    exec(command, (error, stdout, stderr) => {
+    exec(command, { signal }, (error, stdout, stderr) => {
       if (error) reject(error);
       else resolve({ stdout, stderr });
     });
@@ -50,10 +53,10 @@ export async function ensureWeComCli(): Promise<boolean> {
   return isWeComCliInstalled();
 }
 
-export async function isWeComCliAuthenticated(): Promise<boolean> {
+export async function isWeComCliAuthenticated(signal?: AbortSignal): Promise<boolean> {
   try {
-    const { stdout } = await execAsync(`"${wecomCliBin()}" auth status`);
-    return !stdout.includes('not authenticated') && !stdout.includes('未认证');
+    const { stdout } = await execAsync(`"${wecomCliBin()}" auth show --status`, signal);
+    return stdout.trim() === 'authorized';
   } catch {
     return false;
   }

--- a/packages/pi-wecom/src/index.ts
+++ b/packages/pi-wecom/src/index.ts
@@ -32,9 +32,9 @@ export default function piWeComExtension(pi: ExtensionAPI): void {
       if (installed) {
         skillsDir = await resolveSkillsDir();
         ctx.ui.setStatus?.('pi-wecom', 'wecom-cli: ready');
-        if (!(await isWeComCliAuthenticated())) {
+        if (!(await isWeComCliAuthenticated(ctx.signal))) {
           ctx.ui.notify(
-            'pi-wecom: wecom-cli 未认证，请运行 wecom-cli init 完成扫码认证',
+            'pi-wecom: wecom-cli 未认证，请运行 wecom-cli auth init --noninteractive 完成扫码认证',
             'warning',
           );
         }


### PR DESCRIPTION
> [!IMPORTANT]
> Links Issue #184 for context without closing it.

## Summary

- use the wecom-cli 1.2 authentication command and strictly parse its status
- bundle the 14 official WeCom skills at pack time and verify the published tarball contents
- update authentication guidance and add regression coverage

## Verification

- `pnpm pr-check` (1976 passed, 2 skipped)
- `pnpm --dir packages/pi-wecom pack` (14 bundled skills verified)
- Standards/Spec re-review: no findings; ponytail review: lean already

## Related issue

Refs #184

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.