### PR TITLE
fix(pi-image-gen): support custom provider image flow

### DIFF
--- a/packages/pi-image-gen/src/__tests__/config.test.ts
+++ b/packages/pi-image-gen/src/__tests__/config.test.ts
@@ -212,6 +212,23 @@ describe('resolveModel — capability attachment', () => {
     expect(result.capabilities?.maxReferenceImages).toBe(3);
   });
 
+  it('a catch-all custom provider inherits the registry contract for a built-in model', () => {
+    delete process.env.ARK_API_KEY;
+    const result = resolveModel('doubao-seedream-5-0-lite-260128', {
+      customProviders: {
+        amaster: {
+          api: 'openai',
+          baseUrl: 'https://credits.amaster.ai/',
+          apiKey: 'sk-test',
+        },
+      },
+    });
+    if ('error' in result) throw new Error(result.error);
+    expect(result.provider.id).toBe('amaster');
+    expect(result.capabilities?.sizeRange?.tiers).toEqual(['2K', '3K', '4K']);
+    expect(result.capabilities?.sizeRange?.minArea).toBe(3_686_400);
+  });
+
   it('explicit per-field declarations win over the inherited contract', () => {
     const settings: ImageGenSettings = {
       customProviders: {

--- a/packages/pi-image-gen/src/__tests__/generate.test.ts
+++ b/packages/pi-image-gen/src/__tests__/generate.test.ts
@@ -124,7 +124,7 @@ describe('generateImage', () => {
     expect(readFileSync(result.images[0]!.path)).toEqual(PNG_BYTES);
   });
 
-  it('passes the provider host as trustedHosts when downloading url-style results', async () => {
+  it('trusts the provider and returned media hosts when downloading url-style results', async () => {
     const cwd = makeTmpDir();
     const settings: ImageGenSettings = {
       defaultModel: 'x-img',
@@ -141,7 +141,7 @@ describe('generateImage', () => {
       const url = typeof input === 'string' ? input : (input as URL).toString();
       if (url.endsWith('/images/generations')) {
         return fakeJsonResponse({
-          data: [{ url: 'https://gateway.internal.example/img.png' }],
+          data: [{ url: 'https://cdn.example/img.png' }],
         });
       }
       return new Response(PNG_BYTES, {
@@ -153,11 +153,36 @@ describe('generateImage', () => {
 
     await generateImage({ prompt: 'house' }, { cwd, settings, fetchImpl });
 
-    expect(safeFetchMock).toHaveBeenCalledWith(
-      'https://gateway.internal.example/img.png',
-      expect.anything(),
-      { trustedHosts: ['gateway.internal.example'] },
+    expect(safeFetchMock).toHaveBeenCalledWith('https://cdn.example/img.png', expect.anything(), {
+      trustedHosts: ['gateway.internal.example', 'cdn.example'],
+    });
+  });
+
+  it('does not trust provider-returned IP literal media hosts', async () => {
+    const cwd = makeTmpDir();
+    const settings: ImageGenSettings = {
+      defaultModel: 'x-img',
+      customProviders: {
+        myprov: {
+          api: 'openai',
+          apiKey: 'k',
+          baseUrl: 'https://gateway.internal.example/v1',
+          models: ['x-img'],
+        },
+      },
+    };
+    const fetchImpl: typeof fetch = (async () =>
+      fakeJsonResponse({ data: [{ url: 'http://127.0.0.1/private.png' }] })) as typeof fetch;
+    safeFetchMock.mockRejectedValue(
+      new Error('Outbound URL must use a public HTTP(S) destination.'),
     );
+
+    await expect(generateImage({ prompt: 'house' }, { cwd, settings, fetchImpl })).rejects.toThrow(
+      /public HTTP/i,
+    );
+    expect(safeFetchMock).toHaveBeenCalledWith('http://127.0.0.1/private.png', expect.anything(), {
+      trustedHosts: ['gateway.internal.example'],
+    });
   });
 
   it('cancels an unread generated-image HTTP error body', async () => {

--- a/packages/pi-image-gen/src/config.ts
+++ b/packages/pi-image-gen/src/config.ts
@@ -192,7 +192,11 @@ export function resolveModel(
   for (const [name, raw] of Object.entries(settings.customProviders ?? {})) {
     if (raw.models && raw.models.length > 0) continue;
     const provider = buildCustomProvider(name, raw);
-    if (provider) return { provider, remoteId: requested, requestedId: requested };
+    if (provider) {
+      const resolved: ResolvedModel = { provider, remoteId: requested, requestedId: requested };
+      if (builtIn?.capabilities) resolved.capabilities = builtIn.capabilities;
+      return resolved;
+    }
   }
 
   return { error: unknownModelError(requested, settings) };

--- a/packages/pi-image-gen/src/generate.ts
+++ b/packages/pi-image-gen/src/generate.ts
@@ -1,6 +1,8 @@
 import { mkdir, open, unlink } from 'node:fs/promises';
+import { isIP } from 'node:net';
 import { isAbsolute, resolve } from 'node:path';
 import {
+  hostFromUrl,
   readResponseBytes,
   safeFetch,
   type TrustedHosts,
@@ -108,9 +110,6 @@ export async function generateImage(
 
   const stamp = formatStamp(now());
   const baseFilename = sanitizeFilename(params.filename ?? `${resolved.requestedId}-${stamp}`);
-  // The image URL comes from the configured provider — trust its host (and
-  // subdomains) so provider-side caches on private/fake-ip networks still work.
-  const trustedHosts = trustedHostsFromUrls(resolved.provider.baseUrl);
   const images: GeneratedImage[] = [];
   try {
     for (let i = 0; i < raws.length; i++) {
@@ -119,6 +118,13 @@ export async function generateImage(
       // multi-image materialize/write would keep writing files and return success.
       if (options.signal?.aborted) throw cancelledError('image generation');
       const raw = raws[i]!;
+      // Trust provider-returned DNS media hosts for fake-ip proxies; IP literals keep SSRF checks.
+      const mediaUrl = raw.data.kind === 'url' ? raw.data.url : undefined;
+      const mediaHost = hostFromUrl(mediaUrl);
+      const trustedHosts = trustedHostsFromUrls(
+        resolved.provider.baseUrl,
+        mediaHost && !isIP(mediaHost.replace(/^\[|\]$/g, '')) ? mediaUrl : undefined,
+      );
       const fetched = await materialize(raw, options.signal, trustedHosts);
       if (options.signal?.aborted) throw cancelledError('image generation');
       const ext = MIME_TO_EXT[fetched.mimeType] ?? 'png';


### PR DESCRIPTION
## Summary

- inherit built-in model capabilities when a known model is routed through a catch-all custom provider, so Seedream 5 Lite advertises its 2K minimum
- trust DNS media hosts returned by the configured provider for fake-ip proxy downloads while keeping IP literals behind SSRF checks
- cover the Lite capability contract and IP-literal trust boundary with regression tests

## Verification

- `pnpm --filter @amaster.ai/pi-image-gen test` (202 tests)
- `pnpm --filter @amaster.ai/pi-image-gen typecheck`
- `pnpm --filter @amaster.ai/pi-image-gen build`
- `pnpm exec biome check packages/pi-image-gen/src/config.ts packages/pi-image-gen/src/generate.ts packages/pi-image-gen/src/__tests__/config.test.ts packages/pi-image-gen/src/__tests__/generate.test.ts`
- `git diff --check`
- Full `pnpm test` reached 1979 passing tests but is blocked locally by the existing `pi-memory-mem0` `better-sqlite3` Node ABI mismatch (module 141 vs local Node 22 module 127).

## Related issue

Fixes #191

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.