### PR TITLE
fix(pi-telemetry): preserve tool error messages

### DIFF
--- a/packages/pi-telemetry/README.md
+++ b/packages/pi-telemetry/README.md
@@ -111,4 +111,4 @@ const telemetry = createTelemetryExporter(config); // one provider for both dest
 
 ## Privacy
 
-Runtime events omit user prompts, assistant responses, tool arguments, tool outputs, and model inputs/outputs by default. Set `includePayloads: true` to include them. For finer control, construct an exporter directly and pass `redactEvent`.
+Runtime events omit user prompts, assistant responses, tool arguments, tool outputs, and model inputs/outputs by default. Error messages are always exported. Set `includePayloads: true` to include payloads. For finer control, construct an exporter directly and pass `redactEvent`.

--- a/packages/pi-telemetry/src/__tests__/extension.test.ts
+++ b/packages/pi-telemetry/src/__tests__/extension.test.ts
@@ -399,7 +399,7 @@ describe('telemetryExtension', () => {
     });
   });
 
-  it('publishes a sanitized tool failure without raw result details', async () => {
+  it('publishes the original tool failure for exporter-level payload handling', async () => {
     telemetryExtension(mockPi as any);
     await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
     await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: Date.now() });
@@ -408,7 +408,10 @@ describe('telemetryExtension', () => {
       type: 'tool_execution_end',
       toolCallId: 'call-1',
       toolName: 'read_file',
-      result: 'Authorization: Bearer super-secret-token\ninternal stack trace',
+      result: {
+        content: [{ type: 'text', text: 'ENOENT: /missing/file' }],
+        details: { exitCode: 1 },
+      },
       isError: true,
     });
 
@@ -416,10 +419,9 @@ describe('telemetryExtension', () => {
     const toolEvent = events.find((e) => 'toolCallId' in e);
     expect(toolEvent).toMatchObject({
       status: 'failed',
-      error: 'Tool execution failed',
+      error: 'ENOENT: /missing/file',
     });
     expect(toolEvent).not.toHaveProperty('details');
-    expect(JSON.stringify(toolEvent)).not.toContain('super-secret-token');
   });
 
   it('publishes LLM generation started from before_provider_request', async () => {

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -501,13 +501,12 @@ describe('telemetry', () => {
     expect(span.attributes['langfuse.observation.metadata.error']).toBeUndefined();
     // They remain in the plain (catch-all) attributes.
     expect(JSON.parse(String(span.attributes.details))).toEqual({ phase: 'provider' });
-    // Explicit errors are sanitized before they reach any attribute.
-    expect(span.attributes.error).toBe('Telemetry operation failed');
+    expect(span.attributes.error).toBe('request failed');
     expect(span.status.code).toBe(SpanStatusCode.ERROR);
-    expect(span.status.message).toBe('Telemetry operation failed');
+    expect(span.status.message).toBe('request failed');
   });
 
-  it('sanitizes explicit telemetry errors before export', async () => {
+  it('preserves explicit telemetry errors before export', async () => {
     const { exporter, inMemory } = makeExporter({ includePayloads: true });
     await exporter.publish({
       id: 'failed-tool',
@@ -518,16 +517,13 @@ describe('telemetry', () => {
       toolName: 'bash',
       status: 'failed',
       createdAt: '2026-05-02T00:00:01.000Z',
-      error: 'Authorization: Bearer super-secret-token\ninternal stack trace',
+      error: 'ENOENT: /missing/file',
     });
 
     const [span] = inMemory.getFinishedSpans() as [ReadableSpan];
-    const serialized = JSON.stringify(span.attributes);
-    expect(serialized).toContain('Telemetry operation failed');
-    expect(serialized).not.toContain('super-secret-token');
-    expect(serialized).not.toContain('internal stack trace');
+    expect(span.attributes.error).toBe('ENOENT: /missing/file');
     expect(span.status.code).toBe(SpanStatusCode.ERROR);
-    expect(span.status.message).toBe('Telemetry operation failed');
+    expect(span.status.message).toBe('ENOENT: /missing/file');
   });
 
   it('strips payloads when includePayloads is false', async () => {
@@ -544,16 +540,20 @@ describe('telemetry', () => {
     await exporter.publish({
       id: 'turn-1-end',
       traceId,
-      type: 'chat_turn_completed',
+      type: 'chat_turn_failed',
       sessionId: 'session-1',
       conversationId: 'conversation-1',
       createdAt: '2026-05-02T00:00:01.000Z',
       details: { output: 'world' },
+      error: 'request failed',
     });
 
     const [span] = inMemory.getFinishedSpans() as [ReadableSpan];
     expect(span.attributes['langfuse.observation.input']).toBeUndefined();
-    expect(span.attributes['langfuse.observation.output']).toBeUndefined();
+    expect(JSON.parse(String(span.attributes['langfuse.observation.output']))).toEqual({
+      error: 'request failed',
+    });
+    expect(span.status.message).toBe('request failed');
     const serialized = JSON.stringify(span.attributes);
     expect(serialized).not.toContain('hello');
     expect(serialized).not.toContain('world');

--- a/packages/pi-telemetry/src/extension.ts
+++ b/packages/pi-telemetry/src/extension.ts
@@ -68,7 +68,10 @@ function simplifyContent(content: unknown): JsonValue | undefined {
   return content as JsonValue;
 }
 
-function toolEventDetails(result: unknown): JsonObject | undefined {
+function toolEventDetails(
+  result: unknown,
+  isError: boolean,
+): { details?: JsonObject; error?: string } {
   const rawDetails =
     result && typeof result === 'object' && !Array.isArray(result)
       ? (result as Record<string, unknown>).details
@@ -78,7 +81,11 @@ function toolEventDetails(result: unknown): JsonObject | undefined {
   if (output !== undefined && details.output === undefined) {
     details.output = output;
   }
-  return Object.keys(details).length > 0 ? details : undefined;
+  if (isError) {
+    // Tool owners sanitize errors at source; telemetry preserves that text for diagnostics.
+    return { error: typeof details.output === 'string' ? details.output : 'Tool execution failed' };
+  }
+  return Object.keys(details).length > 0 ? { details } : {};
 }
 
 function sanitizeToolDetails(value: unknown): JsonObject {
@@ -353,9 +360,6 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
 
   pi.on('tool_execution_end', async (event) => {
     if (!currentTraceId) return;
-    // Failed tool results can contain credentials, internal paths, or stacks.
-    // Keep the failure signal but never forward the raw result as telemetry.
-    const details = event.isError ? undefined : toolEventDetails(event.result);
 
     await exporter.publish({
       id: randomUUID(),
@@ -370,8 +374,7 @@ export default function telemetryExtension(pi: ExtensionAPI): void {
       toolName: event.toolName,
       status: event.isError ? 'failed' : 'completed',
       createdAt: new Date().toISOString(),
-      ...(details ? { details } : {}),
-      ...(event.isError ? { error: 'Tool execution failed' } : {}),
+      ...toolEventDetails(event.result, event.isError),
     });
   });
 

--- a/packages/pi-telemetry/src/langfuse/utils.ts
+++ b/packages/pi-telemetry/src/langfuse/utils.ts
@@ -108,10 +108,7 @@ export function applyTelemetryRedaction(
   if (!redacted) {
     return undefined;
   }
-  const sanitized = redacted.error
-    ? ({ ...redacted, error: 'Telemetry operation failed' } as RuntimeTelemetryEvent)
-    : redacted;
-  return config.includePayloads === false ? stripTelemetryPayloads(sanitized) : sanitized;
+  return config.includePayloads === false ? stripTelemetryPayloads(redacted) : redacted;
 }
 
 export function stripTelemetryPayloads(event: RuntimeTelemetryEvent): RuntimeTelemetryEvent {
@@ -120,13 +117,13 @@ export function stripTelemetryPayloads(event: RuntimeTelemetryEvent): RuntimeTel
     return { ...rest, streamEvents: [] };
   }
   if (isLlmGenerationEvent(event)) {
-    const { input: _input, output: _output, error: _error, ...rest } = event;
+    const { input: _input, output: _output, ...rest } = event;
     return rest as RuntimeTelemetryEvent;
   }
   if (isToolEvent(event)) {
-    const { args: _args, details: _details, error: _error, ...rest } = event;
+    const { args: _args, details: _details, ...rest } = event;
     return rest as RuntimeTelemetryEvent;
   }
-  const { details: _details, error: _error, ...rest } = event;
+  const { details: _details, ...rest } = event;
   return rest as RuntimeTelemetryEvent;
 }


### PR DESCRIPTION
## Summary

- preserve sanitized tool error messages instead of replacing them with generic telemetry failures
- keep errors observable when payload capture is disabled
- document that tool owners sanitize errors before telemetry export

## Verification

- `pnpm --filter @amaster.ai/pi-telemetry test` (70 passed)
- `pnpm --filter @amaster.ai/pi-telemetry typecheck`
- `pnpm exec biome check packages/pi-telemetry/src/extension.ts packages/pi-telemetry/src/langfuse/utils.ts packages/pi-telemetry/src/__tests__/extension.test.ts packages/pi-telemetry/src/__tests__/index.test.ts packages/pi-telemetry/README.md`
- `git diff --check`
- pre-commit full suite: lint and typecheck passed; tests reached 1977 passed with one unrelated `pi-memory-mem0` persistence failure because Node 22 (ABI 127) could not load `better-sqlite3` built for Node 24 (ABI 141)

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.