### PR TITLE
fix(pi-telemetry): break index.ts import cycle so the extension loads

### DIFF
--- a/packages/pi-telemetry/src/exporters.ts
+++ b/packages/pi-telemetry/src/exporters.ts
@@ -1,0 +1,26 @@
+import type { RuntimeEventExporter, RuntimeTelemetryEvent } from './index.js';
+
+export class NoopRuntimeEventExporter implements RuntimeEventExporter {
+  async publish(_event: RuntimeTelemetryEvent): Promise<void> {}
+  async flush(): Promise<void> {}
+  async close(): Promise<void> {}
+}
+
+export class CompositeRuntimeEventExporter implements RuntimeEventExporter {
+  constructor(private readonly exporters: RuntimeEventExporter[]) {}
+
+  async publish(event: RuntimeTelemetryEvent): Promise<void> {
+    await Promise.allSettled(this.exporters.map((exporter) => exporter.publish(event)));
+  }
+
+  async flush(): Promise<void> {
+    await Promise.allSettled(this.exporters.map((exporter) => exporter.flush?.()));
+  }
+
+  async close(): Promise<void> {
+    // Preserve the public flush-before-close contract. Built-in close()
+    // implementations may flush again, but an already-drained queue is a no-op.
+    await this.flush();
+    await Promise.allSettled(this.exporters.map((exporter) => exporter.close?.()));
+  }
+}

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -8,7 +8,8 @@ import type {
 import { isProjectTrusted } from '@amaster.ai/pi-shared/settings';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { loadConfigFromFile, resolveConfig } from './config.js';
-import { NoopRuntimeEventExporter, type RuntimeEventExporter } from './index.js';
+import { NoopRuntimeEventExporter } from './exporters.js';
+import type { RuntimeEventExporter } from './index.js';
 import { createTelemetryExporter } from './otel.js';
 
 const MAX_STREAM_CAPTURE_BYTES = 1_000_000;

--- a/packages/pi-telemetry/src/index.ts
+++ b/packages/pi-telemetry/src/index.ts
@@ -36,29 +36,13 @@ export type RuntimeTelemetryOptions = {
   redactEvent?: TelemetryRedactor | undefined;
 };
 
-export class NoopRuntimeEventExporter implements RuntimeEventExporter {
-  async publish(_event: RuntimeTelemetryEvent): Promise<void> {}
-  async flush(): Promise<void> {}
-  async close(): Promise<void> {}
-}
-
-export class CompositeRuntimeEventExporter implements RuntimeEventExporter {
-  constructor(private readonly exporters: RuntimeEventExporter[]) {}
-
-  async publish(event: RuntimeTelemetryEvent): Promise<void> {
-    await Promise.allSettled(this.exporters.map((exporter) => exporter.publish(event)));
-  }
-
-  async flush(): Promise<void> {
-    await Promise.allSettled(this.exporters.map((exporter) => exporter.flush?.()));
-  }
-
-  async close(): Promise<void> {
-    // Preserve the public flush-before-close contract. Built-in close()
-    // implementations may flush again, but an already-drained queue is a no-op.
-    await this.flush();
-    await Promise.allSettled(this.exporters.map((exporter) => exporter.close?.()));
-  }
-}
+// The concrete exporters live in a leaf module so that sibling modules (extension.ts,
+// otel.ts, langfuse/config.ts) can import them as runtime values WITHOUT importing back into
+// this entry module. index.ts re-exports the extension factory (`export { default }` below),
+// so a value import from here would make index.ts a circular-import target — and a
+// static/bundling loader (Pi's extension loader, jiti) then evaluates the entry before the
+// cycle resolves and reads the re-exported default as `undefined`. Re-exporting keeps the
+// public `@amaster.ai/pi-telemetry` entry point unchanged.
+export { CompositeRuntimeEventExporter, NoopRuntimeEventExporter } from './exporters.js';
 
 export { default } from './extension.js';

--- a/packages/pi-telemetry/src/langfuse/config.ts
+++ b/packages/pi-telemetry/src/langfuse/config.ts
@@ -1,9 +1,6 @@
 import type { TelemetryConfig } from '../config.js';
-import {
-  NoopRuntimeEventExporter,
-  type RuntimeEventExporter,
-  type TelemetryEnvironment,
-} from '../index.js';
+import { NoopRuntimeEventExporter } from '../exporters.js';
+import type { RuntimeEventExporter, TelemetryEnvironment } from '../index.js';
 import { parseBoolean, parsePositiveInteger, trim } from '../parse.js';
 import { OtelRuntimeEventExporter } from './exporters.js';
 import {

--- a/packages/pi-telemetry/src/otel.ts
+++ b/packages/pi-telemetry/src/otel.ts
@@ -1,9 +1,6 @@
 import type { TelemetryConfig } from './config.js';
-import {
-  NoopRuntimeEventExporter,
-  type RuntimeEventExporter,
-  type TelemetryEnvironment,
-} from './index.js';
+import { NoopRuntimeEventExporter } from './exporters.js';
+import type { RuntimeEventExporter, TelemetryEnvironment } from './index.js';
 import {
   type OtelExporterConfig,
   OtelRuntimeEventExporter,

--- a/tests/extension-e2e.test.ts
+++ b/tests/extension-e2e.test.ts
@@ -96,15 +96,15 @@ function findSchemaViolations(schema: unknown, path = ''): string[] {
   return violations;
 }
 
-// Packages whose declared src/index.ts is type-export-heavy followed by `export { default } from
-// './extension.js'`. jiti 2.7's static interop trips on this combination at the moment
-// (it returns `undefined` for the re-exported default). The factory-invoke contract is
-// still covered by extension-loading.test.ts, which uses vitest's native TS loader.
-// pi-coding-agent itself runs against the built dist/index.js, so jiti behavior here is
-// a developer-time check, not a runtime gate.
+// Packages whose src/index.ts is a circular-import target: index.ts re-exports the extension
+// factory (`export { default } from './extension.js'`) while sibling modules import runtime
+// values back from index.ts. A static/bundling loader (jiti here, and Pi's own extension
+// loader) evaluates the entry before the cycle resolves, so the re-exported default comes back
+// `undefined`. The fix is to move the shared runtime values out of index.ts into a leaf module,
+// so nothing imports values back from the entry (pi-telemetry was fixed this way).
+// pi-task-scheduler still has this shape and is tracked separately.
 const JITI_FACTORY_INVOKE_SKIP = new Set([
   'pi-task-scheduler',
-  'pi-telemetry',
 ]);
 
 describe('Extension E2E loading via jiti', () => {
@@ -174,11 +174,10 @@ describe('Extension E2E loading via jiti', () => {
     expect(ext.commands.has('teamwork-status')).toBe(true);
   });
 
-  // pi-task-scheduler / pi-memory re-export their factory through
-  // `export { default } from './extension.js'`, which jiti 2.7 returns as undefined
-  // when the re-exporting module starts with type-only exports (see
-  // JITI_FACTORY_INVOKE_SKIP). Their command registrations are covered by the
-  // vitest-native-loader path in tests/extension-loading.test.ts.
+  // pi-task-scheduler is skipped above: its src/index.ts is a circular-import target
+  // (siblings import runtime values back from the entry that re-exports the factory), so a
+  // static loader returns `undefined` for the default. Its command registrations are covered by
+  // the vitest-native-loader path in tests/extension-loading.test.ts. See JITI_FACTORY_INVOKE_SKIP.
 });
 
 describe('findSchemaViolations regression', () => {


### PR DESCRIPTION
> [!IMPORTANT]
> Link the related issue with `Fixes #123` when this PR resolves it, or `Refs #123` when it only provides context.

## Summary

Fixes circular import

<!-- In 1-3 bullets: what changed and why? -->

## Verification

<!-- Commands or manual checks. -->
e2e test turned back on, it matches bun behavior

## Related issue

<!-- Fixes #123 or Refs #123. Omit this section when there is no related issue. -->
#186 

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.

**probably same issue with pi-task-scheduler**