### PR TITLE
feat(pi-image-gen): add GPT Image 2.5 models, refresh Gemini registry

### DIFF
--- a/packages/pi-image-gen/README.md
+++ b/packages/pi-image-gen/README.md
@@ -6,8 +6,8 @@ Pi extension that adds an `image_generate` tool. Supported providers:
 
 | Provider                       | Model id (alias)                              | Env var               |
 | ------------------------------ | --------------------------------------------- | --------------------- |
-| OpenAI                         | `gpt-image-2`                                 | `OPENAI_API_KEY`      |
-| Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3.1-flash-image` (alias `nano-banana-2`), `gemini-3.1-flash-lite-image` (alias `nano-banana-2-lite`), `gemini-2.5-flash-image` (alias `nano-banana`) | `GEMINI_API_KEY` |
+| OpenAI                         | `gpt-image-2.5-flare` (alias `gpt-image-2.5`), `gpt-image-2.5-sunburst`, `gpt-image-2` | `OPENAI_API_KEY`      |
+| Google Gemini ("Nano Banana")  | `gemini-3-pro-image` (alias `nano-banana-pro`), `gemini-3.1-flash-image` (alias `nano-banana-2`), `gemini-3.1-flash-lite-image` (alias `nano-banana-2-lite`), `gemini-2.5-flash-image` (alias `nano-banana`, **deprecated — shuts down 2026-10-02; use `gemini-3.1-flash-lite-image` instead**) | `GEMINI_API_KEY` |
 | Alibaba DashScope (Qwen-Image) | `qwen-image-3.0-pro`, `qwen-image-3.0`, `qwen-image-2.0-pro`, `qwen-image-2.0` | `DASHSCOPE_API_KEY`   |
 | Volcengine Ark (ByteDance Seedream) | `doubao-seedream-5-0-pro-260628` (alias `seedream-5-pro`, retired id `doubao-seedream-5-0-pro-260128` still resolves), `doubao-seedream-5-0-260128` (aliases `seedream-5`, `seedream`; the same model also answers to `doubao-seedream-5-0-lite-260128` / `seedream-5-lite`), `doubao-seedream-4-5-251128` (alias `seedream-4-5`), `doubao-seedream-4-0-250828` (alias `seedream-4`) | `ARK_API_KEY`         |
 | OpenRouter                     | any (use `openrouter/<vendor>/<id>`)          | `OPENROUTER_API_KEY`  |
@@ -15,7 +15,7 @@ Pi extension that adds an `image_generate` tool. Supported providers:
 
 Upstream API docs (handy when debugging gateway behavior or adding new models):
 
-- OpenAI gpt-image-2 — [developers.openai.com/api/docs/models/gpt-image-2](https://developers.openai.com/api/docs/models/gpt-image-2)
+- OpenAI GPT Image (2.5 and 2) — [developers.openai.com/api/docs/guides/image-generation](https://developers.openai.com/api/docs/guides/image-generation)
 - Google Gemini image generation — [ai.google.dev/gemini-api/docs/image-generation](https://ai.google.dev/gemini-api/docs/image-generation)
 - Alibaba Qwen-Image 3.0 (generation & editing) — [help.aliyun.com/zh/model-studio/qwen-image-generation-and-editing-api-reference](https://help.aliyun.com/zh/model-studio/qwen-image-generation-and-editing-api-reference)
 - Alibaba DashScope Qwen-Image 2.0 (text-to-image) — [help.aliyun.com/zh/model-studio/qwen-image-api](https://help.aliyun.com/zh/model-studio/qwen-image-api)
@@ -115,14 +115,14 @@ Follow the selected host's documentation for installation and current compatibil
 
 ## Built-in setup walkthrough
 
-### 1. OpenAI (`gpt-image-2`)
+### 1. OpenAI (`gpt-image-2.5-flare`)
 
 ```sh
 export OPENAI_API_KEY=sk-...
 ```
 
 ```json
-{ "pi-image-gen": { "defaultModel": "gpt-image-2" } }
+{ "pi-image-gen": { "defaultModel": "gpt-image-2.5" } }
 ```
 
 ### 2. Google Gemini "Nano Banana"
@@ -318,7 +318,7 @@ If a custom provider has no `models` list, you can still address it with `<provi
 image_generate({
   prompt: string,                  // required — what to draw or how to edit
   image?: string[],                // optional — array of file paths or http(s) URLs
-  n?: number,                      // per-model ceiling (qwen 1–6, gpt-image-2 1–10); hidden for Seedream
+  n?: number,                      // per-model ceiling (qwen 1–6, gpt-image 1–10); hidden for Seedream
   size?: string,                   // per-model form (see below); hidden for Gemini models
   aspectRatio?: string,            // Gemini models only — enum from the model's vocabulary
   imageSize?: string,              // Gemini models only — tier enum ("1K"/"2K"/"4K"), when the model has tiers
@@ -335,11 +335,11 @@ Returns the absolute file path(s) of saved images. Files land in `outputDir` (de
 - `size` follows the model's documented form:
   - **Qwen** (`qwen-image-*`): `"<width>*<height>"` (asterisk, e.g. `"2048*2048"`), total pixels 512²–2048²; 3.0 models additionally cap aspect ratio at 1:8–8:1. The x-form is normalized automatically as a safety net.
   - **Seedream** (`doubao-seedream-*`): a tier token from the model's list (`1K`/`1.5K`/`2K`/`3K`/`4K`) **or** an explicit `"<w>x<h>"` within the model's pixel window (2K floor on 5.0/4.5).
-  - **gpt-image-2**: `"auto"` or `"<w>x<h>"` — arbitrary sizes allowed (both edges divisible by 16, ratio ≤ 3:1, 655,360–8,294,400 px, longest edge ≤ 3840), beyond the standard `1024x1024`/`1536x1024`/`1024x1536`.
+  - **gpt-image** (`gpt-image-2.5-*`, `gpt-image-2`): `"auto"` or `"<w>x<h>"` — arbitrary sizes allowed (both edges divisible by 16, ratio ≤ 3:1, 655,360–8,294,400 px, longest edge ≤ 3840), beyond the standard `1024x1024`/`1536x1024`/`1024x1536`.
   - Omit `size` to use the model's own default (qwen-image-3.0 auto-picks from the prompt).
 - `aspectRatio` / `imageSize` replace `size` for **Gemini** models (they have no pixel-size knob): `aspectRatio` is an enum from the model's vocabulary (10–14 values), `imageSize` an enum of the model's tiers (`1K`/`2K`/`4K`; hidden when the model is fixed at one tier, as `gemini-3.1-flash-lite-image` and `gemini-2.5-flash-image` are).
-- `n` carries the model's documented ceiling in its description (qwen 6, gpt-image-2 10) and is **hidden for Seedream** — that API has no count parameter, so `n` would be silently dropped.
-- `image` spells out the active model's documented reference-image contract in its description (formats, max count, per-image byte ceiling, dimension advice): qwen documents ≤ 3 images (JPG/JPEG/PNG/BMP/TIFF/WEBP/GIF, ≤ 10MB each), Seedream ≤ 10–14 (incl. HEIC/HEIF, ≤ 30MB), gpt-image-2 ≤ 16 (png/webp/jpg, ≤ 50MB), Gemini ≤ 3–14 (≤ 20MB). These are descriptions of the cloud platform's limits, not client-side gates — the provider enforces its own rules.
+- `n` carries the model's documented ceiling in its description (qwen 6, gpt-image 10) and is **hidden for Seedream** — that API has no count parameter, so `n` would be silently dropped.
+- `image` spells out the active model's documented reference-image contract in its description (formats, max count, per-image byte ceiling, dimension advice): qwen documents ≤ 3 images (JPG/JPEG/PNG/BMP/TIFF/WEBP/GIF, ≤ 10MB each), Seedream ≤ 10–14 (incl. HEIC/HEIF, ≤ 30MB), gpt-image ≤ 16 (png/webp/jpg, ≤ 50MB), Gemini ≤ 3–14 (≤ 100MB). These are descriptions of the cloud platform's limits, not client-side gates — the provider enforces its own rules.
 - `quality` appears **only** for a **built-in gpt-image** route — the built-in OpenAI provider on `gpt-image-*`, or an OpenRouter route whose model id is gpt-image (e.g. `openrouter/openai/gpt-image-2`). Only there is it constrained to the enum `low`/`medium`/`high`/`auto` (the vocabulary those APIs document). It is **omitted from the schema entirely** for:
   - Gemini, DashScope/Qwen, and Ark/Seedream — their image APIs have no `quality` field (Seedream varies quality by `size` resolution tier instead);
   - **non-gpt-image routes** on the OpenAI/OpenRouter wire — e.g. built-in `openai/dall-e-3` (which uses `standard`/`hd`) or an OpenRouter route to a non-OpenAI model like Seedream — because the enum above is gpt-image's vocabulary, not the wire format's; and
@@ -393,7 +393,7 @@ Provider behavior:
 
 | Provider | Image input route |
 |---|---|
-| OpenAI (`gpt-image-2`) | `POST /v1/images/edits` (multipart). Supports multi-image. |
+| OpenAI (`gpt-image-2.5-*`, `gpt-image-2`) | `POST /v1/images/edits` (multipart). Supports multi-image. |
 | Gemini (`gemini-3-pro-image`, `gemini-3.1-flash-image`, `gemini-3.1-flash-lite-image`, `gemini-2.5-flash-image`) | `inline_data` parts prepended to the user message. Supports multi-image. |
 | DashScope (`qwen-image-3.0-pro`, `qwen-image-3.0`, `qwen-image-2.0-pro`, `qwen-image-2.0`) | `image` parts in `messages[].content`. Up to 3 images. |
 | OpenRouter | `POST /api/v1/images` with `input_references` JSON. Supports multi-image. |

--- a/packages/pi-image-gen/src/__tests__/models.test.ts
+++ b/packages/pi-image-gen/src/__tests__/models.test.ts
@@ -71,4 +71,23 @@ describe('BUILT_IN_MODELS registry', () => {
     expect(findBuiltInModel('seedream')?.id).toBe(plain?.id);
     expect(findBuiltInModel('seedream-5-lite')?.id).toBe(plain?.id);
   });
+
+  it('registers gpt-image-2.5 flare/sunburst on openai with the gpt-image-2 contract', () => {
+    for (const id of ['gpt-image-2.5-flare', 'gpt-image-2.5-sunburst']) {
+      const entry = findBuiltInModel(id);
+      expect(entry, id).toBeDefined();
+      expect(entry?.provider).toBe('openai');
+      expect(entry?.capabilities?.sizeRange?.allowAuto).toBe(true);
+      expect(entry?.capabilities?.nMax).toBe(10);
+      expect(entry?.capabilities?.maxReferenceImages).toBe(16);
+    }
+    // The generic 2.5 id points at the default tier.
+    expect(findBuiltInModel('gpt-image-2.5')?.id).toBe('gpt-image-2.5-flare');
+  });
+
+  it('limits nano-banana-2-lite to the standard 10 aspect ratios', () => {
+    const lite = findBuiltInModel('gemini-3.1-flash-lite-image');
+    expect(lite?.capabilities?.aspectRatios).toHaveLength(10);
+    expect(findBuiltInModel('gemini-3.1-flash-image')?.capabilities?.aspectRatios).toHaveLength(14);
+  });
 });

--- a/packages/pi-image-gen/src/models.ts
+++ b/packages/pi-image-gen/src/models.ts
@@ -39,8 +39,26 @@ const QWEN3_SIZE_RANGE: NonNullable<ImageModelCapabilities['sizeRange']> = {
 
 const MB = 1024 * 1024;
 
+// Shared by gpt-image-2 and both GPT Image 2.5 tiers (same parameter surface).
+const GPT_IMAGE_CAPABILITIES: ImageModelCapabilities = {
+  sizeRange: {
+    separator: 'x',
+    allowAuto: true,
+    minArea: 655_360,
+    maxArea: 8_294_400,
+    minRatio: 1 / 3,
+    maxRatio: 3,
+    divisibleBy: 16,
+    maxEdge: 3840,
+  },
+  nMax: 10,
+  maxReferenceImages: 16,
+  inputFormats: ['PNG', 'WEBP', 'JPEG'],
+  inputMaxBytes: 50 * MB,
+};
+
 // Gemini aspect-ratio vocabularies per https://ai.google.dev/gemini-api/docs/image-generation
-// (2026-08): the classic 10, and the 3.1 set adding extreme ratios.
+// (2026-09): the classic 10, and the 3.1 set adding extreme ratios.
 const GEMINI_ASPECTS_10 = ['1:1', '2:3', '3:2', '3:4', '4:3', '4:5', '5:4', '9:16', '16:9', '21:9'];
 const GEMINI_ASPECTS_14 = [
   '1:1',
@@ -60,38 +78,36 @@ const GEMINI_ASPECTS_14 = [
 ];
 
 /**
- * Capability values reflect the official provider docs as of 2026-08 and are
- * PENDING live verification where noted:
- * - gpt-image-2: https://developers.openai.com/api/docs/guides/image-generation
+ * Capability values reflect the official provider docs as of 2026-09:
+ * - GPT Image 2.5 / 2: https://developers.openai.com/api/docs/guides/image-generation
  * - Gemini: https://ai.google.dev/gemini-api/docs/image-generation
  * - Qwen 3.0: https://help.aliyun.com/zh/model-studio/qwen-image-generation-and-editing-api-reference
  * - Qwen 2.0: https://help.aliyun.com/zh/model-studio/qwen-image-api (+ qwen-image-edit-api)
  * - Seedream: https://www.volcengine.com/docs/82379/1824121 (+ /1666946)
  */
 export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
-  // OpenAI image generation. gpt-image-2 accepts arbitrary WxH beyond the
+  // OpenAI image generation. GPT Image 2.5 (2026-09-08) is the current line —
+  // flare is the default tier, sunburst the precision tier; both share
+  // gpt-image-2's parameter surface. All accept arbitrary WxH beyond the
   // standard sizes: both edges divisible by 16, ratio ≤ 3:1, total pixels
   // 655,360–8,294,400, longest edge ≤ 3840; "auto" lets the model pick.
-  // Reference images: png/webp/jpg, ≤ 50MB each, up to 16.
+  // Reference images: png/webp/jpg, ≤ 50MB each, up to 16. gpt-image-2 itself
+  // is still fully supported with no announced shutdown.
+  {
+    id: 'gpt-image-2.5-flare',
+    aliases: ['gpt-image-2.5'], // the generic 2.5 id points at the default tier
+    provider: 'openai',
+    capabilities: GPT_IMAGE_CAPABILITIES,
+  },
+  {
+    id: 'gpt-image-2.5-sunburst',
+    provider: 'openai',
+    capabilities: GPT_IMAGE_CAPABILITIES,
+  },
   {
     id: 'gpt-image-2',
     provider: 'openai',
-    capabilities: {
-      sizeRange: {
-        separator: 'x',
-        allowAuto: true,
-        minArea: 655_360,
-        maxArea: 8_294_400,
-        minRatio: 1 / 3,
-        maxRatio: 3,
-        divisibleBy: 16,
-        maxEdge: 3840,
-      },
-      nMax: 10,
-      maxReferenceImages: 16,
-      inputFormats: ['PNG', 'WEBP', 'JPEG'],
-      inputMaxBytes: 50 * MB,
-    },
+    capabilities: GPT_IMAGE_CAPABILITIES,
   },
 
   // Google Gemini "Nano Banana" image generation. Gemini has no pixel-size
@@ -100,8 +116,10 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
   //   Nano Banana Pro      → gemini-3-pro-image
   //   Nano Banana 2        → gemini-3.1-flash-image
   //   Nano Banana 2 Lite   → gemini-3.1-flash-lite-image
-  //   Nano Banana          → gemini-2.5-flash-image
-  // Input formats PNG/JPEG/WEBP/HEIC/HEIF; inline requests cap at 20MB total.
+  //   Nano Banana          → gemini-2.5-flash-image (deprecated — shuts down
+  //     2026-10-02; Google recommends migrating to gemini-3.1-flash-lite-image)
+  // Input formats PNG/JPEG/WEBP/HEIC/HEIF; inline requests cap at 100MB total
+  // (raised from 20MB in 2026-01).
   {
     id: 'gemini-3-pro-image',
     aliases: ['nano-banana-pro'],
@@ -112,7 +130,7 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
       nMax: 8,
       maxReferenceImages: 14,
       inputFormats: GEMINI_INPUT_FORMATS,
-      inputMaxBytes: 20 * MB,
+      inputMaxBytes: 100 * MB,
     },
   },
   {
@@ -121,13 +139,12 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
     provider: 'gemini',
     capabilities: {
       aspectRatios: GEMINI_ASPECTS_14,
-      // The 512px tier is documented for 3.1 Flash — PENDING live verification
-      // of the exact literal ("512px" vs "0.5K").
+      // The only Nano Banana model with a sub-1K tier: "512px" (aka 0.5K).
       imageSizes: ['512px', '1K', '2K', '4K'],
       nMax: 8,
       maxReferenceImages: 14,
       inputFormats: GEMINI_INPUT_FORMATS,
-      inputMaxBytes: 20 * MB,
+      inputMaxBytes: 100 * MB,
     },
   },
   {
@@ -135,12 +152,13 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
     aliases: ['nano-banana-2-lite'],
     provider: 'gemini',
     capabilities: {
-      aspectRatios: GEMINI_ASPECTS_14,
+      // Lite does not support the extreme 1:4/4:1/1:8/8:1 ratios.
+      aspectRatios: GEMINI_ASPECTS_10,
       imageSizes: ['1K'], // fixed at 1K — the schema hides imageSize entirely
       nMax: 8,
       maxReferenceImages: 14,
       inputFormats: GEMINI_INPUT_FORMATS,
-      inputMaxBytes: 20 * MB,
+      inputMaxBytes: 100 * MB,
     },
   },
   {
@@ -148,12 +166,12 @@ export const BUILT_IN_MODELS: BuiltInModelEntry[] = [
     aliases: ['nano-banana'],
     provider: 'gemini',
     capabilities: {
-      aspectRatios: GEMINI_ASPECTS_10,
       // No imageSize knob — fixed 1024px output. Works best with ≤ 3 inputs.
+      aspectRatios: GEMINI_ASPECTS_10,
       nMax: 8,
       maxReferenceImages: 3,
       inputFormats: GEMINI_INPUT_FORMATS,
-      inputMaxBytes: 20 * MB,
+      inputMaxBytes: 100 * MB,
     },
   },
 


### PR DESCRIPTION
## Summary

- Add OpenAI GPT Image 2.5 (released 2026-09-08): `gpt-image-2.5-flare` (alias `gpt-image-2.5`, the default tier) and `gpt-image-2.5-sunburst` (precision tier); all three OpenAI entries now share one `GPT_IMAGE_CAPABILITIES` contract. `gpt-image-2` stays — not deprecated upstream.
- Refresh the Gemini registry against current docs: mark `gemini-2.5-flash-image` deprecated (shuts down 2026-10-02, migrate to `gemini-3.1-flash-lite-image`), fix `gemini-3.1-flash-lite-image` aspect ratios (14 → 10; Lite has no extreme 1:4/4:1/1:8/8:1), raise the inline input cap to 100MB (upstream raised it from 20MB in 2026-01), and confirm the 3.1 Flash `512px` tier (PENDING note dropped).
- No changes for Qwen/DashScope or Seedream/Ark — both registries verified current against official docs (2026-09).

## Verification

- `pnpm vitest run` in packages/pi-image-gen: 204 passed (incl. new registry tests for the 2.5 entries and the Lite 10-aspect-ratio split)
- Full pre-commit gate green: `pnpm lint` (3 pre-existing warnings in other packages, none new), `pnpm typecheck`, `pnpm test` (1993 passed), `pnpm build`
- Two-round code review (standards + spec axes) run on the diff; findings from round 1 fixed and verified in round 2

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.