### PR TITLE
fix(pi-telemetry): honor includePayloads: false in the combined exporter factory

### DIFF
--- a/.github/scripts/integration-matrix.test.mjs
+++ b/.github/scripts/integration-matrix.test.mjs
@@ -109,7 +109,7 @@ test('threads the integration model through generated configs and skill evaluati
   assert.equal(documents.length, 4);
   for (const model of ['deepseek-v4-flash', 'glm-5.3-flash', 'custom-model']) {
     const configs = documents.map(([, kind, body]) => [kind, JSON.parse(execFileSync('bash', ['-c', `cat <<EOF\n${body}\nEOF`], {
-      encoding: 'utf8', env: { PATH: process.env.PATH, PI_INTEGRATION_MODEL: model, WEB_ACCESS_SETTINGS: '{}', IMAGE_GEN_MODEL: 'image-model', RUNNER_TEMP: '/tmp/pi-integration-config-test' },
+      encoding: 'utf8', env: { PATH: process.env.PATH, PI_INTEGRATION_MODEL: model, WEB_ACCESS_SETTINGS: '{}', IMAGE_GEN_MODEL: 'image-model', INCLUDE_PAYLOADS_JSON: 'true', RUNNER_TEMP: '/tmp/pi-integration-config-test' },
     }))]);
     for (const [, config] of configs.filter(([kind]) => kind === 'models')) {
       assert.equal(config.providers['deepseek-integration'].models[0].id, model);
@@ -120,5 +120,8 @@ test('threads the integration model through generated configs and skill evaluati
     assert.equal(settings['pi-memory-mem0'].oss.llm.config.model, model);
     assert.equal(settings['pi-memory-mem0'].oss.embedder.config.model, 'text-embedding-v4');
     assert.equal(settings['pi-browser-use'].visionModel.model, 'kimi-k2.6');
+    // The workflow heredoc renders includePayloads from INCLUDE_PAYLOADS_JSON
+    // (true for every leg; the redacted scenario flips it to false).
+    assert.equal(settings['pi-telemetry'].includePayloads, true);
   }
 });

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -456,6 +456,13 @@ jobs:
           #    location like ~/.pi/agent/memories/.
           # ${LANGFUSE_*} stays literal for pi's settings resolver. Every
           # model-backed matrix leg installs pi-telemetry below.
+          # The pi-telemetry "redacted" scenario exercises the
+          # includePayloads: false privacy path (issue #197); every other leg
+          # keeps payloads on so trace-shape assertions can match on content.
+          INCLUDE_PAYLOADS_JSON=true
+          if [ "${{ matrix.extension }}" = "pi-telemetry" ] && [ "${{ matrix.scenario }}" = "redacted" ]; then
+            INCLUDE_PAYLOADS_JSON=false
+          fi
           cat > "$PI_CODING_AGENT_DIR/settings.json" <<EOF
           {
             "pi-teamwork": {
@@ -538,7 +545,7 @@ jobs:
             },
             "pi-telemetry": {
               "serviceName": "pi-telemetry-ci",
-              "includePayloads": true,
+              "includePayloads": ${INCLUDE_PAYLOADS_JSON},
               "langfuse": {
                 "enabled": true,
                 "publicKey": "\${LANGFUSE_PUBLIC_KEY}",

--- a/packages/pi-telemetry/src/__tests__/index.test.ts
+++ b/packages/pi-telemetry/src/__tests__/index.test.ts
@@ -365,6 +365,39 @@ describe('telemetry', () => {
     await exporter.close?.();
   });
 
+  it('passes includePayloads through the combined factory, defaulting to stripped', async () => {
+    // Regression: a truthy-only spread used to drop `false` here, so the
+    // exporter saw undefined and applyTelemetryRedaction never stripped.
+    const configOf = (exporter: ReturnType<typeof createTelemetryExporter>) =>
+      (exporter as unknown as { config: OtelExporterConfig }).config.includePayloads;
+    const stripped = createTelemetryExporter({
+      includePayloads: false,
+      otel: { enabled: true, endpoint: 'https://otel.example.com' },
+    });
+    const defaulted = createTelemetryExporter({
+      otel: { enabled: true, endpoint: 'https://otel.example.com' },
+    });
+    const langfusePrimary = createTelemetryExporter({
+      includePayloads: false,
+      langfuse: { enabled: true, publicKey: 'public', secretKey: 'secret' },
+    });
+    const included = createTelemetryExporter({
+      includePayloads: true,
+      otel: { enabled: true, endpoint: 'https://otel.example.com' },
+    });
+
+    expect(configOf(stripped)).toBe(false);
+    expect(configOf(defaulted)).toBe(false);
+    expect(configOf(langfusePrimary)).toBe(false);
+    expect(configOf(included)).toBe(true);
+    await Promise.all([
+      stripped.close?.(),
+      defaulted.close?.(),
+      langfusePrimary.close?.(),
+      included.close?.(),
+    ]);
+  });
+
   it('exports a chat turn as linked spans', async () => {
     const { exporter, inMemory } = makeExporter({ serviceName: 'pi-test' });
 

--- a/packages/pi-telemetry/src/otel.ts
+++ b/packages/pi-telemetry/src/otel.ts
@@ -43,7 +43,9 @@ export function createTelemetryExporter(telemetryConfig: TelemetryConfig): Runti
     flushIntervalMs: otel.flushIntervalMs,
     ...(primary.serviceName !== undefined ? { serviceName: primary.serviceName } : {}),
     ...(primary.serviceVersion !== undefined ? { serviceVersion: primary.serviceVersion } : {}),
-    ...(primary.includePayloads ? { includePayloads: true } : {}),
+    // Both resolvers default this to false; a truthy spread here would drop the
+    // false and applyTelemetryRedaction's strict === false check would never strip.
+    includePayloads: primary.includePayloads === true,
   });
 }
 


### PR DESCRIPTION
## Summary

- Fix: `createTelemetryExporter` passed `includePayloads` through a truthy-only spread (`...(primary.includePayloads ? { includePayloads: true } : {})`), so `false` never reached `OtelRuntimeEventExporter` and `applyTelemetryRedaction`'s strict `=== false` check never stripped — prompts, responses, tool args, and model I/O were exported on every span despite the documented privacy default. Now the resolved boolean is passed through (`=== true`).
- Test: factory-level regression covering explicit `false` / unset (defaults to stripped) / langfuse-primary branch / explicit `true`.
- CI prep (inert): parameterize the integration workflow's pi-telemetry settings write as `INCLUDE_PAYLOADS_JSON` (default `true` for every existing leg). This must land **before** the redacted scenario that flips it to `false`, because `integration.yml` runs under `pull_request_target` — the executing workflow comes from the PR's base branch, so a workflow-side settings change cannot take effect within the same PR that introduces it.

The `TELEMETRY_INCLUDE_PAYLOADS` env var remains scoped to the embedder-facing env factories; the extension's only config surface is `settings.json`.

## Verification

- `pnpm pr-check` (lint + typecheck + full vitest + build) via the pre-commit hook: 1999 passed, 2 skipped; the 3 lint warnings are pre-existing in unrelated packages.
- Matrix script tests execute the workflow heredoc through bash and assert the rendered settings keep `includePayloads: true`.

## Related issue

#197

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.
