### PR TITLE
ci(integration): add pi-telemetry "redacted" scenario asserting no payload upload

### DIFF
--- a/.github/scripts/integration-matrix.mjs
+++ b/.github/scripts/integration-matrix.mjs
@@ -137,6 +137,18 @@ export const fullMatrix = [
     assert_pattern: 'TELEMETRY-HIERARCHY-DONE',
   },
   {
+    extension: 'pi-telemetry',
+    scenario: 'redacted',
+    tools: 'bash',
+    // Runs with includePayloads: false (the settings write in integration.yml
+    // flips it for this scenario). The Langfuse verify step asserts the
+    // privacy contract from issue #197: the trace is complete, but no
+    // observation carries the prompt, tool args/output, or model I/O — nothing
+    // containing the codeword may leave the process.
+    prompt: 'Step 1 — use the bash tool exactly once to run: echo ci-langfuse-probe redacted. Then reply with the single word TELEMETRY-REDACTED-DONE.',
+    assert_pattern: 'TELEMETRY-REDACTED-DONE',
+  },
+  {
     extension: 'pi-browser-use',
     tools: 'browser_list_pages,browser_navigate_page,browser_take_snapshot',
     prompt: 'Use browser_list_pages first to get the current pageId. Pass that pageId to browser_navigate_page to go to https://example.com, then pass it to browser_take_snapshot and tell me the page title.',

--- a/.github/scripts/integration-matrix.test.mjs
+++ b/.github/scripts/integration-matrix.test.mjs
@@ -58,6 +58,7 @@ test('selects a separate Langfuse hierarchy scenario', () => {
     [
       ['pi-telemetry', undefined],
       ['pi-telemetry', 'hierarchy'],
+      ['pi-telemetry', 'redacted'],
     ],
   );
 });
@@ -89,11 +90,11 @@ test('skips Stage C when no tested extension changed', () => {
   assert.deepEqual(selectIntegrationMatrix(['README.md']), []);
   assert.deepEqual(
     selectIntegrationMatrix(['packages/pi-telemetry/src/extension.ts']).map(({ extension }) => extension),
-    ['pi-telemetry', 'pi-telemetry'],
+    ['pi-telemetry', 'pi-telemetry', 'pi-telemetry'],
   );
   assert.deepEqual(
     selectIntegrationMatrix(['.github/scripts/telemetry-langfuse-verify.mjs']).map(({ extension }) => extension),
-    ['pi-telemetry', 'pi-telemetry'],
+    ['pi-telemetry', 'pi-telemetry', 'pi-telemetry'],
   );
 });
 
@@ -120,8 +121,8 @@ test('threads the integration model through generated configs and skill evaluati
     assert.equal(settings['pi-memory-mem0'].oss.llm.config.model, model);
     assert.equal(settings['pi-memory-mem0'].oss.embedder.config.model, 'text-embedding-v4');
     assert.equal(settings['pi-browser-use'].visionModel.model, 'kimi-k2.6');
-    // The workflow heredoc renders includePayloads from INCLUDE_PAYLOADS_JSON
-    // (true for every leg; the redacted scenario flips it to false).
+    // Non-redacted legs keep payloads on; the redacted scenario flips this to
+    // false in the workflow before the heredoc runs.
     assert.equal(settings['pi-telemetry'].includePayloads, true);
   }
 });

--- a/.github/scripts/telemetry-langfuse-verify.mjs
+++ b/.github/scripts/telemetry-langfuse-verify.mjs
@@ -19,6 +19,10 @@
 // The hierarchy scenario adds a second nested pi and verifies:
 // chat-turn → subagent [ci-hierarchy] → subagent [ci-probe] → child work.
 //
+// The redacted scenario runs with includePayloads: false and verifies the
+// privacy contract (issue #197): the trace is still complete, but no
+// observation may carry the prompt, tool args/output, or model I/O.
+//
 // Reads via the Observations API v2 (the v1 reads are deprecated on Cloud).
 // Self-hosted v3 gates v2 behind LANGFUSE_ENABLE_EVENTS_TABLE_V2_APIS
 // (default off), so a 404 on v2 falls back to the v1 observations endpoint for
@@ -36,7 +40,7 @@
 // Optional env: LANGFUSE_BASE_URL (default https://cloud.langfuse.com),
 //               TELEMETRY_TRACE_FROM (ISO lower bound; default: 1h ago),
 //               TELEMETRY_CODEWORD (default ci-langfuse-probe),
-//               TELEMETRY_SCENARIO (basic or hierarchy; default basic).
+//               TELEMETRY_SCENARIO (basic, hierarchy, or redacted; default basic).
 
 import { createHash } from 'node:crypto';
 import { setTimeout as delay } from 'node:timers/promises';
@@ -136,10 +140,12 @@ export function evaluateTrace(observations, codeword, scenario = 'basic') {
   need(root.endTime != null, 'root "chat-turn" span has no endTime');
   // JSON.stringify like discovery does — a structured input would otherwise
   // stringify to '[object Object]' and spuriously fail the whole poll.
-  need(
-    JSON.stringify(root.input ?? '').includes(codeword),
-    'root span input is missing the codeword',
-  );
+  if (scenario !== 'redacted') {
+    need(
+      JSON.stringify(root.input ?? '').includes(codeword),
+      'root span input is missing the codeword',
+    );
+  }
 
   const validateChildren = (checks) => {
     for (const { label, matches, parent, exact } of checks) {
@@ -159,6 +165,45 @@ export function evaluateTrace(observations, codeword, scenario = 'basic') {
       }
     }
   };
+
+  if (scenario === 'redacted') {
+    // includePayloads: false (issue #197): the trace must still be complete,
+    // but no observation may carry payload content. Span names lose their
+    // payload brackets when args/input are stripped ("bash [echo …]" →
+    // "bash"), so the codeword appearing in any name or input/output is a
+    // leak — regardless of which attribute key carried it.
+    need(
+      root.input == null && root.output == null,
+      'root "chat-turn" span carries input/output despite includePayloads: false',
+    );
+    need(
+      !spans.some((o) => o.name === 'chat-input'),
+      'a "chat-input" span was exported despite includePayloads: false',
+    );
+    for (const observation of observations) {
+      const label = `${observation.type} "${observation.name ?? observation.id}"`;
+      need(
+        !(observation.name ?? '').includes(codeword),
+        `${label} leaks the codeword into the observation name`,
+      );
+      const io = `${JSON.stringify(observation.input ?? '')}\n${JSON.stringify(observation.output ?? '')}`;
+      need(!io.includes(codeword), `${label} leaks the codeword into input/output`);
+    }
+    validateChildren([
+      {
+        label: 'span "bash"',
+        matches: spans.filter((o) => o.name === 'bash'),
+        parent: root,
+        exact: true,
+      },
+      {
+        label: 'generation "llm-generation [main]"',
+        matches: generations.filter((o) => o.name?.startsWith('llm-generation [main]')),
+        parent: root,
+      },
+    ]);
+    return problems;
+  }
 
   if (scenario === 'hierarchy') {
     const outerMatches = spans.filter((o) => o.name === 'subagent [ci-hierarchy]');

--- a/.github/scripts/telemetry-langfuse-verify.test.mjs
+++ b/.github/scripts/telemetry-langfuse-verify.test.mjs
@@ -41,6 +41,18 @@ function hierarchyTrace() {
   ]);
 }
 
+// Redacted scenario (includePayloads: false): same pipeline, but payloads are
+// stripped before export — no root input, no chat-input span, tool spans lose
+// their [args] bracket, generations carry model/usage/cost metadata only.
+function redactedTrace() {
+  return withSemantics([
+    { id: 'root', traceId: 't3', type: 'SPAN', name: 'chat-turn', parentObservationId: null, startTime: 'a', endTime: 'b' },
+    { id: 'b1', traceId: 't3', type: 'SPAN', name: 'bash', parentObservationId: 'root', startTime: 'a', endTime: 'b' },
+    { id: 'g1', traceId: 't3', type: 'GENERATION', name: 'llm-generation [main] [request]', parentObservationId: 'root', startTime: 'a', endTime: 'b' },
+    { id: 's1', traceId: 't3', type: 'SPAN', name: 'llm-stream', parentObservationId: 'g1', startTime: 'a', endTime: 'b' },
+  ]);
+}
+
 function withSemantics(observations) {
   return observations.map((observation) => ({
     ...observation,
@@ -111,6 +123,18 @@ it('runVerification selects the hierarchy contract', async () => {
     ...baseArgs,
     scenario: 'hierarchy',
     traceId: 't2',
+    deadlineMs: 1,
+    fetchImpl,
+  });
+  assert.equal(result.ok, true);
+});
+
+it('runVerification selects the redacted contract', async () => {
+  const fetchImpl = fakeFetch(() => ({ data: redactedTrace(), meta: {} }));
+  const result = await runVerification({
+    ...baseArgs,
+    scenario: 'redacted',
+    traceId: 't3',
     deadlineMs: 1,
     fetchImpl,
   });
@@ -215,6 +239,56 @@ it('evaluateTrace validates the nested subagent hierarchy scenario', () => {
   );
   const problems = evaluateTrace(broken, CODEWORD, 'hierarchy');
   assert.ok(problems.some((problem) => problem.includes('subagent [ci-probe]') && problem.includes('expected outer')));
+});
+
+it('evaluateTrace validates the redacted scenario', () => {
+  assert.deepEqual(evaluateTrace(redactedTrace(), CODEWORD, 'redacted'), []);
+});
+
+// The redacted scenario is the regression gate for issue #197: with
+// includePayloads: false, nothing containing the prompt may be uploaded —
+// regardless of which attribute key carries it.
+it('evaluateTrace rejects payload leaks in the redacted scenario', () => {
+  // The pre-fix bug shape: a generation carries the prompt.
+  const leakingGeneration = redactedTrace().map((observation) =>
+    observation.id === 'g1'
+      ? { ...observation, input: [{ role: 'user', content: `echo ${CODEWORD} redacted` }] }
+      : observation,
+  );
+  assert.ok(
+    evaluateTrace(leakingGeneration, CODEWORD, 'redacted').some((problem) =>
+      problem.includes('leaks the codeword'),
+    ),
+  );
+
+  // Root input present (the chat-turn payload) must fail twice: the root
+  // input/output check and the codeword scan.
+  const leakingRoot = redactedTrace().map((observation) =>
+    observation.id === 'root' ? { ...observation, input: `echo ${CODEWORD} redacted` } : observation,
+  );
+  const rootProblems = evaluateTrace(leakingRoot, CODEWORD, 'redacted');
+  assert.ok(rootProblems.some((problem) => problem.includes('root "chat-turn"')));
+  assert.ok(rootProblems.some((problem) => problem.includes('leaks the codeword')));
+
+  // The chat-input span exists only to carry the prompt up front.
+  const chatInput = withSemantics([
+    { id: 'ci', traceId: 't3', type: 'SPAN', name: 'chat-input', parentObservationId: 'root', startTime: 'a', endTime: 'b' },
+  ]);
+  assert.ok(
+    evaluateTrace([...redactedTrace(), ...chatInput], CODEWORD, 'redacted').some((problem) =>
+      problem.includes('chat-input'),
+    ),
+  );
+
+  // A tool span name built from unstripped args carries the codeword.
+  const leakingName = redactedTrace().map((observation) =>
+    observation.id === 'b1' ? { ...observation, name: `bash [echo ${CODEWORD} redacted]` } : observation,
+  );
+  assert.ok(
+    evaluateTrace(leakingName, CODEWORD, 'redacted').some((problem) =>
+      problem.includes('observation name'),
+    ),
+  );
 });
 
 it('evaluateTrace validates EVERY matching generation, not just the first', () => {


### PR DESCRIPTION
## Summary

- Adds a third pi-telemetry matrix leg, `scenario: 'redacted'`: one bash echo of the per-run codeword with `includePayloads: false` in the rendered settings.json (the base branch's workflow flips `INCLUDE_PAYLOADS_JSON` to `false` for this leg).
- The Langfuse verify step gains a redacted contract: the trace must still be structurally complete (root `chat-turn` ended, exactly one `bash` span, `llm-generation [main]` with model/usage/cost metadata, one `llm-stream` child per generation) while **no** observation carries the codeword in its name or input/output, the root span has no input/output, and no `chat-input` span is exported.
- Script tests cover the contract both ways: a clean redacted trace passes; codeword in generation input, root input, a `chat-input` span, or a span name all fail.

> [!NOTE]
> Stacked on the fix branch because `integration.yml` runs under `pull_request_target`: the executing workflow comes from the PR's **base** branch, so the `includePayloads: false` settings write only takes effect once the base carries the parameterization. Merge the base PR first; this PR then re-targets to master automatically and its redacted leg runs green (verified shape: the base PR's run showed the contract correctly detecting the leak when settings still forced `true`).

## Verification

- `pnpm vitest run .github/scripts/` — 69 passed, including the new redacted contract tests and updated matrix-selection assertions.
- The base PR's integration run proves the negative path: with `includePayloads: true` still forced by the base-branch workflow, the redacted leg failed with exactly the expected leak findings (`chat-input` span present, codeword in generation/bash input-output and span names).

## Related issue

#197

## Checklist

- [x] This PR is focused; tests and docs are updated where applicable.
