### PR TITLE
perf(pi-browser-use): defer heavy imports to first connect

### DIFF
--- a/packages/pi-browser-use/src/analyze-screenshot.ts
+++ b/packages/pi-browser-use/src/analyze-screenshot.ts
@@ -10,8 +10,6 @@
  */
 
 import type { TextContent as AiTextContent } from '@earendil-works/pi-ai';
-import { complete } from '@earendil-works/pi-ai/compat';
-import { ModelRegistry, ModelRuntime } from '@earendil-works/pi-coding-agent';
 import type { VisionModelConfig } from './config.js';
 import type { DevToolsClient } from './index.js';
 
@@ -49,8 +47,10 @@ export type VisionCaller = (
 
 /** Create a VisionCaller that resolves credentials from Pi's model registry. Used in CLI standalone mode. */
 export function createFetchVisionCaller(visionConfig: VisionModelConfig): VisionCaller {
-  const registryPromise = ModelRuntime.create().then(
-    (modelRuntime) => new ModelRegistry(modelRuntime),
+  // Imported lazily: pi-ai and pi-coding-agent are heavy and only needed on an actual vision call.
+  const registryPromise = import('@earendil-works/pi-coding-agent').then(
+    ({ ModelRegistry, ModelRuntime }) =>
+      ModelRuntime.create().then((modelRuntime) => new ModelRegistry(modelRuntime)),
   );
 
   return async (
@@ -59,7 +59,10 @@ export function createFetchVisionCaller(visionConfig: VisionModelConfig): Vision
     mimeType: string,
     signal?: AbortSignal,
   ): Promise<string> => {
-    const registry = await registryPromise;
+    const [registry, { complete }] = await Promise.all([
+      registryPromise,
+      import('@earendil-works/pi-ai/compat'),
+    ]);
     const model = registry.find(visionConfig.provider, visionConfig.model);
     if (!model) {
       throw new Error(

--- a/packages/pi-browser-use/src/index.ts
+++ b/packages/pi-browser-use/src/index.ts
@@ -6,10 +6,8 @@ import {
   type PiSettingsOptions,
 } from '@amaster.ai/pi-shared/settings';
 import type { TextContent as AiTextContent } from '@earendil-works/pi-ai';
-import { complete } from '@earendil-works/pi-ai/compat';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { Tool } from '@modelcontextprotocol/sdk/types.js';
 import { Type } from 'typebox';
 import {
@@ -59,18 +57,17 @@ const MCP_STDERR_LIMIT = 4_096;
 const MCP_SYSTEM_ERROR_CODE_PATTERN =
   /^(?:EACCES|EADDRINUSE|ECONNREFUSED|ECONNRESET|EHOSTUNREACH|ENOENT|ENOTEMPTY|ENOTFOUND|EPERM|ETIMEDOUT)$/;
 const require = createRequire(import.meta.url);
-const chromeDevToolsMcpPackagePath = require.resolve('chrome-devtools-mcp/package.json');
-const chromeDevToolsMcpPackage = require(chromeDevToolsMcpPackagePath) as {
-  bin?: Record<string, string>;
-};
-const chromeDevToolsMcpBin = chromeDevToolsMcpPackage.bin?.['chrome-devtools-mcp'];
-if (!chromeDevToolsMcpBin) {
-  throw new Error('chrome-devtools-mcp package does not declare its chrome-devtools-mcp binary');
+
+// Resolved lazily at connect time so extension load does no filesystem work.
+function resolveChromeDevToolsMcpEntrypoint(): string {
+  const packagePath = require.resolve('chrome-devtools-mcp/package.json');
+  const pkg = require(packagePath) as { bin?: Record<string, string> };
+  const bin = pkg.bin?.['chrome-devtools-mcp'];
+  if (!bin) {
+    throw new Error('chrome-devtools-mcp package does not declare its chrome-devtools-mcp binary');
+  }
+  return join(dirname(packagePath), bin);
 }
-const CHROME_DEVTOOLS_MCP_ENTRYPOINT = join(
-  dirname(chromeDevToolsMcpPackagePath),
-  chromeDevToolsMcpBin,
-);
 
 function requestOptions(timeout: number, signal?: AbortSignal) {
   return signal ? { signal, timeout } : { timeout };
@@ -160,31 +157,39 @@ export class DevToolsClient {
     const args = configToArgs(this.config);
     const generation = ++this.generation;
 
-    const transport = new StdioClientTransport({
-      command: process.env.PI_BROWSER_USE_NODE?.trim() || process.execPath,
-      args: [CHROME_DEVTOOLS_MCP_ENTRYPOINT, ...args],
-      stderr: 'pipe',
-    });
+    let client: Client | null = null;
     let stderr = '';
     let transportErrorCode: string | undefined;
-    transport.stderr?.on('data', (chunk) => {
-      stderr = `${stderr}${String(chunk)}`.slice(-MCP_STDERR_LIMIT);
-    });
-
-    const client = new Client({ name: 'pi-browser-use', version: '0.1.0' }, { capabilities: {} });
-    this.client = client;
-
-    transport.onerror = (error: Error) => {
-      if (generation !== this.generation) return;
-      transportErrorCode = safeMcpSystemErrorCode((error as Error & { code?: unknown }).code);
-      console.error(
-        `[pi-browser-use] chrome-devtools-mcp transport error (${transportErrorCode ?? error.name})`,
-      );
-      void this.disconnectUnhealthyClient(generation);
-    };
-    transport.onclose = () => this.markDisconnected(generation);
 
     try {
+      // Imported lazily: the MCP SDK is heavy and only needed once a session actually connects.
+      const [{ Client }, { StdioClientTransport }] = await Promise.all([
+        import('@modelcontextprotocol/sdk/client/index.js'),
+        import('@modelcontextprotocol/sdk/client/stdio.js'),
+      ]);
+
+      const transport = new StdioClientTransport({
+        command: process.env.PI_BROWSER_USE_NODE?.trim() || process.execPath,
+        args: [resolveChromeDevToolsMcpEntrypoint(), ...args],
+        stderr: 'pipe',
+      });
+      transport.stderr?.on('data', (chunk) => {
+        stderr = `${stderr}${String(chunk)}`.slice(-MCP_STDERR_LIMIT);
+      });
+
+      client = new Client({ name: 'pi-browser-use', version: '0.1.0' }, { capabilities: {} });
+      this.client = client;
+
+      transport.onerror = (error: Error) => {
+        if (generation !== this.generation) return;
+        transportErrorCode = safeMcpSystemErrorCode((error as Error & { code?: unknown }).code);
+        console.error(
+          `[pi-browser-use] chrome-devtools-mcp transport error (${transportErrorCode ?? error.name})`,
+        );
+        void this.disconnectUnhealthyClient(generation);
+      };
+      transport.onclose = () => this.markDisconnected(generation);
+
       await client.connect(transport, requestOptions(MCP_TIMEOUT_MS, signal));
       if (generation !== this.generation) return;
       this.state = 'ready';
@@ -197,7 +202,7 @@ export class DevToolsClient {
         this.state = 'failed';
       }
       try {
-        await client.close();
+        await client?.close();
       } catch {
         // The failed transport may already be closed.
       }
@@ -459,6 +464,8 @@ export default function browserUseExtension(pi: ExtensionAPI): void {
       mimeType: string,
       signal?: AbortSignal,
     ): Promise<string> => {
+      // Imported lazily: pi-ai is heavy and only needed when a vision call actually runs.
+      const { complete } = await import('@earendil-works/pi-ai/compat');
       const model = ctx.modelRegistry.find(visionConfig.provider, visionConfig.model);
       if (!model) {
         throw new Error(


### PR DESCRIPTION
## Summary

- Extension load spent most of its time on top-level static imports: `@modelcontextprotocol/sdk`, `@earendil-works/pi-ai/compat`, and a synchronous `require.resolve` of chrome-devtools-mcp's package.json — observed as a 784 ms load entry vs. <300 ms for sibling extensions.
- All heavy imports now sit behind dynamic `import()` at first actual use: the MCP SDK and entrypoint resolution moved into `DevToolsClient.openConnection()`, and the vision-only `complete()` / `ModelRegistry` / `ModelRuntime` into the vision callers. The lazy setup runs inside `openConnection()`'s `try`, so failures keep the sanitized error and `failed` state.
- No behavior change after connect: tool registration, `callTool`, vision analysis, and the standalone CLI mode are unchanged.

## Verification

- `pnpm typecheck` and `pnpm test` (152/152) for the package; biome clean; root pre-commit pipeline (lint + typecheck + 1994 tests + build) green.
- Import benchmark: jiti import of the extension with pi-ai pre-warmed drops from ~250–370 ms to ~2–3 ms; plain `import()` of `dist/index.js` from 310–620 ms to 37–69 ms.
- E2E against built `dist`: connect → `listAllTools` (27 tools) → `callTool` → `close`; failure path (missing Node binary) returns the sanitized `Browser connection failed. MCP subprocess failed (ENOENT).` error.

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.