### PR TITLE
fix(pi-telemetry): publish turn input instantly and sweep open spans on shutdown

### DIFF
--- a/packages/pi-telemetry/README.md
+++ b/packages/pi-telemetry/README.md
@@ -31,7 +31,7 @@ The extension hooks into the following Pi lifecycle events:
 | `message_end` | Complete an LLM generation span with output and usage |
 | `model_select` | Record model switch events |
 | `session_compact` | Record context compaction events |
-| `session_shutdown` | Flush and shutdown exporters |
+| `session_shutdown` | End any spans still open (marked `terminatedBy: session_shutdown`), then flush and shutdown exporters |
 
 ### Trace lifecycle
 

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -433,8 +433,18 @@ describe('telemetry', () => {
     });
 
     const spans = inMemory.getFinishedSpans();
-    // End order: generation, tool, root.
-    const [generation, tool, root] = spans as [ReadableSpan, ReadableSpan, ReadableSpan];
+    // End order: chat-input (instant), generation, tool, root.
+    const [chatInput, generation, tool, root] = spans as [
+      ReadableSpan,
+      ReadableSpan,
+      ReadableSpan,
+      ReadableSpan,
+    ];
+    expect(chatInput.name).toBe('chat-input');
+    expect(chatInput.parentSpanContext?.spanId).toBe(root.spanContext().spanId);
+    expect(hrTimeToMs(chatInput.startTime)).toBe(hrTimeToMs(chatInput.endTime));
+    expect(chatInput.attributes['langfuse.trace.input']).toBe('hello');
+    expect(chatInput.attributes['langfuse.observation.input']).toBe(JSON.stringify('hello'));
     expect(root.name).toBe('chat-turn');
     expect(tool.name).toBe('bash [echo hi]');
     expect(generation.name).toBe('llm-generation [main] [hello]');
@@ -473,6 +483,61 @@ describe('telemetry', () => {
       JSON.stringify({ command: 'echo hi' }),
     );
     expect(tool.attributes['langfuse.observation.output']).toBe(JSON.stringify({ output: 'hi' }));
+  });
+
+  it('publishes the turn input on an instant span before the root ends', async () => {
+    const { exporter, inMemory } = makeExporter();
+
+    await exporter.publish({
+      id: 'turn-1-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'session-1',
+      createdAt: '2026-05-02T00:00:00.000Z',
+      details: { input: 'hello' },
+    });
+
+    // The query lands on the instant span right away — it survives even if
+    // the root span's terminal event never comes (interrupt, process kill).
+    const spans = inMemory.getFinishedSpans();
+    expect(spans.map((span) => span.name)).toEqual(['chat-input']);
+    const [chatInput] = spans as [ReadableSpan];
+    expect(chatInput.attributes['langfuse.trace.input']).toBe('hello');
+    expect(chatInput.attributes['langfuse.observation.input']).toBe(JSON.stringify('hello'));
+    expect(hrTimeToMs(chatInput.startTime)).toBe(hrTimeToMs(chatInput.endTime));
+  });
+
+  it('ends open spans with a warning marker on close', async () => {
+    const { exporter, inMemory } = makeExporter();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // InMemorySpanExporter.shutdown() clears its buffer on close, so record
+    // every export call instead of reading finished spans after the fact.
+    const exported: ReadableSpan[] = [];
+    const originalExport = inMemory.export.bind(inMemory);
+    vi.spyOn(inMemory, 'export').mockImplementation((spans, callback) => {
+      exported.push(...spans);
+      return originalExport(spans, callback);
+    });
+
+    await exporter.publish({
+      id: 'turn-1-start',
+      traceId,
+      type: 'chat_turn_started',
+      sessionId: 'session-1',
+      createdAt: '2026-05-02T00:00:00.000Z',
+      details: { input: 'hello' },
+    });
+    expect(exported.some((span) => span.name === 'chat-turn')).toBe(false);
+
+    // Shutdown ends the orphaned root instead of dropping it silently.
+    await exporter.close();
+    const root = exported.find((span) => span.name === 'chat-turn') as ReadableSpan;
+    expect(root.attributes['langfuse.observation.input']).toBe(JSON.stringify('hello'));
+    expect(root.attributes['langfuse.observation.level']).toBe('WARNING');
+    expect(root.attributes['langfuse.observation.metadata.terminatedBy']).toBe('session_shutdown');
+    expect(
+      errorSpy.mock.calls.filter((args) => String(args[0]).includes('open span(s)')),
+    ).toHaveLength(1);
   });
 
   it('keeps SDK metadata fields filterable on the OTEL path', async () => {
@@ -548,7 +613,11 @@ describe('telemetry', () => {
       error: 'request failed',
     });
 
-    const [span] = inMemory.getFinishedSpans() as [ReadableSpan];
+    const spans = inMemory.getFinishedSpans();
+    // Redaction strips details before publish, so no instant chat-input span
+    // carrying the query may leak either.
+    expect(spans.map((span) => span.name)).toEqual(['chat-turn']);
+    const [span] = spans as [ReadableSpan];
     expect(span.attributes['langfuse.observation.input']).toBeUndefined();
     expect(JSON.parse(String(span.attributes['langfuse.observation.output']))).toEqual({
       error: 'request failed',

--- a/packages/pi-telemetry/src/__tests__/interrupt-flow.test.ts
+++ b/packages/pi-telemetry/src/__tests__/interrupt-flow.test.ts
@@ -1,0 +1,145 @@
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config.js', () => ({
+  loadConfigFromFile: vi.fn(() => ({})),
+  resolveConfig: vi.fn((config: unknown) => config ?? {}),
+}));
+
+// The only mocked seam is the exporter factory: everything downstream — the
+// extension's event mapping and the exporter's span logic — runs for real
+// against an in-memory OTEL pipeline.
+const { holder } = vi.hoisted(() => ({
+  holder: {} as { inMemory?: InMemorySpanExporter },
+}));
+
+vi.mock('../otel.js', async () => {
+  const { OtelRuntimeEventExporter } = await import('../langfuse/exporters.js');
+  return {
+    createTelemetryExporter: vi.fn(() => {
+      const inMemory = new InMemorySpanExporter();
+      const provider = new BasicTracerProvider({
+        spanProcessors: [new SimpleSpanProcessor(inMemory)],
+      });
+      holder.inMemory = inMemory;
+      return new OtelRuntimeEventExporter(
+        { enabled: true, endpoint: '', flushAt: 10, flushIntervalMs: 60_000 },
+        { provider },
+      );
+    }),
+  };
+});
+
+type EventHandler = (...args: any[]) => Promise<void> | void;
+
+const handlers = new Map<string, EventHandler>();
+
+const mockPi = {
+  registerTool: vi.fn(),
+  on: vi.fn((event: string, handler: EventHandler) => {
+    handlers.set(event, handler);
+  }),
+};
+
+const { default: telemetryExtension } = await import('../extension.js');
+
+async function fireEvent(name: string, event?: unknown, ctx?: Record<string, unknown>) {
+  const handler = handlers.get(name);
+  if (handler) await handler(event, ctx ?? {});
+}
+
+function assistantMessage(text: string) {
+  return { role: 'assistant', content: [{ type: 'text', text }] };
+}
+
+describe('interrupt flow', () => {
+  // InMemorySpanExporter.shutdown() clears its buffer on close, so record
+  // every export call instead of reading finished spans after the fact.
+  let exported: ReadableSpan[];
+
+  beforeEach(() => {
+    handlers.clear();
+    exported = [];
+    telemetryExtension(mockPi as any);
+  });
+
+  afterEach(() => {
+    delete process.env.PI_TELEMETRY_TRACEPARENT;
+  });
+
+  function recordExports(): void {
+    const inMemory = holder.inMemory;
+    if (!inMemory) throw new Error('exporter not created — fire session_start first');
+    const originalExport = inMemory.export.bind(inMemory);
+    vi.spyOn(inMemory, 'export').mockImplementation((spans, callback) => {
+      exported.push(...spans);
+      return originalExport(spans, callback);
+    });
+  }
+
+  it('cancel mid-turn (agent_end still fires) completes the root with the query intact', async () => {
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    recordExports();
+    await fireEvent('input', { type: 'input', text: 'cancel this run' });
+    await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: 1700000000000 });
+
+    // The query is exported immediately, before the turn finishes.
+    const chatInput = exported.find((span) => span.name === 'chat-input');
+    expect(chatInput?.attributes['langfuse.trace.input']).toBe('cancel this run');
+    expect(exported.some((span) => span.name === 'chat-turn')).toBe(false);
+
+    // pi's agent loop emits agent_end even when aborted, so an Esc cancel
+    // completes the root span normally rather than orphaning it.
+    await fireEvent('agent_end', {
+      type: 'agent_end',
+      messages: [assistantMessage('partial answer')],
+    });
+
+    const root = exported.find((span) => span.name === 'chat-turn');
+    expect(root?.attributes['langfuse.observation.input']).toBe(JSON.stringify('cancel this run'));
+    expect(root?.attributes['langfuse.observation.output']).toBe(JSON.stringify('partial answer'));
+    expect(root?.attributes['langfuse.observation.level']).toBe('DEFAULT');
+    expect(root?.attributes['langfuse.observation.metadata.terminatedBy']).toBeUndefined();
+  });
+
+  it('interrupt (session exit mid-turn, no agent_end) still exports the query and sweeps the root', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await fireEvent('session_start', { type: 'session_start', reason: 'startup' });
+    recordExports();
+    await fireEvent('input', { type: 'input', text: 'kill this run' });
+    await fireEvent('turn_start', { type: 'turn_start', turnIndex: 0, timestamp: 1700000000000 });
+    await fireEvent('tool_execution_start', {
+      type: 'tool_execution_start',
+      toolCallId: 'call-1',
+      toolName: 'bash',
+      args: { command: 'sleep 999' },
+    });
+
+    const beforeShutdown = exported.length;
+    expect(exported.some((span) => span.name === 'chat-input')).toBe(true);
+    expect(exported.some((span) => span.name === 'chat-turn')).toBe(false);
+
+    await fireEvent('session_shutdown', { type: 'session_shutdown' });
+
+    const swept = exported.slice(beforeShutdown);
+    const root = swept.find((span) => span.name === 'chat-turn');
+    const tool = swept.find((span) => span.name.startsWith('bash'));
+    for (const span of [root, tool]) {
+      expect(span?.attributes['langfuse.observation.level']).toBe('WARNING');
+      expect(span?.attributes['langfuse.observation.metadata.terminatedBy']).toBe(
+        'session_shutdown',
+      );
+    }
+    expect(root?.attributes['langfuse.observation.input']).toBe(JSON.stringify('kill this run'));
+    expect(new Set(exported.map((span) => span.spanContext().traceId)).size).toBe(1);
+    expect(
+      errorSpy.mock.calls.filter((args) => String(args[0]).includes('open span(s)')),
+    ).toHaveLength(1);
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/pi-telemetry/src/langfuse/exporters.ts
+++ b/packages/pi-telemetry/src/langfuse/exporters.ts
@@ -157,6 +157,20 @@ export class OtelRuntimeEventExporter implements RuntimeEventExporter {
   }
 
   async close(): Promise<void> {
+    // Spans still open at shutdown (session exit mid-turn) never end on their
+    // own and would never export — end them so their start attributes
+    // (the root input included) survive.
+    for (const span of this.openSpans.values()) {
+      span.otelSpan.setAttributes({
+        'langfuse.observation.level': 'WARNING',
+        'langfuse.observation.metadata.terminatedBy': 'session_shutdown',
+      });
+      span.end();
+    }
+    if (this.openSpans.size > 0) {
+      console.error(`[pi-telemetry] ended ${this.openSpans.size} open span(s) at session shutdown`);
+    }
+    this.openSpans.clear();
     await waitForExport(
       this.provider.shutdown().catch((error: unknown) => {
         console.error(
@@ -184,6 +198,27 @@ export class OtelRuntimeEventExporter implements RuntimeEventExporter {
         this.trackOpenSpan(chatSpanKey(event), span);
         // A nested pi process parents its subagent span to this root.
         process.env[TRACEPARENT_ENV] = traceparent(span);
+        // The root span exports only when the turn ends; an instant child
+        // span carries the input up front so the query reaches Langfuse even
+        // if the root span is lost to an interrupt or a process kill.
+        const input = event.details?.input;
+        if (input !== undefined) {
+          const inputSpan = this.startSpan(
+            'chat-input',
+            event,
+            createdAtMs,
+            this.enrichSpanAttributes(
+              {
+                ...lifecycleMetadata(event),
+                'langfuse.trace.input': input,
+                ...langfuseObservationAttributes({ input, level: 'DEFAULT' }),
+              },
+              event,
+            ),
+            parentContextOf(span),
+          );
+          inputSpan.end(createdAtMs);
+        }
         return;
       }
       case 'chat_turn_completed':


### PR DESCRIPTION
## Summary

- `chat_turn_started` now also emits an instant zero-duration `chat-input` child span carrying `langfuse.trace.input`, so the query is visible in Langfuse from the moment a turn starts and survives even a later process kill (previously the trace input only appeared when the root span ended, i.e. after the whole turn).
- `close()` now ends any still-open spans — marked `level: WARNING` + `terminatedBy: session_shutdown`, with a one-line summary log — before the OTEL provider shuts down, so Ctrl+C / `/exit` / session switches no longer silently drop the root span and its input.

Redaction is respected: when `includePayloads` is false the stripped `details` suppress the instant span (explicitly tested).

## Verification

- `pnpm vitest run` in packages/pi-telemetry: 72 passed (2 new tests for the instant span and the shutdown sweep; redaction guard made explicit in the strips-payloads test)
- Root `pnpm build` + `pnpm test`: 134 files / 1996 tests passed
- `pnpm typecheck` + biome clean on changed files

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.